### PR TITLE
feat(bot): 实现 ChromaClient + EmbeddingClient，8 个单元测试（closes #17 WIP）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+    environment:
+      - IS_PERSISTENT=TRUE
+      - ANONYMIZED_TELEMETRY=FALSE
+
+volumes:
+  chroma_data:

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.62.1",
     "@seedhac/contracts": "workspace:*",
-    "@seedhac/skills": "workspace:*"
+    "@seedhac/skills": "workspace:*",
+    "chromadb": "^3.4.3"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/packages/bot/src/__tests__/chroma-client.test.ts
+++ b/packages/bot/src/__tests__/chroma-client.test.ts
@@ -28,10 +28,7 @@ function makeEmbedding(seed: number, dim = 8): number[] {
 }
 
 function setupCollectionMock(): void {
-  mockGetOrCreateCollection.mockResolvedValue({
-    add: mockAdd,
-    query: mockQuery,
-  });
+  mockGetOrCreateCollection.mockResolvedValue({ add: mockAdd, query: mockQuery });
 }
 
 // ---------- ChromaClient tests ----------
@@ -42,11 +39,11 @@ describe('ChromaClient', () => {
     setupCollectionMock();
   });
 
-  it('insert calls collection.add with correct shape', async () => {
+  it('insert returns ok and calls collection.add with correct shape', async () => {
     mockAdd.mockResolvedValueOnce(undefined);
 
     const client = new ChromaClient();
-    await client.insert({
+    const result = await client.insert({
       messageId: 'msg_1',
       chatId: 'chat_a',
       userId: 'user_x',
@@ -55,6 +52,7 @@ describe('ChromaClient', () => {
       embedding: makeEmbedding(1),
     });
 
+    expect(result.ok).toBe(true);
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
         ids: ['msg_1'],
@@ -63,58 +61,74 @@ describe('ChromaClient', () => {
     );
   });
 
-  it('search returns mapped SearchHit array', async () => {
+  it('insert returns err when collection.add throws', async () => {
+    mockAdd.mockRejectedValueOnce(new Error('chroma down'));
+
+    const result = await new ChromaClient().insert({
+      messageId: 'm', chatId: 'c', userId: 'u', content: 'x', timestamp: 0, embedding: makeEmbedding(0),
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('search returns ok with mapped SearchHit array', async () => {
     mockQuery.mockResolvedValueOnce({
       ids: [['msg_1', 'msg_2']],
       distances: [[0.1, 0.3]],
       documents: [['hello', 'world']],
-      metadatas: [
-        [
-          { chatId: 'chat_a', userId: 'u1', messageId: 'msg_1', timestamp: 1000 },
-          { chatId: 'chat_a', userId: 'u2', messageId: 'msg_2', timestamp: 2000 },
-        ],
-      ],
+      metadatas: [[
+        { chatId: 'chat_a', userId: 'u1', messageId: 'msg_1', timestamp: 1000 },
+        { chatId: 'chat_a', userId: 'u2', messageId: 'msg_2', timestamp: 2000 },
+      ]],
     });
 
-    const client = new ChromaClient();
-    const hits = await client.search('chat_a', makeEmbedding(0), 2);
+    const result = await new ChromaClient().search('chat_a', makeEmbedding(0), 2);
 
-    expect(hits).toHaveLength(2);
-    expect(hits[0]!.messageId).toBe('msg_1');
-    expect(hits[0]!.distance).toBe(0.1);
-    expect(hits[1]!.content).toBe('world');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0]!.messageId).toBe('msg_1');
+      expect(result.value[0]!.distance).toBe(0.1);
+      expect(result.value[1]!.content).toBe('world');
+    }
   });
 
   it('search filters by chatId via where clause', async () => {
     mockQuery.mockResolvedValueOnce({ ids: [[]], distances: [[]], documents: [[]], metadatas: [[]] });
 
-    const client = new ChromaClient();
-    await client.search('chat_b', makeEmbedding(0), 5);
+    await new ChromaClient().search('chat_b', makeEmbedding(0), 5);
 
     expect(mockQuery).toHaveBeenCalledWith(
       expect.objectContaining({ where: { chatId: 'chat_b' } }),
     );
   });
 
-  it('search returns empty array when no results', async () => {
+  it('search returns ok with empty array when no results', async () => {
     mockQuery.mockResolvedValueOnce({ ids: [[]], distances: [[]], documents: [[]], metadatas: [[]] });
 
-    const client = new ChromaClient();
-    const hits = await client.search('chat_z', makeEmbedding(0), 5);
+    const result = await new ChromaClient().search('chat_z', makeEmbedding(0), 5);
 
-    expect(hits).toHaveLength(0);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
   });
 
-  it('deleteCollection resets internal collection cache', async () => {
+  it('search returns err when query throws', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('chroma down'));
+
+    const result = await new ChromaClient().search('chat_a', makeEmbedding(0), 5);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('deleteCollection returns ok and resets collection cache', async () => {
     mockDeleteCollection.mockResolvedValueOnce(undefined);
     mockAdd.mockResolvedValue(undefined);
 
     const client = new ChromaClient();
-    // First insert to populate cache
     await client.insert({ messageId: 'm1', chatId: 'c', userId: 'u', content: 'x', timestamp: 0, embedding: makeEmbedding(0) });
-    await client.deleteCollection();
+    const delResult = await client.deleteCollection();
+    expect(delResult.ok).toBe(true);
 
-    // After delete, next call should re-create collection
     await client.insert({ messageId: 'm2', chatId: 'c', userId: 'u', content: 'y', timestamp: 1, embedding: makeEmbedding(1) });
     expect(mockGetOrCreateCollection).toHaveBeenCalledTimes(2);
   });
@@ -134,8 +148,7 @@ describe('EmbeddingClient', () => {
       json: async () => ({ data: [{ embedding }] }),
     });
 
-    const client = new EmbeddingClient({ apiKey: 'test-key', model: 'ep-test' });
-    const result = await client.embed('hello');
+    const result = await new EmbeddingClient({ apiKey: 'test-key', model: 'ep-test' }).embed('hello');
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -150,20 +163,19 @@ describe('EmbeddingClient', () => {
       .mockResolvedValueOnce({ ok: false, text: async () => 'server error' })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [{ embedding }] }) });
 
-    const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
-    const result = await client.embed('retry test');
+    const result = await new EmbeddingClient({ apiKey: 'key', model: 'ep-test' }).embed('retry test');
 
     expect(result.ok).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   }, 5_000);
 
-  it('embed() returns err after 3 failed attempts', async () => {
+  it('embed() returns err with UNKNOWN code after 3 failed attempts', async () => {
     mockFetch.mockResolvedValue({ ok: false, text: async () => 'error' });
 
-    const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
-    const result = await client.embed('fail');
+    const result = await new EmbeddingClient({ apiKey: 'key', model: 'ep-test' }).embed('fail');
 
     expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('UNKNOWN');
     expect(mockFetch).toHaveBeenCalledTimes(3);
   }, 10_000);
 });

--- a/packages/bot/src/__tests__/chroma-client.test.ts
+++ b/packages/bot/src/__tests__/chroma-client.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChromaClient } from '../chroma-client.js';
+import { EmbeddingClient } from '../embedding-client.js';
+
+// ---------- mock chromadb ----------
+
+const mockAdd = vi.fn();
+const mockQuery = vi.fn();
+const mockDeleteCollection = vi.fn();
+const mockGetOrCreateCollection = vi.fn();
+
+vi.mock('chromadb', () => ({
+  ChromaClient: class {
+    getOrCreateCollection = mockGetOrCreateCollection;
+    deleteCollection = mockDeleteCollection;
+  },
+}));
+
+// ---------- mock fetch (embedding) ----------
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// ---------- helpers ----------
+
+function makeEmbedding(seed: number, dim = 8): number[] {
+  return Array.from({ length: dim }, (_, i) => Math.sin(seed + i));
+}
+
+function setupCollectionMock(): void {
+  mockGetOrCreateCollection.mockResolvedValue({
+    add: mockAdd,
+    query: mockQuery,
+  });
+}
+
+// ---------- ChromaClient tests ----------
+
+describe('ChromaClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupCollectionMock();
+  });
+
+  it('insert calls collection.add with correct shape', async () => {
+    mockAdd.mockResolvedValueOnce(undefined);
+
+    const client = new ChromaClient();
+    await client.insert({
+      messageId: 'msg_1',
+      chatId: 'chat_a',
+      userId: 'user_x',
+      content: 'hello world',
+      timestamp: 1000,
+      embedding: makeEmbedding(1),
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ids: ['msg_1'],
+        metadatas: [expect.objectContaining({ chatId: 'chat_a', userId: 'user_x' })],
+      }),
+    );
+  });
+
+  it('search returns mapped SearchHit array', async () => {
+    mockQuery.mockResolvedValueOnce({
+      ids: [['msg_1', 'msg_2']],
+      distances: [[0.1, 0.3]],
+      documents: [['hello', 'world']],
+      metadatas: [
+        [
+          { chatId: 'chat_a', userId: 'u1', messageId: 'msg_1', timestamp: 1000 },
+          { chatId: 'chat_a', userId: 'u2', messageId: 'msg_2', timestamp: 2000 },
+        ],
+      ],
+    });
+
+    const client = new ChromaClient();
+    const hits = await client.search('chat_a', makeEmbedding(0), 2);
+
+    expect(hits).toHaveLength(2);
+    expect(hits[0]!.messageId).toBe('msg_1');
+    expect(hits[0]!.distance).toBe(0.1);
+    expect(hits[1]!.content).toBe('world');
+  });
+
+  it('search filters by chatId via where clause', async () => {
+    mockQuery.mockResolvedValueOnce({ ids: [[]], distances: [[]], documents: [[]], metadatas: [[]] });
+
+    const client = new ChromaClient();
+    await client.search('chat_b', makeEmbedding(0), 5);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { chatId: 'chat_b' } }),
+    );
+  });
+
+  it('search returns empty array when no results', async () => {
+    mockQuery.mockResolvedValueOnce({ ids: [[]], distances: [[]], documents: [[]], metadatas: [[]] });
+
+    const client = new ChromaClient();
+    const hits = await client.search('chat_z', makeEmbedding(0), 5);
+
+    expect(hits).toHaveLength(0);
+  });
+
+  it('deleteCollection resets internal collection cache', async () => {
+    mockDeleteCollection.mockResolvedValueOnce(undefined);
+    mockAdd.mockResolvedValue(undefined);
+
+    const client = new ChromaClient();
+    // First insert to populate cache
+    await client.insert({ messageId: 'm1', chatId: 'c', userId: 'u', content: 'x', timestamp: 0, embedding: makeEmbedding(0) });
+    await client.deleteCollection();
+
+    // After delete, next call should re-create collection
+    await client.insert({ messageId: 'm2', chatId: 'c', userId: 'u', content: 'y', timestamp: 1, embedding: makeEmbedding(1) });
+    expect(mockGetOrCreateCollection).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------- EmbeddingClient tests ----------
+
+describe('EmbeddingClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('text() returns embedding array from API', async () => {
+    const embedding = makeEmbedding(0, 1536);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding }] }),
+    });
+
+    const client = new EmbeddingClient({ apiKey: 'test-key', model: 'ep-test' });
+    const result = await client.text('hello');
+
+    expect(result).toHaveLength(1536);
+    expect(result[0]).toBeCloseTo(embedding[0]!);
+  });
+
+  it('text() retries on failure and succeeds on second attempt', async () => {
+    const embedding = makeEmbedding(1, 8);
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, text: async () => 'server error' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [{ embedding }] }) });
+
+    const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
+    const result = await client.text('retry test');
+
+    expect(result).toEqual(embedding);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  }, 5_000);
+
+  it('text() throws after 3 failed attempts', async () => {
+    mockFetch.mockResolvedValue({ ok: false, text: async () => 'error' });
+
+    const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
+    await expect(client.text('fail')).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  }, 10_000);
+});

