### PR TITLE
feat(bot,skills): GapDetector（closes #47）

### DIFF
--- a/packages/bot/src/__tests__/gap-detector.test.ts
+++ b/packages/bot/src/__tests__/gap-detector.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GapDetector } from '../gap-detector.js';
+
+const mockLLMAsk = vi.fn();
+const mockLLM = { ask: mockLLMAsk, chat: vi.fn(), askStructured: vi.fn() };
+
+function makeDetector(): GapDetector {
+  return new GapDetector(mockLLM as never);
+}
+
+function makeMessage(name: string, text: string) {
+  return {
+    messageId: 'msg_1',
+    chatId: 'chat_1',
+    chatType: 'group' as const,
+    sender: { userId: 'u1', name },
+    contentType: 'text' as const,
+    text,
+    rawContent: text,
+    mentions: [],
+    timestamp: Date.now(),
+  };
+}
+
+describe('GapDetector', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns shouldRecall:false immediately when messages is empty', async () => {
+    const result = await makeDetector().detect([]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(false);
+      expect(mockLLMAsk).not.toHaveBeenCalled();
+    }
+  });
+
+  it('returns shouldRecall:true when LLM detects a gap', async () => {
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"有人问了但没人回答","query":"上次会议结论"}',
+    });
+
+    const result = await makeDetector().detect([makeMessage('Alice', '上次我们决定的方案是什么来着？')]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(true);
+      expect(result.value.reason).toBe('有人问了但没人回答');
+      expect(result.value.query).toBe('上次会议结论');
+    }
+  });
+
+  it('returns shouldRecall:false when LLM says no gap', async () => {
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":false,"reason":"","query":""}',
+    });
+
+    const result = await makeDetector().detect([makeMessage('Bob', '今天天气不错')]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(false);
+    }
+  });
+
+  it('falls back to shouldRecall:false when LLM fails', async () => {
+    mockLLMAsk.mockResolvedValueOnce({ ok: false, error: { code: 'LLM_TIMEOUT', message: 'timeout' } });
+
+    const result = await makeDetector().detect([makeMessage('Alice', '那个预算是多少来着')]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(false);
+      expect(result.value.reason).toBe('');
+    }
+  });
+
+  it('falls back to shouldRecall:false when LLM returns invalid JSON', async () => {
+    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: 'not json at all' });
+
+    const result = await makeDetector().detect([makeMessage('Alice', '我记得好像上次说过')]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(false);
+    }
+  });
+
+  it('strips markdown code fences before parsing JSON', async () => {
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '```json\n{"shouldRecall":true,"reason":"有未解答的问题","query":"项目截止日期"}\n```',
+    });
+
+    const result = await makeDetector().detect([makeMessage('Carol', '截止日期是哪天来着')]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.shouldRecall).toBe(true);
+      expect(result.value.query).toBe('项目截止日期');
+    }
+  });
+});

