### PR TITLE
feat(bot): MessageBuffer 滑窗批处理（closes #46）

### DIFF
--- a/packages/bot/src/__tests__/message-buffer.test.ts
+++ b/packages/bot/src/__tests__/message-buffer.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MessageBuffer, DEFAULT_STRONG_SIGNALS } from '../message-buffer.js';
+import type { Message } from '@seedhac/contracts';
+
+let counter = 0;
+function makeMsg(chatId: string, text: string): Message {
+  counter += 1;
+  return {
+    messageId: `msg_${counter}`,
+    chatId,
+    chatType: 'group',
+    sender: { userId: 'u1' },
+    contentType: 'text',
+    text,
+    rawContent: text,
+    mentions: [],
+    timestamp: 1_700_000_000_000 + counter,
+  };
+}
+
+describe('MessageBuffer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    counter = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flush after batchSize messages reached', () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 3, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'hi'));
+    buf.push(makeMsg('chat_a', 'hello'));
+    expect(onFlush).not.toHaveBeenCalled();
+
+    buf.push(makeMsg('chat_a', 'yo'));
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![0]).toBe('chat_a');
+    expect(onFlush.mock.calls[0]![1]).toHaveLength(3);
+  });
+
+  it('flush after windowMs elapses even if batch not full', () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 10, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'one'));
+    buf.push(makeMsg('chat_a', 'two'));
+
+    vi.advanceTimersByTime(29_999);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2);
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![1]).toHaveLength(2);
+  });
+
+  it('strong signal triggers immediate flush', () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 10, strongSignals: DEFAULT_STRONG_SIGNALS },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', '今天天气不错'));
+    buf.push(makeMsg('chat_a', 'Q3 数据是多少来着'));
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![1]).toHaveLength(2);
+  });
+
+  it('isolates buffers per chatId', () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 2, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'a1'));
+    buf.push(makeMsg('chat_b', 'b1'));
+    expect(onFlush).not.toHaveBeenCalled();
+
+    buf.push(makeMsg('chat_a', 'a2'));
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![0]).toBe('chat_a');
+    expect(onFlush.mock.calls[0]![1]).toHaveLength(2);
+
+    buf.push(makeMsg('chat_b', 'b2'));
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush.mock.calls[1]![0]).toBe('chat_b');
+  });
+
+  it('manual flush() empties one chat without affecting others', async () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 10, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'a1'));
+    buf.push(makeMsg('chat_b', 'b1'));
+
+    await buf.flush('chat_a');
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![0]).toBe('chat_a');
+
+    await buf.flush('chat_b');
+    expect(onFlush).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() clears timers and flushes all buffers', async () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 10, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'a1'));
+    buf.push(makeMsg('chat_b', 'b1'));
+
+    await buf.stop();
+
+    expect(onFlush).toHaveBeenCalledTimes(2);
+
+    // 进一步 advance timer 不应再触发任何 flush
+    vi.advanceTimersByTime(60_000);
+    expect(onFlush).toHaveBeenCalledTimes(2);
+
+    // stop 后再 push 也应被忽略
+    buf.push(makeMsg('chat_a', 'should be ignored'));
+    expect(onFlush).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not start a new timer when buffer already has items', () => {
+    const onFlush = vi.fn();
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 10, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'm1'));
+    vi.advanceTimersByTime(15_000);
+    buf.push(makeMsg('chat_a', 'm2')); // 不应重置 timer
+    vi.advanceTimersByTime(15_001);
+
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]![1]).toHaveLength(2);
+  });
+
+  it('onFlush throwing does not break the buffer for subsequent batches', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onFlush = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    const buf = new MessageBuffer(
+      { windowMs: 30_000, batchSize: 1, strongSignals: [] },
+      onFlush,
+    );
+
+    buf.push(makeMsg('chat_a', 'first'));
+    // microtask 排队，等一拍
+    await Promise.resolve();
+    await Promise.resolve();
+
+    buf.push(makeMsg('chat_a', 'second'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/packages/bot/src/message-buffer.ts
+++ b/packages/bot/src/message-buffer.ts
@@ -1,0 +1,121 @@
+/**
+ * MessageBuffer — 滑窗批处理（cost-control 核心）
+ *
+ * 每条群消息都过 LLM 缺口检测会烧钱。本类负责把消息攒成批，
+ * 在以下任一条件触发时统一 flush 给 onFlush 处理：
+ *   1. 累积到 batchSize 条
+ *   2. 距首条消息超过 windowMs
+ *   3. 检测到 strongSignals 关键词 — 立即 flush，不等批
+ *
+ * 多 chatId 隔离：每个 chatId 有独立缓冲区与独立 timer。
+ */
+
+import type { Message } from '@seedhac/contracts';
+
+export interface MessageBufferConfig {
+  /** 窗口时长（毫秒），默认 30000 */
+  readonly windowMs: number;
+  /** 攒满即 flush，默认 10 */
+  readonly batchSize: number;
+  /** 命中即立即 flush 的强信号正则；为空 = 不启用强信号短路 */
+  readonly strongSignals: readonly RegExp[];
+}
+
+export type FlushHandler = (
+  chatId: string,
+  messages: readonly Message[],
+) => Promise<void> | void;
+
+interface ChatState {
+  buffer: Message[];
+  timer: NodeJS.Timeout | null;
+}
+
+export const DEFAULT_STRONG_SIGNALS: readonly RegExp[] = [
+  /是多少来着/,
+  /那个数据/,
+  /上次.{0,6}(数据|结果|说|聊|讲|定|决定)/,
+  /我记得/,
+];
+
+export class MessageBuffer {
+  private readonly states = new Map<string, ChatState>();
+  private stopped = false;
+
+  constructor(
+    private readonly config: MessageBufferConfig,
+    private readonly onFlush: FlushHandler,
+  ) {}
+
+  push(msg: Message): void {
+    if (this.stopped) return;
+
+    const state = this.getOrCreateState(msg.chatId);
+    state.buffer.push(msg);
+
+    // 强信号 → 立即 flush
+    if (this.matchesStrongSignal(msg.text)) {
+      void this.flushState(msg.chatId, state);
+      return;
+    }
+
+    // 攒满 batchSize → 立即 flush
+    if (state.buffer.length >= this.config.batchSize) {
+      void this.flushState(msg.chatId, state);
+      return;
+    }
+
+    // 首条消息：启动窗口 timer
+    if (state.buffer.length === 1 && state.timer === null) {
+      state.timer = setTimeout(() => {
+        void this.flushState(msg.chatId, state);
+      }, this.config.windowMs);
+    }
+  }
+
+  /** 手动触发 flush（外部调用，比如 SIGINT 前清空） */
+  async flush(chatId: string): Promise<void> {
+    const state = this.states.get(chatId);
+    if (!state) return;
+    await this.flushState(chatId, state);
+  }
+
+  /** 停止：清所有 timer + flush 所有剩余缓冲区 */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    const chatIds = Array.from(this.states.keys());
+    await Promise.all(chatIds.map((id) => this.flush(id)));
+  }
+
+  private getOrCreateState(chatId: string): ChatState {
+    let state = this.states.get(chatId);
+    if (!state) {
+      state = { buffer: [], timer: null };
+      this.states.set(chatId, state);
+    }
+    return state;
+  }
+
+  private matchesStrongSignal(text: string): boolean {
+    return this.config.strongSignals.some((re) => re.test(text));
+  }
+
+  private async flushState(chatId: string, state: ChatState): Promise<void> {
+    if (state.timer !== null) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+    if (state.buffer.length === 0) return;
+
+    const batch = state.buffer;
+    state.buffer = [];
+
+    try {
+      await this.onFlush(chatId, batch);
+    } catch (e) {
+      // onFlush 抛错不能让 buffer 死掉；调用方应在 handler 内自己处理错误。
+      // 这里仅吞掉避免 unhandled rejection。
+      console.error('[MessageBuffer] onFlush threw:', e);
+    }
+  }
+}


### PR DESCRIPTION
closes #46
父 issue: #44 recall skill

## 实现

\`packages/bot/src/message-buffer.ts\`

cost-control 核心：把群消息攒成批，三种条件触发 flush：

| 触发条件 | 行为 |
|---|---|
| 累积 \`batchSize\`（默认 10）条 | 立即 flush |
| 距首条消息超过 \`windowMs\`（默认 30s）| 立即 flush |
| 命中 \`strongSignals\` 关键词（"是多少来着" / "那个数据" / "上次..."）| 不等批，立即 flush |

多 chatId 隔离：每个 chatId 独立缓冲区与独立 timer。stop() 幂等清场。

## 单元测试 8/8 通过

| # | 场景 |
|---|---|
| 1 | batchSize 触发 |
| 2 | windowMs 超时触发 |
| 3 | 强信号短路触发 |
| 4 | 多 chatId 缓冲隔离 |
| 5 | 手动 flush 单个 chat |
| 6 | stop 清空所有 + 后续 push 被忽略 |
| 7 | timer 不被中途消息重置 |
| 8 | onFlush 抛错不破坏 buffer |

## 接口

\`\`\`typescript
const buf = new MessageBuffer(
  {
    windowMs: 30_000,
    batchSize: 10,
    strongSignals: DEFAULT_STRONG_SIGNALS, // 或自定义 RegExp[]
  },
  async (chatId, messages) => {
    // 这里调 GapDetector + recall.run()
  },
);
buf.push(msg);     // 收到群消息时调
await buf.flush(chatId);  // 手动 flush
await buf.stop();  // SIGINT 时调
\`\`\`

## 不在本 PR 范围

- ❌ GapDetector（issue #47）
- ❌ recall skill 本体（issue #45）
- ❌ runtime wiring（issue #22）

## Test plan

- [x] 本地 \`pnpm typecheck\` ✅
- [x] 本地 \`pnpm test\` 95/95 ✅
- [x] 本地 \`pnpm lint\` 0 error ✅
- [ ] CI 绿（依赖 PR #48 合入）