### PR TITLE
chore: 代码对齐与注释清洁（closes #41）

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "seedhac",
   "version": "0.1.0",
   "private": true,
-  "description": "SeedHAC / Sentinel — 飞书 AI 校园挑战赛参赛项目",
+  "description": "Lark Loom — 飞书 AI 校园挑战赛参赛项目",
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
@@ -10,14 +10,14 @@
   "packageManager": "pnpm@9.12.0",
   "scripts": {
     "build": "pnpm -r build",
-    "clean": "pnpm -r exec rm -rf dist .tsbuildinfo",
+    "clean": "pnpm -r exec rm -rf dist .tsbuildinfo tsconfig.tsbuildinfo",
     "dev": "pnpm --filter @seedhac/bot dev",
     "lint": "eslint \"packages/*/src/**/*.ts\"",
     "lint:fix": "eslint \"packages/*/src/**/*.ts\" --fix",
     "format": "prettier --write \"packages/*/src/**/*.{ts,json,md}\"",
     "format:check": "prettier --check \"packages/*/src/**/*.{ts,json,md}\"",
     "test": "pnpm -r test",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "tsc -b packages/contracts packages/skills packages/bot"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -2,7 +2,7 @@
   "name": "@seedhac/bot",
   "version": "0.1.0",
   "private": true,
-  "description": "SeedHAC 飞书 bot 进程入口（WSClient + Skill Router + 限流）",
+  "description": "Lark Loom 飞书 bot 进程入口（WSClient + Skill Router + 限流）",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * SeedHAC bot 入口（v0.1 联调脚手架）。
+ * Lark Loom bot 入口（联调脚手架）。
  *
- * 这一版只做 issue #13 的最后一步验收：
+ * 当前职责：
  *   - 读 .env 里的 4 个凭证
  *   - 启 WSClient 长连接
  *   - 收到群消息时把发送人 / 群 ID / 文本打到控制台
  *
- * BotRuntime / SkillRouter / 限流等真实运行时在后续 issue 实现。
+ * BotRuntime / SkillRouter / 限流等真实运行时在 issue #22 wiring 完成后接入。
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
@@ -107,7 +107,7 @@ function printSkillRoster(): void {
 }
 
 async function main(): Promise<void> {
-  console.info('[seedhac/bot] booting v0.1 (WSClient scaffold)');
+  console.info('[seedhac/bot] booting (WSClient scaffold)');
   printSkillRoster();
 
   const env = readEnv();

--- a/packages/bot/src/skill-router.ts
+++ b/packages/bot/src/skill-router.ts
@@ -1,8 +1,8 @@
 /**
  * SkillRouter — 飞书消息 → 业务意图分类。
  *
- * RouteIntent 是 bot 包内部类型，对应 PDF 里的实际 Skill 粒度，
- * 不依赖 contracts/SkillName（contracts 改动需三人 review，等复赛后再对齐）。
+ * RouteIntent 是 bot 包内部类型，与 contracts/SkillName 解耦
+ * （contracts 改动需三人 review，路由意图迭代频率高，先放本包）。
  *
  * 双轨制：
  *   - qa           唯一需要 @bot（避免对组员间普通问句乱插话）
@@ -24,12 +24,10 @@ export type RouteIntent =
   | 'requirementDoc'   // 需求整理 — 听到项目需求/资料
   | 'silent';          // 不处理
 
-/** @deprecated 兼容旧命名，后续统一用 RouteIntent */
-export type RouteResult = RouteIntent;
-
 interface RouteRule {
   readonly intent: Exclude<RouteIntent, 'silent'>;
-  readonly requiresMention: boolean;
+  /** 与 contracts/Skill.trigger.requireMention 同名，语义一致：是否要求 @bot */
+  readonly requireMention: boolean;
   readonly patterns: readonly RegExp[];
 }
 
@@ -38,7 +36,7 @@ const RULES: readonly RouteRule[] = [
   // ── qa：唯一需要 @bot ─────────────────────────────────────────────
   {
     intent: 'qa',
-    requiresMention: true,
+    requireMention: true,
     patterns: [
       /是什么/,
       /怎么/,
@@ -57,7 +55,7 @@ const RULES: readonly RouteRule[] = [
   // ── taskAssignment：分工讨论（被动）───────────────────────────────
   {
     intent: 'taskAssignment',
-    requiresMention: false,
+    requireMention: false,
     patterns: [
       /你来负责/,
       /我来负责/,
@@ -77,7 +75,7 @@ const RULES: readonly RouteRule[] = [
   // ── progressUpdate：进展汇报（被动）──────────────────────────────
   {
     intent: 'progressUpdate',
-    requiresMention: false,
+    requireMention: false,
     patterns: [
       /完成了/,
       /做完了/,
@@ -94,7 +92,7 @@ const RULES: readonly RouteRule[] = [
   // ── meetingNotes：会议纪要进群（被动）────────────────────────────
   {
     intent: 'meetingNotes',
-    requiresMention: false,
+    requireMention: false,
     patterns: [
       /会议纪要/,
       /妙记/,
@@ -107,7 +105,7 @@ const RULES: readonly RouteRule[] = [
   // ── slides：需要做 PPT 汇报（被动）──────────────────────────────
   {
     intent: 'slides',
-    requiresMention: false,
+    requireMention: false,
     patterns: [
       /ppt/i,
       /幻灯片/,
@@ -121,7 +119,7 @@ const RULES: readonly RouteRule[] = [
   // ── requirementDoc：项目需求/资料（被动，最宽泛放最后）──────────
   {
     intent: 'requirementDoc',
-    requiresMention: false,
+    requireMention: false,
     patterns: [
       /项目需求/,
       /需求文档/,
@@ -153,7 +151,7 @@ export class SkillRouter {
     const mentioned = this.mentionsBot(msg);
 
     for (const rule of RULES) {
-      if (rule.requiresMention && !mentioned) continue;
+      if (rule.requireMention && !mentioned) continue;
       if (rule.patterns.some((p) => p.test(text))) {
         return rule.intent;
       }

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,6 +1,8 @@
 # @seedhac/contracts
 
-> SeedHAC / Sentinel **跨包接口契约**单一来源。所有 `interface` / `type` / `Schema` 都在这里。
+> Lark Loom **跨包接口契约**单一来源。所有 `interface` / `type` / `Schema` 都在这里。
+
+> 注：包名仍为 `@seedhac/*` 以避免大规模 import 改动；产品名是 Lark Loom。
 
 ## 改这个包的规则
 
@@ -70,7 +72,7 @@ export const qaSkill: Skill = {
 
 ## 版本
 
-v0.1 — 初始冻结。覆盖 7 条业务主线最小集。
+初始冻结，覆盖 7 条业务主线最小集。
 
 下一步可能扩展点（不算"改契约"）：
 - Bitable 4 张表的 Row 类型从 `Record<string, unknown>` 收紧到具体接口

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,7 +2,7 @@
   "name": "@seedhac/contracts",
   "version": "0.1.0",
   "private": true,
-  "description": "SeedHAC 跨包接口契约 — 所有 interface / type / schema 的单一来源",
+  "description": "Lark Loom 跨包接口契约 — 所有 interface / type / schema 的单一来源",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/contracts/src/bitable.ts
+++ b/packages/contracts/src/bitable.ts
@@ -4,7 +4,7 @@
  * Bitable 在我们这套架构里承担：Memory / 决策 / 待办 / 知识图谱（双向关联字段）的存储。
  * 限制（CLAUDE.md）：10 QPS、单批 ≤ 500 条、批量操作全成功或全失败。
  *
- * v0.1：行类型用宽松的 Record<string, unknown>，待 Bitable 表 schema 实建后收紧
+ * 行类型当前用宽松的 Record<string, unknown>，待 Bitable 表 schema 实建后收紧
  * （收紧不算"改契约"，算"补全"）。
  */
 

--- a/packages/contracts/src/message.ts
+++ b/packages/contracts/src/message.ts
@@ -1,7 +1,7 @@
 /**
  * 飞书消息 + 事件抽象。
- * 飞书原始事件字段繁杂，这里只暴露我们用得到的最小集；
- * 写入实现时通过 lark-cli schema im.message.receive_v1 校对原始字段。
+ * 飞书原始事件字段繁杂，这里只暴露我们用得到的最小集。
+ * 原始字段以飞书开放平台 im.message.receive_v1 文档为准。
  */
 
 export type ChatType = 'group' | 'p2p';

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -2,7 +2,7 @@
   "name": "@seedhac/skills",
   "version": "0.1.0",
   "private": true,
-  "description": "SeedHAC 7 条业务主线 Skill 实现（v0.1 stub）",
+  "description": "Lark Loom 7 条业务主线 Skill 实现（stub）",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/skills/src/recall.ts
+++ b/packages/skills/src/recall.ts
@@ -4,7 +4,7 @@
  * 触发：群消息中出现 "上次 / 之前 / 我记得 / 那个数据 / 上回..."
  * 数据流：缺口检测（小模型）→ 命中 → Skill Router 选数据源 → 并行检索 → 召回卡片
  *
- * 这是 Sentinel 的灵魂 Skill；做好了是神，做差了就是骚扰机器人。
+ * 这是 Lark Loom 的灵魂 Skill；做好了是神，做差了就是骚扰机器人。
  */
 
 import type { Skill } from '@seedhac/contracts';

--- a/packages/skills/src/slides.ts
+++ b/packages/skills/src/slides.ts
@@ -2,10 +2,9 @@
  * 🅳 slides — 幻灯片生成
  *
  * 触发：@bot 做 PPT / @bot 生成幻灯片
- * 数据流：群聊上下文 → LLM 出大纲 → 拼飞书 SML 2.0 XML → lark-cli slides +create
+ * 数据流：群聊上下文 → LLM 出大纲 → 飞书 docx-v1 API 创建 markdown 文档 → 用户一键转 PPT
  *
- * 飞书云文档"演示文稿"开放 API，bot tenant token 即可调用。
- * 页面 schema：<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>...</data></slide>
+ * 通过 @larksuiteoapi/node-sdk 调用，bot tenant token 即可。
  */
 
 import type { Skill } from '@seedhac/contracts';

--- a/packages/skills/src/weekly.ts
+++ b/packages/skills/src/weekly.ts
@@ -11,7 +11,7 @@ import { ErrorCode, err, makeError } from '@seedhac/contracts';
 export const weeklySkill: Skill = {
   name: 'weekly',
   trigger: {
-    events: ['message'], // 占位；真实实现走 scheduler 注入
+    events: [], // 不监听消息事件，由 runtime scheduler 按 cron 推 BotEvent
     requireMention: false,
     cron: '0 17 * * 5',
     description: '周五 17:00 → 扫本周消息生成周报卡片',


### PR DESCRIPTION
closes #41
关联：#40 fix 1 + fix 2（在本 PR 一并落地，fix 3 留给 #22 wiring）

## 范围

不改业务行为，只动注释 / 命名 / tsconfig。

| # | 范围 | 文件 |
|---|------|------|
| 1 | SeedHAC / Sentinel → Lark Loom | 4 个 package.json + contracts/README + bot/index.ts + skill-router.ts + recall.ts |
| 2 | 删 RouteResult 弃用别名 | skill-router.ts |
| 3 | requiresMention → requireMention（router 内部字段对齐合约） | skill-router.ts |
| 4 | weekly.ts events: [] | skills/weekly.ts |
| 5 | 修 contracts dist 漂移：根 typecheck 改 tsc -b 走 references | package.json |
| 6 | 删过期注释（lark-cli / PDF / v0.1） | slides.ts + message.ts + bitable.ts + index.ts |

包名 \`@seedhac/*\` 保留（动 import 全仓，决赛后再改）。docs/* 里的设计期 \"Sentinel\" 字样保留。

## 验收

- ✅ \`pnpm typecheck\` 在 cold（无 dist + 无 buildinfo）状态下也能通过
- ✅ \`pnpm test\` 87/87 通过
- ✅ \`pnpm lint\` 0 error（18 个 console warning 是 smoke scripts 的，与本 PR 无关）
- ✅ 全仓 grep \`requiresMention\` 0 命中（src）
- ✅ 全仓 grep \`RouteResult\` 0 命中（src）
- ✅ 全仓 grep \`SeedHAC\` 0 命中（src）

## 不在本 PR 范围

- ❌ index.ts 硬编码回复替换 → issue #22 单独做
- ❌ RouteIntent → SkillName 映射表 → 跟 #22 wiring 一起做
- ❌ 包名 @seedhac → @lark-loom → 决赛后

## Test plan

- [x] CI 跑通（typecheck / test / lint）
- [x] 本地拉下 PR + \`rm -rf packages/*/dist packages/*/.tsbuildinfo packages/contracts/tsconfig.tsbuildinfo && pnpm typecheck\` 一次过
- [x] qi / antares review 注释改动是否符合各自模块语义