--- a/packages/bot/src/gap-detector.ts
+++ b/packages/bot/src/gap-detector.ts
@@ -1,0 +1,64 @@
+/**
+ * GapDetector — 信息缺口检测器。
+ *
+ * 用豆包 Lite 判断一批群消息里是否存在"有人需要某个信息但没找到"的场景。
+ * LLM 失败 / 非法 JSON → 返回 shouldRecall: false，不崩。
+ */
+
+import { type Result, type LLMClient, type Message, ok } from '@seedhac/contracts';
+
+export interface GapDetection {
+  readonly shouldRecall: boolean;
+  readonly reason: string;
+  readonly query: string;
+}
+
+const FALLBACK: GapDetection = { shouldRecall: false, reason: '', query: '' };
+
+function buildPrompt(messages: readonly Message[]): string {
+  const lines = messages.map((m) => `[${m.sender.name ?? m.sender.userId}]: ${m.text}`).join('\n');
+
+  return `你是一个群聊信息缺口检测助手。
+
+请判断下面这段群聊记录中，是否存在"有人在寻找某个信息但没有得到答案"的情况。
+
+触发条件（满足任一即可）：
+1. 不确定性表述：「那个...」「上次...」「是多少来着」「我记得好像」
+2. 任务型讨论：涉及「决定 / 方案 / 计划」但缺少具体数据
+3. 有人提问但后续没人回答
+4. 当前话题与某段历史记录明显相关但没人提起
+
+群聊记录：
+${lines}
+
+请只返回如下 JSON，不要有任何其他文字：
+{"shouldRecall":true,"reason":"简短说明触发原因","query":"用于检索的关键词或问题"}
+
+如果不需要召回，返回：
+{"shouldRecall":false,"reason":"","query":""}`;
+}
+
+export class GapDetector {
+  constructor(private readonly llm: LLMClient) {}
+
+  async detect(messages: readonly Message[]): Promise<Result<GapDetection>> {
+    if (messages.length === 0) return ok(FALLBACK);
+
+    const prompt = buildPrompt(messages);
+    const result = await this.llm.ask(prompt, { model: 'lite' });
+
+    if (!result.ok) return ok(FALLBACK);
+
+    try {
+      const cleaned = result.value.trim().replace(/```json|```/g, '').trim();
+      const parsed = JSON.parse(cleaned) as GapDetection;
+      return ok({
+        shouldRecall: Boolean(parsed.shouldRecall),
+        reason: String(parsed.reason ?? ''),
+        query: String(parsed.query ?? ''),
+      });
+    } catch {
+      return ok(FALLBACK);
+    }
+  }
+}

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -17,9 +17,13 @@
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist .tsbuildinfo"
+    "clean": "rm -rf dist .tsbuildinfo",
+    "test": "vitest run"
   },
   "dependencies": {
     "@seedhac/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/skills/src/__tests__/recall.test.ts
+++ b/packages/skills/src/__tests__/recall.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { recallSkill } from '../recall.js';
+import type { SkillContext, BotEvent, Message, Result, RetrieveHit } from '@seedhac/contracts';
+
+// ── mock helpers ────────────────────────────────────────────────────────────
+
+const mockLLMAsk = vi.fn();
+const mockFetchHistory = vi.fn();
+const mockVectorRetrieve = vi.fn();
+const mockBitableRetrieve = vi.fn();
+
+function makeMessage(text: string, messageId = 'msg_1'): Message {
+  return {
+    messageId,
+    chatId: 'chat_1',
+    chatType: 'group',
+    sender: { userId: 'u1', name: 'Alice' },
+    contentType: 'text',
+    text,
+    rawContent: text,
+    mentions: [],
+    timestamp: Date.now(),
+  };
+}
+
+function makeEvent(text: string, messageId = 'msg_1'): BotEvent {
+  return { type: 'message', payload: makeMessage(text, messageId) };
+}
+
+function makeCtx(event: BotEvent): SkillContext {
+  return {
+    event,
+    runtime: {
+      fetchHistory: mockFetchHistory,
+      sendText: vi.fn(),
+      sendCard: vi.fn(),
+      patchCard: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    },
+    llm: { ask: mockLLMAsk, chat: vi.fn(), askStructured: vi.fn() },
+    bitable: { find: vi.fn(), insert: vi.fn(), batchInsert: vi.fn(), update: vi.fn(), delete: vi.fn(), link: vi.fn() },
+    retrievers: {
+      vector: { source: 'vector', retrieve: mockVectorRetrieve },
+      bitable: { source: 'bitable', retrieve: mockBitableRetrieve },
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as SkillContext;
+}
+
+function makeHit(id: string, snippet: string): RetrieveHit {
+  return { source: 'vector', id, title: snippet.slice(0, 30), snippet, score: 0.9, timestamp: Date.now() };
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+describe('recallSkill', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('match returns false for non-message events', async () => {
+    const ctx = makeCtx({ type: 'botJoinedChat', payload: { chatId: 'c', inviter: { userId: 'u' }, timestamp: 0 } });
+    expect(await recallSkill.match(ctx)).toBe(false);
+    expect(mockFetchHistory).not.toHaveBeenCalled();
+  });
+
+  it('match returns false when no keyword present', async () => {
+    const ctx = makeCtx(makeEvent('今天天气真好'));
+    expect(await recallSkill.match(ctx)).toBe(false);
+    expect(mockFetchHistory).not.toHaveBeenCalled();
+  });
+
+  it('match returns false when keyword present but LLM detects no gap', async () => {
+    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [makeMessage('我记得好像不对')], hasMore: false } });
+    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: '{"shouldRecall":false,"reason":"","query":""}' });
+
+    const ctx = makeCtx(makeEvent('我记得好像不对'));
+    expect(await recallSkill.match(ctx)).toBe(false);
+  });
+
+  it('normal path: match detects gap → run retrieves + synthesizes text', async () => {
+    const messageId = 'msg_norm';
+    const ctx = makeCtx(makeEvent('那个预算是多少来着', messageId));
+
+    // match() calls
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [makeMessage('那个预算是多少来着', messageId)], hasMore: false },
+    });
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"有人询问预算","query":"项目预算"}',
+    });
+
+    const matched = await recallSkill.match(ctx);
+    expect(matched).toBe(true);
+
+    // run() calls — cache hit, no second LLM detection
+    mockVectorRetrieve.mockResolvedValueOnce({ ok: true, value: [makeHit('h1', '预算是 10 万')] });
+    mockBitableRetrieve.mockResolvedValueOnce({ ok: true, value: [makeHit('h2', '已核定 10 万预算')] });
+    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: '项目预算是 10 万，上次会议已确认。' });
+
+    const result: Result<import('@seedhac/contracts').SkillResult> = await recallSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.text).toBe('项目预算是 10 万，上次会议已确认。');
+      expect(result.value.reasoning).toBe('有人询问预算');
+    }
+    // LLM was called once for detection (in match) + once for synthesis (in run)
+    expect(mockLLMAsk).toHaveBeenCalledTimes(2);
+  });
+
+  it('run returns empty text when both retrievers return no hits', async () => {
+    const messageId = 'msg_nohits';
+    const ctx = makeCtx(makeEvent('上次那个结论是啥', messageId));
+
+    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"未解答","query":"会议结论"}',
+    });
+    await recallSkill.match(ctx);
+
+    mockVectorRetrieve.mockResolvedValueOnce({ ok: true, value: [] });
+    mockBitableRetrieve.mockResolvedValueOnce({ ok: true, value: [] });
+
+    const result = await recallSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.text).toBe('');
+    expect(mockLLMAsk).toHaveBeenCalledTimes(1); // only detection, no synthesis
+  });
+
+  it('run degrades gracefully when LLM synthesis fails — returns first snippet', async () => {
+    const messageId = 'msg_synthfail';
+    const ctx = makeCtx(makeEvent('之前说的方案是啥', messageId));
+
+    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"方案缺失","query":"项目方案"}',
+    });
+    await recallSkill.match(ctx);
+
+    mockVectorRetrieve.mockResolvedValueOnce({ ok: true, value: [makeHit('h1', '采用方案A')] });
+    mockBitableRetrieve.mockResolvedValueOnce({ ok: true, value: [] });
+    mockLLMAsk.mockResolvedValueOnce({ ok: false, error: { code: 'LLM_TIMEOUT', message: 'timeout' } });
+
+    const result = await recallSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.text).toBe('采用方案A');
+  });
+
+  it('run merges hits from both vector and bitable retrievers', async () => {
+    const messageId = 'msg_merge';
+    const ctx = makeCtx(makeEvent('上回那个截止日期', messageId));
+
+    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"截止日期未确认","query":"截止日期"}',
+    });
+    await recallSkill.match(ctx);
+
+    const vectorHit = makeHit('v1', 'DDL 是 5 月 1 日');
+    const bitableHit: RetrieveHit = { source: 'bitable', id: 'b1', title: '截止', snippet: '确认 DDL：2026-05-01', score: 1, timestamp: Date.now() };
+    mockVectorRetrieve.mockResolvedValueOnce({ ok: true, value: [vectorHit] });
+    mockBitableRetrieve.mockResolvedValueOnce({ ok: true, value: [bitableHit] });
+    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: '截止日期是 5 月 1 日，已在表格中确认。' });
+
+    const result = await recallSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    // verify both retrievers were called with the right query
+    expect(mockVectorRetrieve).toHaveBeenCalledWith(expect.objectContaining({ query: '截止日期' }));
+    expect(mockBitableRetrieve).toHaveBeenCalledWith(expect.objectContaining({ query: '截止日期' }));
+    if (result.ok) expect(result.value.text).toContain('5 月');
+  });
+
+  it('run handles total retriever failure and returns empty text', async () => {
+    const messageId = 'msg_retrieverr';
+    const ctx = makeCtx(makeEvent('我记得之前讨论过这个', messageId));
+
+    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
+    mockLLMAsk.mockResolvedValueOnce({
+      ok: true,
+      value: '{"shouldRecall":true,"reason":"历史讨论未追溯","query":"历史讨论"}',
+    });
+    await recallSkill.match(ctx);
+
+    mockVectorRetrieve.mockResolvedValueOnce({ ok: false, error: { code: 'UNKNOWN', message: 'chroma down' } });
+    mockBitableRetrieve.mockResolvedValueOnce({ ok: false, error: { code: 'FEISHU_API_ERROR', message: 'timeout' } });
+
+    const result = await recallSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.text).toBe('');
+    expect(mockLLMAsk).toHaveBeenCalledTimes(1); // no synthesis when hits empty
+  });
+});