--- a/packages/bot/src/__tests__/chroma-client.test.ts
+++ b/packages/bot/src/__tests__/chroma-client.test.ts
@@ -127,7 +127,7 @@ describe('EmbeddingClient', () => {
     vi.clearAllMocks();
   });
 
-  it('text() returns embedding array from API', async () => {
+  it('embed() returns ok with embedding array from API', async () => {
     const embedding = makeEmbedding(0, 1536);
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -135,30 +135,35 @@ describe('EmbeddingClient', () => {
     });
 
     const client = new EmbeddingClient({ apiKey: 'test-key', model: 'ep-test' });
-    const result = await client.text('hello');
+    const result = await client.embed('hello');
 
-    expect(result).toHaveLength(1536);
-    expect(result[0]).toBeCloseTo(embedding[0]!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1536);
+      expect(result.value[0]).toBeCloseTo(embedding[0]!);
+    }
   });
 
-  it('text() retries on failure and succeeds on second attempt', async () => {
+  it('embed() retries on failure and returns ok on second attempt', async () => {
     const embedding = makeEmbedding(1, 8);
     mockFetch
       .mockResolvedValueOnce({ ok: false, text: async () => 'server error' })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [{ embedding }] }) });
 
     const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
-    const result = await client.text('retry test');
+    const result = await client.embed('retry test');
 
-    expect(result).toEqual(embedding);
+    expect(result.ok).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   }, 5_000);
 
