### PR TITLE
ci: GitHub Actions workflow — typecheck + test + lint (closes #43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: typecheck + test + lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build contracts first so downstream packages resolve dist types.
+      # Once root typecheck is migrated to `tsc -b` (PR #42), this step
+      # becomes redundant but harmless.
+      - name: Build (for cross-package type resolution)
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Lint
+        run: pnpm lint


### PR DESCRIPTION
closes #43

## 内容

\`.github/workflows/ci.yml\`：

- **触发**：PR opened/synchronize 到 main、push 到 main
- **环境**：ubuntu-latest + Node 20 + pnpm 9.12.0（带 store cache）
- **步骤**：install → build → typecheck → test → lint
- **timeout**：10 分钟
- **concurrency**：按 ref 分组，新 push 自动 cancel 旧的，省 quota

## 为什么先 build 再 typecheck

main 当前 \`pnpm typecheck\` 是 \`pnpm -r typecheck\`（每包 \`tsc --noEmit\`），依赖 contracts 的 \`dist/index.d.ts\` 才能解析跨包类型。冷启动会挂。

修法两条路：
1. CI 先 \`pnpm build\` 把 dist 生出来再 typecheck（**本 PR 选这条**）
2. 根 \`typecheck\` 改成 \`tsc -b\` 走 references（PR #42 的修法）

PR #42 合并后第 1 步会冗余但无害。先用方案 1 让 CI 立刻能落地，不阻塞 PR #42 review 节奏。

## Test plan

- [ ] 本 PR 自身能在 CI 上变绿
- [ ] 故意 push 一个 typecheck 错误，CI 必须红（后续 PR 验证）
- [ ] 故意 push 一个 test 失败，CI 必须红（后续 PR 验证）
- [ ] lint warning（现在有 18 个 console warning）不阻塞 CI ✅

## 后续

- PR #42 合并后，把 build 步骤删掉（或留下当无害冗余）
- 加集成测试 job（需要 ARK_API_KEY / ARK_EMBEDDING_EP secrets，独立 issue）
- 加 PR 模板 + CODEOWNERS（独立 issue）