--- a/packages/skills/src/recall.ts
+++ b/packages/skills/src/recall.ts
@@ -1,23 +1,156 @@
 /**
- * 🅱 recall — 主动浮信息（核心差异化）🔥
+ * recall — 主动浮信息（核心差异化）
  *
- * 触发：群消息中出现 "上次 / 之前 / 我记得 / 那个数据 / 上回..."
- * 数据流：缺口检测（小模型）→ 命中 → Skill Router 选数据源 → 并行检索 → 召回卡片
+ * 触发：群消息中出现模糊表述 → 豆包 Lite 判断是否存在信息缺口
+ * 数据流：keyword 预筛 → 拉近期消息 → 缺口检测 → 并行检索（vector + bitable）→ LLM 整合 → 纯文本回复
  *
- * 这是 Lark Loom 的灵魂 Skill；做好了是神，做差了就是骚扰机器人。
+ * 注意：卡片规范里 recall 直接返回 SkillResult.text，像同事随口一句话。
  */
 
-import type { Skill } from '@seedhac/contracts';
-import { ErrorCode, err, makeError } from '@seedhac/contracts';
+import {
+  type Skill,
+  type SkillContext,
+  type SkillResult,
+  type RetrieveQuery,
+  type RetrieveHit,
+  type LLMClient,
+  type Message,
+  type Result,
+  ok,
+  err,
+  makeError,
+  ErrorCode,
+} from '@seedhac/contracts';
 