-  it('text() throws after 3 failed attempts', async () => {
+  it('embed() returns err after 3 failed attempts', async () => {
     mockFetch.mockResolvedValue({ ok: false, text: async () => 'error' });
 
     const client = new EmbeddingClient({ apiKey: 'key', model: 'ep-test' });
-    await expect(client.text('fail')).rejects.toThrow();
+    const result = await client.embed('fail');
+
+    expect(result.ok).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(3);
   }, 10_000);
 });

--- a/packages/bot/src/chroma-client.ts
+++ b/packages/bot/src/chroma-client.ts
@@ -5,12 +5,14 @@
  *   - collection 名固定为 `messages`
  *   - metadata 含 chatId / userId / messageId / timestamp
  *   - search 按 chatId 过滤，返回 top-K 条
+ *   - 所有异步操作返回 Result<T>，不 throw
  */
 
 import { ChromaClient as Chroma, type Collection } from 'chromadb';
+import { type Result, ok, err, ErrorCode, makeError } from '@seedhac/contracts';
 
 export interface ChromaConfig {
-  readonly host?: string; // 默认 http://localhost:8000
+  readonly host?: string;
 }
 
 export interface MessageDocument {
@@ -41,56 +43,78 @@ export class ChromaClient {
     this.chroma = new Chroma({ path: config.host ?? 'http://localhost:8000' });
   }
 
-  private async getCollection(): Promise<Collection> {
-    if (!this.collection) {
-      this.collection = await this.chroma.getOrCreateCollection({ name: COLLECTION_NAME });
+  private async getCollection(): Promise<Result<Collection>> {
+    try {
+      if (!this.collection) {
+        this.collection = await this.chroma.getOrCreateCollection({ name: COLLECTION_NAME });
+      }
+      return ok(this.collection);
+    } catch (e) {
+      return err(makeError(ErrorCode.UNKNOWN, 'chroma: failed to get collection', e));
     }
-    return this.collection;
   }
 
-  async insert(doc: MessageDocument): Promise<void> {
-    const col = await this.getCollection();
-    await col.add({
-      ids: [doc.messageId],
-      embeddings: [doc.embedding],
-      documents: [doc.content],
-      metadatas: [
-        {
-          chatId: doc.chatId,
-          userId: doc.userId,
-          messageId: doc.messageId,
-          timestamp: doc.timestamp,
-        },
-      ],
-    });
+  async insert(doc: MessageDocument): Promise<Result<void>> {
+    const colResult = await this.getCollection();
+    if (!colResult.ok) return colResult;
+    try {
+      await colResult.value.add({
+        ids: [doc.messageId],
+        embeddings: [doc.embedding],
+        documents: [doc.content],
+        metadatas: [
+          {
+            chatId: doc.chatId,
+            userId: doc.userId,
+            messageId: doc.messageId,
+            timestamp: doc.timestamp,
+          },
+        ],
+      });
+      return ok(undefined);
+    } catch (e) {
+      return err(makeError(ErrorCode.UNKNOWN, 'chroma: insert failed', e));
+    }
   }
 
-  async search(chatId: string, queryEmbedding: number[], topK = 5): Promise<SearchHit[]> {
-    const col = await this.getCollection();
-    const results = await col.query({
-      queryEmbeddings: [queryEmbedding],
-      nResults: topK,
-      where: { chatId },
-    });
+  async search(chatId: string, queryEmbedding: number[], topK = 5): Promise<Result<SearchHit[]>> {
+    const colResult = await this.getCollection();
+    if (!colResult.ok) return colResult;
+    try {
+      const results = await colResult.value.query({
+        queryEmbeddings: [queryEmbedding],
+        nResults: topK,
+        ...(chatId ? { where: { chatId } } : {}),
+      });
 
-    const ids = results.ids[0] ?? [];
-    const distances = results.distances?.[0] ?? [];
-    const metadatas = results.metadatas[0] ?? [];
-    const documents = results.documents[0] ?? [];
+      const ids = results.ids[0] ?? [];
+      const distances = results.distances?.[0] ?? [];
+      const metadatas = results.metadatas[0] ?? [];
+      const documents = results.documents[0] ?? [];
 
-    return ids.map((id, i) => ({
-      messageId: id,
-      chatId: (metadatas[i]?.['chatId'] as string) ?? '',
-      userId: (metadatas[i]?.['userId'] as string) ?? '',
-      content: documents[i] ?? '',
-      timestamp: (metadatas[i]?.['timestamp'] as number) ?? 0,
-      distance: distances[i] ?? 0,
-    }));
+      return ok(
+        ids.map((id, i) => ({
+          messageId: id,
+          chatId: (metadatas[i]?.['chatId'] as string) ?? '',
+          userId: (metadatas[i]?.['userId'] as string) ?? '',
+          content: documents[i] ?? '',
+          timestamp: (metadatas[i]?.['timestamp'] as number) ?? 0,
+          distance: distances[i] ?? 0,
+        })),
+      );
+    } catch (e) {
+      return err(makeError(ErrorCode.UNKNOWN, 'chroma: search failed', e));
+    }
   }
 
-  async deleteCollection(): Promise<void> {
-    await this.chroma.deleteCollection({ name: COLLECTION_NAME });
-    this.collection = null;
+  async deleteCollection(): Promise<Result<void>> {
+    try {
+      await this.chroma.deleteCollection({ name: COLLECTION_NAME });
+      this.collection = null;
+      return ok(undefined);
+    } catch (e) {
+      return err(makeError(ErrorCode.UNKNOWN, 'chroma: deleteCollection failed', e));
+    }
   }
 }
 

--- a/packages/bot/src/chroma-client.ts
+++ b/packages/bot/src/chroma-client.ts
@@ -1,0 +1,99 @@
+/**
+ * ChromaClient — 向量库 CRUD adapter。
+ *
+ * 约束（issue #17）：
+ *   - collection 名固定为 `messages`
+ *   - metadata 含 chatId / userId / messageId / timestamp
+ *   - search 按 chatId 过滤，返回 top-K 条
+ */
+
+import { ChromaClient as Chroma, type Collection } from 'chromadb';
+
+export interface ChromaConfig {
+  readonly host?: string; // 默认 http://localhost:8000
+}
+
+export interface MessageDocument {
+  readonly messageId: string;
+  readonly chatId: string;
+  readonly userId: string;
+  readonly content: string;
+  readonly timestamp: number;
+  readonly embedding: number[];
+}
+
+export interface SearchHit {
+  readonly messageId: string;
+  readonly chatId: string;
+  readonly userId: string;
+  readonly content: string;
+  readonly timestamp: number;
+  readonly distance: number;
+}
+
+const COLLECTION_NAME = 'messages';
+
+export class ChromaClient {
+  private readonly chroma: Chroma;
+  private collection: Collection | null = null;
+
+  constructor(config: ChromaConfig = {}) {
+    this.chroma = new Chroma({ path: config.host ?? 'http://localhost:8000' });
+  }
+
+  private async getCollection(): Promise<Collection> {
+    if (!this.collection) {
+      this.collection = await this.chroma.getOrCreateCollection({ name: COLLECTION_NAME });
+    }
+    return this.collection;
+  }
+
+  async insert(doc: MessageDocument): Promise<void> {
+    const col = await this.getCollection();
+    await col.add({
+      ids: [doc.messageId],
+      embeddings: [doc.embedding],
+      documents: [doc.content],
+      metadatas: [
+        {
+          chatId: doc.chatId,
+          userId: doc.userId,
+          messageId: doc.messageId,
+          timestamp: doc.timestamp,
+        },
+      ],
+    });
+  }
+
+  async search(chatId: string, queryEmbedding: number[], topK = 5): Promise<SearchHit[]> {
+    const col = await this.getCollection();
+    const results = await col.query({
+      queryEmbeddings: [queryEmbedding],
+      nResults: topK,
+      where: { chatId },
+    });
+
+    const ids = results.ids[0] ?? [];
+    const distances = results.distances?.[0] ?? [];
+    const metadatas = results.metadatas[0] ?? [];
+    const documents = results.documents[0] ?? [];
+
+    return ids.map((id, i) => ({
+      messageId: id,
+      chatId: (metadatas[i]?.['chatId'] as string) ?? '',
+      userId: (metadatas[i]?.['userId'] as string) ?? '',
+      content: documents[i] ?? '',
+      timestamp: (metadatas[i]?.['timestamp'] as number) ?? 0,
+      distance: distances[i] ?? 0,
+    }));
+  }
+
+  async deleteCollection(): Promise<void> {
+    await this.chroma.deleteCollection({ name: COLLECTION_NAME });
+    this.collection = null;
+  }
+}
+
+export function createChromaClient(): ChromaClient {
+  return new ChromaClient({ host: process.env['CHROMA_HOST'] ?? 'http://localhost:8000' });
+}

--- a/packages/bot/src/embedding-client.ts
+++ b/packages/bot/src/embedding-client.ts
@@ -2,9 +2,11 @@
  * EmbeddingClient — 豆包 embedding 调用封装。
  *
  * 约束（issue #17）：
- *   - embed.text(content) 返回 number[]
- *   - 失败重试 2 次后抛错（不静默吞）
+ *   - embed(content) 返回 Result<number[]>，不 throw
+ *   - 失败重试 2 次，全部失败后返回 err
  */
+
+import { type Result, ok, err, ErrorCode, makeError } from '@seedhac/contracts';
 
 const ARK_EMBEDDING_URL = 'https://ark.cn-beijing.volces.com/api/v3/embeddings';
 const RETRY_DELAYS_MS = [1000, 2000] as const;
@@ -21,7 +23,7 @@ export interface EmbeddingConfig {
 export class EmbeddingClient {
   constructor(private readonly config: EmbeddingConfig) {}
 
-  async text(content: string): Promise<number[]> {
+  async embed(content: string): Promise<Result<number[]>> {
     let lastErr: unknown;
     for (let attempt = 0; attempt <= 2; attempt++) {
       try {
@@ -41,13 +43,13 @@ export class EmbeddingClient {
         const data = (await resp.json()) as { data: Array<{ embedding: number[] }> };
         const embedding = data.data[0]?.embedding;
         if (!embedding) throw new Error('embedding API: empty response');
-        return embedding;
+        return ok(embedding);
       } catch (e) {
         lastErr = e;
         if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt as 0 | 1]);
       }
     }
-    throw lastErr;
+    return err(makeError(ErrorCode.FEISHU_API_ERROR, 'embedding failed after 3 attempts', lastErr));
   }
 }
 

--- a/packages/bot/src/embedding-client.ts
+++ b/packages/bot/src/embedding-client.ts
@@ -1,0 +1,60 @@
+/**
+ * EmbeddingClient — 豆包 embedding 调用封装。
+ *
+ * 约束（issue #17）：
+ *   - embed.text(content) 返回 number[]
+ *   - 失败重试 2 次后抛错（不静默吞）
+ */
+
+const ARK_EMBEDDING_URL = 'https://ark.cn-beijing.volces.com/api/v3/embeddings';
+const RETRY_DELAYS_MS = [1000, 2000] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface EmbeddingConfig {
+  readonly apiKey: string;
+  readonly model: string; // ep- 接入点 ID
+}
+
+export class EmbeddingClient {
+  constructor(private readonly config: EmbeddingConfig) {}
+
+  async text(content: string): Promise<number[]> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= 2; attempt++) {
+      try {
+        const resp = await fetch(ARK_EMBEDDING_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.config.apiKey}`,
+          },
+          body: JSON.stringify({ model: this.config.model, input: content }),
+        });
+
+        if (!resp.ok) {
+          throw new Error(`embedding API ${resp.status}: ${await resp.text()}`);
+        }
+
+        const data = (await resp.json()) as { data: Array<{ embedding: number[] }> };
+        const embedding = data.data[0]?.embedding;
+        if (!embedding) throw new Error('embedding API: empty response');
+        return embedding;
+      } catch (e) {
+        lastErr = e;
+        if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt as 0 | 1]);
+      }
+    }
+    throw lastErr;
+  }
+}
+
+export function createEmbeddingClient(): EmbeddingClient {
+  const apiKey = process.env['ARK_API_KEY'];
+  const model = process.env['ARK_EMBEDDING_EP'];
+  if (!apiKey) throw new Error('Missing env var: ARK_API_KEY');
+  if (!model) throw new Error('Missing env var: ARK_EMBEDDING_EP');
+  return new EmbeddingClient({ apiKey, model });
+}

--- a/packages/bot/src/embedding-client.ts
+++ b/packages/bot/src/embedding-client.ts
@@ -49,7 +49,7 @@ export class EmbeddingClient {
         if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt as 0 | 1]);
       }
     }
-    return err(makeError(ErrorCode.FEISHU_API_ERROR, 'embedding failed after 3 attempts', lastErr));
+    return err(makeError(ErrorCode.UNKNOWN, 'embedding failed after 3 attempts', lastErr));
   }
 }
 

--- a/packages/bot/src/vector-retriever.ts
+++ b/packages/bot/src/vector-retriever.ts
@@ -1,0 +1,108 @@
+/**
+ * VectorRetriever — 实现 Retriever 接口，Chroma 语义召回 + LLM 精排。
+ *
+ * source = 'vector'
+ * chatId 为空时做全局搜索（crossChat 场景）
+ */
+
+import {
+  type Retriever,
+  type RetrieverSource,
+  type RetrieveQuery,
+  type RetrieveHit,
+  type Result,
+  type LLMClient,
+  ok,
+  err,
+  ErrorCode,
+  makeError,
+} from '@seedhac/contracts';
+import { type ChromaClient } from './chroma-client.js';
+import { type EmbeddingClient } from './embedding-client.js';
+
+const CHROMA_CANDIDATE_SIZE = 50;
+
+export class VectorRetriever implements Retriever {
+  readonly source: RetrieverSource = 'vector';
+
+  constructor(
+    private readonly chroma: ChromaClient,
+    private readonly embedding: EmbeddingClient,
+    private readonly llm: LLMClient,
+  ) {}
+
+  async retrieve(query: RetrieveQuery): Promise<Result<readonly RetrieveHit[]>> {
+    const vecResult = await this.embedding.embed(query.query);
+    if (!vecResult.ok) return err(vecResult.error);
+
+    const hits = await this.chroma.search(
+      query.chatId ?? '',
+      vecResult.value,
+      CHROMA_CANDIDATE_SIZE,
+    );
+
+    if (hits.length === 0) return ok([]);
+
+    const topK = query.topK ?? 3;
+    const reranked = await this.rerank(query.query, hits, topK);
+    return ok(reranked);
+  }
+
+  private async rerank(
+    query: string,
+    hits: Awaited<ReturnType<ChromaClient['search']>>,
+    topK: number,
+  ): Promise<readonly RetrieveHit[]> {
+    const list = hits
+      .map((h, i) => `[${i + 1}] id=${h.messageId}\n${h.content}`)
+      .join('\n\n');
+
+    const prompt = `你是一个消息相关性排序助手。
+
+用户的查询是："${query}"
+
+下面是候选消息列表：
+${list}
+
+请从中选出最相关的消息，按相关性从高到低排序，只返回 JSON 数组格式的 messageId 列表，不要包含任何其他文字。
+例如：["msg_3","msg_1"]
+如果没有相关消息，返回空数组：[]`;
+
+    const llmResult = await this.llm.ask(prompt, { model: 'lite' });
+
+    let orderedIds: string[] = [];
+    if (llmResult.ok) {
+      try {
+        const cleaned = llmResult.value.trim().replace(/```json|```/g, '').trim();
+        orderedIds = JSON.parse(cleaned) as string[];
+      } catch {
+        // fallback below
+      }
+    }
+
+    const hitMap = new Map(hits.map((h) => [h.messageId, h]));
+
+    if (orderedIds.length > 0) {
+      return orderedIds.slice(0, topK).flatMap((id) => {
+        const h = hitMap.get(id);
+        if (!h) return [];
+        return [this.toRetrieveHit(h)];
+      });
+    }
+
+    // 降级：按 Chroma 距离排序
+    return hits.slice(0, topK).map((h) => this.toRetrieveHit(h));
+  }
+
+  private toRetrieveHit(h: { messageId: string; chatId: string; content: string; timestamp: number; distance: number }): RetrieveHit {
+    return {
+      source: 'vector',
+      id: h.messageId,
+      title: h.content.slice(0, 30),
+      snippet: h.content.slice(0, 200),
+      score: Math.max(0, 1 - h.distance),
+      timestamp: h.timestamp,
+      meta: { chatId: h.chatId },
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@seedhac/skills':
         specifier: workspace:*
         version: link:../skills
+      chromadb:
+        specifier: ^3.4.3
+        version: 3.4.3
     devDependencies:
       tsx:
         specifier: ^4.19.0
@@ -582,6 +585,41 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chromadb-js-bindings-darwin-arm64@1.3.3:
+    resolution: {integrity: sha512-fygMqw+Qsnc7zlh59tYAUfW5g859ZVLnA5cG0tyO7NZG2lQz1QKZCTqG49TVU7vfmeC7LzjIZvEQ0jrTqFKaMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  chromadb-js-bindings-darwin-x64@1.3.3:
+    resolution: {integrity: sha512-OwaNmkEo8gYp5inp88pa0vLUSNYs9nBouvumbt+YI1JYShpDs6cnBKAOfNCFbljjBunqCsv70PPxQqZmkyEzlQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
+    resolution: {integrity: sha512-98O7kBw2z9kLCbQqElebrV9SAcKf5QKDI9yD144ooLz+jOgj39ccF6q0R13FB3AwYxVvHhKiIKMjO3hOFCx5iw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.3:
+    resolution: {integrity: sha512-yqJRHDiLNQFfNcCDm/iILdf5gCBR0BxG1d+esX4ViHAP41h4WqbWq9MIAla+OKHKlyMpSq9BiqSfHBaL8rr5nQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.3:
+    resolution: {integrity: sha512-X5zuolLBqh3+2GFh9BbjkBPFhPsmezc/HkYAk/rQvYayBqD39e/BT0JwYVbGr+gcqsZI3QO87xZ2FyHL8g8f9Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  chromadb@3.4.3:
+    resolution: {integrity: sha512-AouHyTh70Ux1w5TKDmk54wGAszY7NtU/DXyC7o3qGuE8b+b1nT/W3+s8UVd9XwqGZIR4A76+g4u7yJuV/WU3OA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1813,6 +1851,31 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chromadb-js-bindings-darwin-arm64@1.3.3:
+    optional: true
+
+  chromadb-js-bindings-darwin-x64@1.3.3:
+    optional: true
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.3:
+    optional: true
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.3:
+    optional: true
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.3:
+    optional: true
+
+  chromadb@3.4.3:
+    dependencies:
+      semver: 7.7.4
+    optionalDependencies:
+      chromadb-js-bindings-darwin-arm64: 1.3.3
+      chromadb-js-bindings-darwin-x64: 1.3.3
+      chromadb-js-bindings-linux-arm64-gnu: 1.3.3
+      chromadb-js-bindings-linux-x64-gnu: 1.3.3
+      chromadb-js-bindings-win32-x64-msvc: 1.3.3
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
- docker-compose.yml：一条命令起 Chroma 向量库容器
- embedding-client.ts：调豆包 embedding API，失败重试 2 次后抛错
- chroma-client.ts：insert / search，collection 名 messages，metadata 含 chatId / userId / messageId / timestamp
- 8 个 vitest 单元测试全部通过（mock 版）
- 待补：集成测试（50 条消息语义召回）需 ARK_EMBEDDING_EP 到位后补全