-export const recallSkill: Skill = {
-  name: 'recall',
-  trigger: {
-    events: ['message'],
+const KEYWORDS = ['上次', '之前', '我记得', '那个', '上回', '是多少来着'] as const;
+
+interface GapDetection {
+  readonly shouldRecall: boolean;
+  readonly reason: string;
+  readonly query: string;
+}
+
+const NO_GAP: GapDetection = { shouldRecall: false, reason: '', query: '' };
+
+function buildGapPrompt(messages: readonly Message[]): string {
+  const lines = messages.map((m) => `[${m.sender.name ?? m.sender.userId}]: ${m.text}`).join('\n');
+
+  return `你是一个群聊信息缺口检测助手。
+
+请判断下面这段群聊记录中，是否存在"有人在寻找某个信息但没有得到答案"的情况。
+
+触发条件（满足任一即可）：
+1. 不确定性表述：「那个...」「上次...」「是多少来着」「我记得好像」
+2. 任务型讨论：涉及「决定 / 方案 / 计划」但缺少具体数据
+3. 有人提问但后续没人回答
+4. 当前话题与某段历史记录明显相关但没人提起
+
+群聊记录：
+${lines}
+
+请只返回如下 JSON，不要有任何其他文字：
+{"shouldRecall":true,"reason":"简短说明触发原因","query":"用于检索的关键词或问题"}
+
+如果不需要召回，返回：
+{"shouldRecall":false,"reason":"","query":""}`;
+}
+
+async function detectGap(llm: LLMClient, messages: readonly Message[]): Promise<GapDetection> {
+  const result = await llm.ask(buildGapPrompt(messages), { model: 'lite' });
+  if (!result.ok) return NO_GAP;
+  try {
+    const cleaned = result.value.trim().replace(/```json|```/g, '').trim();
+    const parsed = JSON.parse(cleaned) as GapDetection;
+    return {
+      shouldRecall: Boolean(parsed.shouldRecall),
+      reason: String(parsed.reason ?? ''),
+      query: String(parsed.query ?? ''),
+    };
+  } catch {
+    return NO_GAP;
+  }
+}
+
+async function synthesize(llm: LLMClient, query: string, hits: readonly RetrieveHit[]): Promise<string> {
+  const snippets = hits.map((h, i) => `[${i + 1}] ${h.snippet}`).join('\n\n');
+  const prompt = `你是群聊助手，请根据历史消息帮忙回答。
+
+查询：${query}
+
+相关历史消息：
+${snippets}
+
+请用 1-3 句话，以自然口语化的方式回答，像熟悉项目的同事随口提醒。直接说内容，不要说"根据历史记录"。`;
+
+  const result = await llm.ask(prompt, { model: 'pro' });
+  if (!result.ok) return hits[0]?.snippet ?? '';
+  return result.value;
+}
+
+class RecallSkill implements Skill {
+  readonly name = 'recall' as const;
+  readonly trigger = {
+    events: ['message'] as const,
     requireMention: false,
-    keywords: ['上次', '之前', '我记得', '那个', '上回', '是多少来着'],
+    keywords: KEYWORDS,
     description: '群消息出现模糊表述 → 主动召回历史信息（事中介入）',
-  },
-  match: () => false, // TODO: 缺口检测（豆包 Lite）
-  run: async () => err(makeError(ErrorCode.SKILL_NOT_IMPLEMENTED, 'recall skill not implemented')),
-};
+  };
+
+  private readonly gapCache = new Map<string, GapDetection>();
+  private static readonly GAP_CACHE_MAX = 200;
+
+  async match(ctx: SkillContext): Promise<boolean> {
+    if (ctx.event.type !== 'message') return false;
+    const msg = ctx.event.payload;
+
+    if (!KEYWORDS.some((k) => msg.text.includes(k))) return false;
+
+    const histResult = await ctx.runtime.fetchHistory({ chatId: msg.chatId, pageSize: 10 });
+    const messages = histResult.ok ? histResult.value.messages : [msg];
+
+    const detection = await detectGap(ctx.llm, messages);
+    if (detection.shouldRecall) {
+      if (this.gapCache.size >= RecallSkill.GAP_CACHE_MAX) {
+        this.gapCache.delete(this.gapCache.keys().next().value!);
+      }
+      this.gapCache.set(msg.messageId, detection);
+    }
+    return detection.shouldRecall;
+  }
+
+  async run(ctx: SkillContext): Promise<Result<SkillResult>> {
+    if (ctx.event.type !== 'message') {
+      return err(makeError(ErrorCode.INVALID_INPUT, 'recall only handles message events'));
+    }
+    const msg = ctx.event.payload;
+
+    let detection = this.gapCache.get(msg.messageId);
+    this.gapCache.delete(msg.messageId);
+
+    if (!detection) {
+      const histResult = await ctx.runtime.fetchHistory({ chatId: msg.chatId, pageSize: 10 });
+      const messages = histResult.ok ? histResult.value.messages : [msg];
+      detection = await detectGap(ctx.llm, messages);
+      if (!detection.shouldRecall) return ok({ text: '' });
+    }
+
+    const query: RetrieveQuery = { query: detection.query, chatId: msg.chatId, topK: 5 };
+
+    const [vectorResult, bitableResult] = await Promise.all([
+      ctx.retrievers['vector']?.retrieve(query) ?? Promise.resolve(ok([] as readonly RetrieveHit[])),
+      ctx.retrievers['bitable']?.retrieve(query) ?? Promise.resolve(ok([] as readonly RetrieveHit[])),
+    ]);
+
+    const hits: RetrieveHit[] = [
+      ...(vectorResult.ok ? vectorResult.value : []),
+      ...(bitableResult.ok ? bitableResult.value : []),
+    ];
+
+    if (hits.length === 0) return ok({ text: '' });
+
+    const text = await synthesize(ctx.llm, detection.query, hits);
+    return ok({ text, reasoning: detection.reason });
+  }
+}
+
+export const recallSkill: Skill = new RecallSkill();

--- a/packages/skills/vitest.config.ts
+++ b/packages/skills/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,10 @@ importers:
       '@seedhac/contracts':
         specifier: workspace:*
         version: link:../contracts
+    devDependencies:
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 


### PR DESCRIPTION
### #47 GapDetector                         
  - 新增 `packages/bot/src/gap-detector.ts`
  - 用豆包 Lite 判断一批群消息里是否存在信息缺口
  - 返回 `GapDetection { shouldRecall, reason, query }`                         
  - LLM 失败 / 非法 JSON → fallback shouldRecall: false，不崩