### PR TITLE
Implement QA over Feishu context sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ LARK_APP_ID=cli_xxxxxxxxxxxxxxxx
 # 应用 App Secret
 LARK_APP_SECRET=
 
+# Bot 自身 open_id，用于判断群消息是否 @ 了机器人
+LARK_BOT_OPEN_ID=ou_xxxxxxxxxxxxxxxx
+
 # 事件订阅 · Verification Token
 LARK_VERIFICATION_TOKEN=
 

--- a/packages/bot/src/__tests__/bot-runtime.test.ts
+++ b/packages/bot/src/__tests__/bot-runtime.test.ts
@@ -114,7 +114,10 @@ describe('LarkBotRuntime', () => {
   it('sendCard calls SDK create with msg_type interactive', async () => {
     mockMessageCreate.mockResolvedValue({ code: 0, data: { message_id: 'msg_3' } });
     const runtime = makeRuntime();
-    const card = { type: 'card', header: { title: 'test' } } as unknown as Card;
+    const card = {
+      templateName: 'qa',
+      content: { schema: '2.0', header: { title: 'test' } },
+    } as unknown as Card;
 
     const result = await runtime.sendCard({ chatId: 'oc_chat1', card });
 
@@ -122,6 +125,8 @@ describe('LarkBotRuntime', () => {
     expect(mockMessageCreate).toHaveBeenCalledOnce();
     const callArgs = mockMessageCreate.mock.calls[0]![0];
     expect(callArgs.data.msg_type).toBe('interactive');
+    expect(JSON.parse(callArgs.data.content)).toEqual(card.content);
+    expect(callArgs.data.content).not.toContain('templateName');
   });
 
   // 4. fetchHistory → 返回正确的 FetchHistoryResult
@@ -215,5 +220,36 @@ describe('LarkBotRuntime', () => {
     });
 
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('card action event triggers handler with action payload', async () => {
+    const runtime = makeRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+    await runtime.start();
+
+    const registeredHandlers = mockRegister.mock.calls[0]![0] as Record<
+      string,
+      (data: unknown) => Promise<unknown>
+    >;
+    const actionHandler = registeredHandlers['card.action.trigger']!;
+
+    await actionHandler({
+      context: { open_message_id: 'om_card1', open_chat_id: 'oc_chat1' },
+      operator: { open_id: 'ou_user1', name: '张三' },
+      action: {
+        tag: 'button',
+        value: { action: 'qa.reanswer', questionMessageId: 'msg_1' },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = (handler as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(event.type).toBe('cardAction');
+    expect(event.payload.chatId).toBe('oc_chat1');
+    expect(event.payload.messageId).toBe('om_card1');
+    expect(event.payload.user.userId).toBe('ou_user1');
+    expect(event.payload.value).toEqual({ action: 'qa.reanswer', questionMessageId: 'msg_1' });
+    await expect(actionHandler({})).resolves.toBeUndefined();
   });
 });

--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -84,7 +84,16 @@ describe('qa card', () => {
     const card = larkCardBuilder.build('qa', {
       question: '复赛截止日期是什么时候？',
       answer: '复赛日期为 **2026-05-06**。',
-      sources: [{ title: 'README', kind: 'wiki', snippet: '时间节点表' }],
+      sources: [
+        {
+          title: '群聊历史消息',
+          kind: 'chat',
+          snippet: '复赛日期是 2026-05-06',
+          authorName: 'Antares',
+          timestamp: Date.parse('2026-05-03T10:30:00+08:00'),
+        },
+        { title: 'README', kind: 'wiki', snippet: '时间节点表' },
+      ],
       buttons: [
         { text: '查看原文', value: { action: 'open', target: 'readme' }, variant: 'primary' },
       ],
@@ -94,6 +103,7 @@ describe('qa card', () => {
     expect(noPlaceholders(j)).toBe(true);
     expect(j).toContain('复赛截止日期');
     expect(j).toContain('2026-05-06');
+    expect(j).toContain('Antares');
     expect(j).toContain('README');
   });
 });

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { qaSkill } from '@seedhac/skills';
 import { err, makeError, ErrorCode, ok } from '@seedhac/contracts';
-import type { BotEvent, BotRuntime, Message, Skill, SkillContext, SkillName } from '@seedhac/contracts';
+import type {
+  BotEvent,
+  BotRuntime,
+  Message,
+  Skill,
+  SkillContext,
+  SkillName,
+} from '@seedhac/contracts';
 import { SkillRouter } from '../skill-router.js';
 import { handleEvent } from '../wiring.js';
 
@@ -44,11 +51,22 @@ function makeCtx(event: BotEvent, runtimeOverride?: BotRuntime): SkillContext {
   return {
     event,
     runtime: runtimeOverride ?? makeRuntime(),
-    llm: {} as SkillContext['llm'],
+    llm: {
+      ask: vi.fn().mockResolvedValue(ok('这是测试回答。')),
+      chat: vi.fn(),
+      askStructured: vi.fn(),
+    } as unknown as SkillContext['llm'],
     bitable: {} as SkillContext['bitable'],
+    docx: {} as SkillContext['docx'],
+    cardBuilder: {
+      build: vi.fn().mockReturnValue({ templateName: 'qa', content: { mock: true } }),
+    } as unknown as SkillContext['cardBuilder'],
     retrievers: {},
     logger: {
-      debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
     },
   };
 }
@@ -60,11 +78,14 @@ describe('qaSkill.match()', () => {
     process.env['LARK_BOT_OPEN_ID'] = BOT_ID;
   });
 
-  // 1. @bot → match() 返回 true（不要求问号）
-  it('@bot → returns true regardless of question mark', () => {
-    const msg = makeMessage({ text: '帮我查一下上周的会议记录', mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }] });
+  // 1. @bot 但没有疑问意图 → match() 返回 false
+  it('@bot without question intent → returns false', () => {
+    const msg = makeMessage({
+      text: '帮我查一下上周的会议记录',
+      mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }],
+    });
     const ctx = makeCtx(makeEvent(msg));
-    expect(qaSkill.match(ctx)).toBe(true);
+    expect(qaSkill.match(ctx)).toBe(false);
   });
 
   // 2. 无 @mention → match() 返回 false
@@ -82,22 +103,45 @@ describe('handleEvent wiring', () => {
     process.env['LARK_BOT_OPEN_ID'] = BOT_ID;
   });
 
-  // 3. @bot + 问号 → 路由到 qa → run() 被调用，sendText 被调用
-  it('@bot + ? → qaSkill.run() is called and response is sent', async () => {
+  // 3. @bot + 问号 → 路由到 qa → run() 被调用，sendCard 被调用
+  it('@bot + ? → qaSkill.run() is called and card response is sent', async () => {
     const runSpy = vi.spyOn(qaSkill, 'run');
-    const runtime = makeRuntime();
-    const msg = makeMessage({ text: '这是什么？', mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }] });
+    // Provide a history message that bigram-matches "这是什么？" so the skill
+    // doesn't bail early with "找不到相关记录".
+    const runtime = {
+      ...makeRuntime(),
+      fetchHistory: vi.fn().mockResolvedValue(
+        ok({
+          messages: [
+            makeMessage({ messageId: 'hist_1', text: '这是飞书的问答功能', sender: { userId: 'ou_other' } }),
+          ],
+          hasMore: false,
+        }),
+      ),
+    } as unknown as BotRuntime;
+    const msg = makeMessage({
+      text: '这是什么？',
+      mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }],
+    });
     const ctx = makeCtx(makeEvent(msg), runtime);
 
-    await handleEvent(ctx, router, { qa: qaSkill } as Partial<Record<SkillName, Skill>> as Record<SkillName, Skill>);
+    await handleEvent(ctx, router, { qa: qaSkill } as Partial<Record<SkillName, Skill>> as Record<
+      SkillName,
+      Skill
+    >);
 
     expect(runSpy).toHaveBeenCalledOnce();
-    expect(runtime.sendText).toHaveBeenCalledOnce();
+    expect(runtime.sendCard).toHaveBeenCalledOnce();
+    expect(runtime.sendText).not.toHaveBeenCalled();
   });
 
   // 4. intent 无映射（taskAssignment）→ 不触发任何 skill
   it('intent with no skill mapping → run() not called', async () => {
-    const mockSkill: Skill = { ...qaSkill, match: () => true, run: vi.fn().mockResolvedValue(ok({ text: 'x' })) };
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
     // 分工讨论触发 taskAssignment，intentToSkill 无 taskAssignment 映射
     const msg = makeMessage({ text: '张三负责前端，李四负责后端', mentions: [] });
     const ctx = makeCtx(makeEvent(msg));
@@ -115,20 +159,27 @@ describe('handleEvent wiring', () => {
       run: vi.fn().mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'boom'))),
     };
     const runtime = makeRuntime();
-    const msg = makeMessage({ text: '这是什么？', mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }] });
+    const msg = makeMessage({
+      text: '这是什么？',
+      mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }],
+    });
     const ctx = makeCtx(makeEvent(msg), runtime);
 
     await expect(
       handleEvent(ctx, router, { qa: failSkill } as unknown as Record<SkillName, Skill>),
     ).resolves.toBeUndefined();
 
-    expect((ctx.logger.error as ReturnType<typeof vi.fn>)).toHaveBeenCalledOnce();
+    expect(ctx.logger.error as ReturnType<typeof vi.fn>).toHaveBeenCalledOnce();
     expect(runtime.sendText).not.toHaveBeenCalled();
   });
 
   // 6. intent='silent'（非 qa/meetingNotes 等消息）→ 不触发任何 skill
   it('silent intent → no skill triggered', async () => {
-    const mockSkill: Skill = { ...qaSkill, match: () => true, run: vi.fn().mockResolvedValue(ok({ text: 'x' })) };
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
     // 普通聊天消息不匹配任何规则 → SkillRouter 返回 'silent'
     const msg = makeMessage({ text: '好的，明白了', mentions: [] });
     const ctx = makeCtx(makeEvent(msg));
@@ -140,12 +191,61 @@ describe('handleEvent wiring', () => {
 
   // 7. non-message event → 直接跳过
   it('non-message event → no skill triggered', async () => {
-    const mockSkill: Skill = { ...qaSkill, match: () => true, run: vi.fn().mockResolvedValue(ok({ text: 'x' })) };
-    const event: BotEvent = { type: 'botJoinedChat', payload: { chatId: 'c1', inviter: { userId: 'u1' }, timestamp: 0 } };
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
+    const event: BotEvent = {
+      type: 'botJoinedChat',
+      payload: { chatId: 'c1', inviter: { userId: 'u1' }, timestamp: 0 },
+    };
     const ctx = makeCtx(event);
 
     await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
 
     expect(mockSkill.run).not.toHaveBeenCalled();
+  });
+
+  it('qa.reanswer card action fetches edited source message and sends a new card', async () => {
+    const editedQuestion = makeMessage({
+      messageId: 'msg_question',
+      text: 'PPT 这期要直接生成飞书幻灯片吗？',
+    });
+    const runtime = {
+      ...makeRuntime(),
+      fetchHistory: vi.fn().mockResolvedValue(ok({ messages: [editedQuestion], hasMore: false })),
+    } as unknown as BotRuntime;
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: vi.fn(),
+      run: vi.fn().mockResolvedValue(ok({ card: { templateName: 'qa', content: { mock: true } } })),
+    };
+    const event: BotEvent = {
+      type: 'cardAction',
+      payload: {
+        chatId: 'oc_chat1',
+        messageId: 'om_card1',
+        user: { userId: 'ou_user1' },
+        value: {
+          action: 'qa.reanswer',
+          questionMessageId: 'msg_question',
+          chatId: 'oc_chat1',
+        },
+        timestamp: 0,
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+
+    await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
+
+    expect(runtime.fetchHistory).toHaveBeenCalledWith({ chatId: 'oc_chat1', pageSize: 50 });
+    expect(mockSkill.run).toHaveBeenCalledOnce();
+    const replayCtx = (mockSkill.run as ReturnType<typeof vi.fn>).mock.calls[0]![0] as SkillContext;
+    expect(replayCtx.event.type).toBe('message');
+    if (replayCtx.event.type === 'message') {
+      expect(replayCtx.event.payload.text).toBe('PPT 这期要直接生成飞书幻灯片吗？');
+    }
+    expect(runtime.sendCard).toHaveBeenCalledOnce();
   });
 });

--- a/packages/bot/src/bitable-client.ts
+++ b/packages/bot/src/bitable-client.ts
@@ -281,6 +281,31 @@ export class LarkBitableClient implements BitableClient {
       return err(makeError(ErrorCode.FEISHU_API_ERROR, 'link failed', e));
     }
   }
+
+  async readTable(appToken: string, tableId: string, maxRows = 50): Promise<Result<string>> {
+    try {
+      const res = await this.call(() =>
+        this.larkClient.bitable.appTableRecord.list({
+          path: { app_token: appToken, table_id: tableId },
+          params: { page_size: Math.min(maxRows, 100) },
+        }),
+      );
+      if (!res.data?.items?.length) {
+        return ok('（多维表格暂无记录）');
+      }
+      const rows = res.data.items;
+      const allKeys = [...new Set(rows.flatMap((r) => Object.keys(r.fields as object)))];
+      const header = allKeys.join(' | ');
+      const lines = rows.map((r) => {
+        const fields = r.fields as Record<string, unknown>;
+        return allKeys.map((k) => String(fields[k] ?? '')).join(' | ');
+      });
+      return ok([header, ...lines].join('\n'));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `readTable error: ${msg}`, e));
+    }
+  }
 }
 
 // ---------- 工厂函数（从环境变量读取配置）----------

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -2,6 +2,7 @@ import * as lark from '@larksuiteoapi/node-sdk';
 import {
   type BotRuntime,
   type BotEvent,
+  type CardAction,
   type EventHandler,
   type SendTextParams,
   type SendCardParams,
@@ -125,7 +126,9 @@ function parseMessage(data: Record<string, unknown>): Message {
     chatType: (msg.chat_type as string | undefined) === 'p2p' ? 'p2p' : 'group',
     sender: {
       userId: (senderId.open_id as string | undefined) ?? '',
-      ...((senderId.union_id as string | undefined) !== undefined && { unionId: senderId.union_id as string }),
+      ...((senderId.union_id as string | undefined) !== undefined && {
+        unionId: senderId.union_id as string,
+      }),
     },
     contentType: parseMsgType(msgType),
     text,
@@ -133,6 +136,38 @@ function parseMessage(data: Record<string, unknown>): Message {
     mentions,
     ...(replyTo !== undefined && { replyTo }),
     timestamp: Number(tsRaw),
+  };
+}
+
+function parseCardAction(data: Record<string, unknown>): CardAction {
+  const context = (data.context ?? {}) as Record<string, unknown>;
+  const action = (data.action ?? {}) as Record<string, unknown>;
+  const operator = (data.operator ?? {}) as Record<string, unknown>;
+  const value = (action.value ?? {}) as Record<string, unknown>;
+  const formValue = data.form_value as Record<string, unknown> | undefined;
+
+  return {
+    chatId:
+      (context.open_chat_id as string | undefined) ??
+      (data.open_chat_id as string | undefined) ??
+      (data.chat_id as string | undefined) ??
+      '',
+    messageId:
+      (context.open_message_id as string | undefined) ??
+      (data.open_message_id as string | undefined) ??
+      (data.message_id as string | undefined) ??
+      '',
+    user: {
+      userId:
+        (operator.open_id as string | undefined) ?? (data.open_id as string | undefined) ?? '',
+      ...((operator.union_id as string | undefined) !== undefined && {
+        unionId: operator.union_id as string,
+      }),
+      ...((operator.name as string | undefined) !== undefined && { name: operator.name as string }),
+    },
+    value,
+    ...(formValue !== undefined && { formValue }),
+    timestamp: Date.now(),
   };
 }
 
@@ -146,13 +181,15 @@ export class LarkBotRuntime implements BotRuntime {
   /** patchCard 节流：messageId → 上次 patch 完成的时间 */
   private readonly patchTimes = new Map<string, number>();
 
-  constructor(private readonly env: {
-    appId: string;
-    appSecret: string;
-    verificationToken?: string;
-    encryptKey?: string;
-    logLevel?: lark.LoggerLevel;
-  }) {
+  constructor(
+    private readonly env: {
+      appId: string;
+      appSecret: string;
+      verificationToken?: string;
+      encryptKey?: string;
+      logLevel?: lark.LoggerLevel;
+    },
+  ) {
     this.client = new lark.Client({
       appId: env.appId,
       appSecret: env.appSecret,
@@ -166,7 +203,9 @@ export class LarkBotRuntime implements BotRuntime {
 
   on(handler: EventHandler): () => void {
     this.handlers.add(handler);
-    return () => { this.handlers.delete(handler); };
+    return () => {
+      this.handlers.delete(handler);
+    };
   }
 
   private emit(event: BotEvent): void {
@@ -198,14 +237,16 @@ export class LarkBotRuntime implements BotRuntime {
               chatId: (d.chat_id as string | undefined) ?? '',
               inviter: {
                 userId: (operatorId.open_id as string | undefined) ?? '',
-                ...((operatorId.union_id as string | undefined) !== undefined && { unionId: operatorId.union_id as string }),
+                ...((operatorId.union_id as string | undefined) !== undefined && {
+                  unionId: operatorId.union_id as string,
+                }),
               },
               timestamp: Date.now(),
             },
           });
           return { code: 0 };
         },
-        'p2p_chat_create': async (data) => {
+        p2p_chat_create: async (data) => {
           const d = data as unknown as Record<string, unknown>;
           const userId = (d.open_id as string | undefined) ?? '';
           this.emit({
@@ -217,6 +258,11 @@ export class LarkBotRuntime implements BotRuntime {
             },
           });
           return { code: 0 };
+        },
+        'card.action.trigger': async (data: unknown) => {
+          const action = parseCardAction(data as unknown as Record<string, unknown>);
+          this.emit({ type: 'cardAction', payload: action });
+          return undefined;
         },
       });
 
@@ -264,7 +310,7 @@ export class LarkBotRuntime implements BotRuntime {
   async sendCard(params: SendCardParams): Promise<Result<SentMessage>> {
     await this.limiter.acquire();
     try {
-      const content = JSON.stringify(params.card);
+      const content = JSON.stringify(params.card.content);
       const res = params.replyTo
         ? await this.client.im.message.reply({
             path: { message_id: params.replyTo },
@@ -299,7 +345,7 @@ export class LarkBotRuntime implements BotRuntime {
     try {
       const res = await this.client.im.message.patch({
         path: { message_id: params.messageId },
-        data: { content: JSON.stringify(params.card) },
+        data: { content: JSON.stringify(params.card.content) },
       });
 
       this.patchTimes.set(params.messageId, Date.now());
@@ -317,17 +363,19 @@ export class LarkBotRuntime implements BotRuntime {
   async fetchHistory(params: FetchHistoryParams): Promise<Result<FetchHistoryResult>> {
     await this.limiter.acquire();
     try {
-      const res = await (this.client.im.message as unknown as {
-        list: (p: unknown) => Promise<{
-          code?: number;
-          msg?: string;
-          data?: {
-            has_more?: boolean;
-            page_token?: string;
-            items?: Array<Record<string, unknown>>;
-          };
-        }>;
-      }).list({
+      const res = await (
+        this.client.im.message as unknown as {
+          list: (p: unknown) => Promise<{
+            code?: number;
+            msg?: string;
+            data?: {
+              has_more?: boolean;
+              page_token?: string;
+              items?: Array<Record<string, unknown>>;
+            };
+          }>;
+        }
+      ).list({
         params: {
           container_id: params.chatId,
           container_id_type: 'chat',
@@ -353,7 +401,7 @@ export class LarkBotRuntime implements BotRuntime {
             message_id: item.message_id,
             chat_id: item.chat_id,
             chat_type: item.chat_type,
-            message_type: (item.message_type ?? item.msg_type),
+            message_type: item.message_type ?? item.msg_type,
             content: item.body ? (item.body as Record<string, unknown>).content : item.content,
             create_time: item.create_time,
             mentions: item.mentions ?? [],
@@ -401,6 +449,7 @@ export function createBotRuntime(): LarkBotRuntime {
     appSecret,
     verificationToken: process.env['LARK_VERIFICATION_TOKEN'] ?? '',
     encryptKey: process.env['LARK_ENCRYPT_KEY'] ?? '',
-    logLevel: logLevelMap[(process.env['LARK_LOG_LEVEL'] ?? 'info').toLowerCase()] ?? lark.LoggerLevel.info,
+    logLevel:
+      logLevelMap[(process.env['LARK_LOG_LEVEL'] ?? 'info').toLowerCase()] ?? lark.LoggerLevel.info,
   });
 }

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -91,19 +91,41 @@ function btn(
 function renderSources(sources: readonly CardSource[]): string {
   if (sources.length === 0) return '';
   const kindMap: Record<CardSource['kind'], string> = {
+    doc: '📄 文档',
     wiki: '📄 Wiki',
+    slides: '🖼 幻灯片',
     bitable: '📊 表格',
     chat: '💬 群聊',
     minutes: '🎙 妙记',
     web: '🌐 网页',
     other: '📎 其他',
   };
+
+  const timeFormat = new Intl.DateTimeFormat('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
   return `**来源**\n${sources
-    .map(
-      (s) =>
-        `- ${kindMap[s.kind]} ${s.url ? `[${s.title}](${s.url})` : s.title}${s.snippet ? `：${s.snippet}` : ''}`,
-    )
-    .join('\n')}`;
+    .map((s, i) => {
+      const author = s.authorName ? s.authorName : '';
+      const time = s.timestamp ? timeFormat.format(new Date(s.timestamp)) : '';
+      const byline = [author, time].filter(Boolean).join(' · ');
+
+      if (s.kind === 'chat') {
+        // Format: "1. 💬 author · time — snippet" all on one line
+        const label = s.url ? `[${s.title}](${s.url})` : s.title;
+        const who = byline || label;
+        const snippet = s.snippet ? s.snippet : label;
+        return `${i + 1}. ${kindMap[s.kind]} **${who}** — ${snippet}`;
+      }
+
+      const title = s.url ? `[${s.title}](${s.url})` : s.title;
+      const heading = `${i + 1}. ${kindMap[s.kind]} ${title}${byline ? `｜${byline}` : ''}`;
+      return s.snippet ? `${heading}\n   ${s.snippet}` : heading;
+    })
+    .join('\n\n')}`;
 }
 
 function renderButtons(btns: readonly CardButton[]): ButtonElement[] {

--- a/packages/bot/src/docx-client.ts
+++ b/packages/bot/src/docx-client.ts
@@ -91,7 +91,9 @@ export class LarkDocxClient implements DocxClient {
       });
 
       if (res.code !== 0) {
-        return err(makeError(ErrorCode.FEISHU_API_ERROR, `set share permission failed: ${res.msg}`));
+        return err(
+          makeError(ErrorCode.FEISHU_API_ERROR, `set share permission failed: ${res.msg}`),
+        );
       }
 
       return ok(`https://feishu.cn/docx/${docToken}`);
@@ -99,6 +101,109 @@ export class LarkDocxClient implements DocxClient {
       const msg = e instanceof Error ? e.message : String(e);
       return err(makeError(ErrorCode.FEISHU_API_ERROR, `get share link error: ${msg}`));
     }
+  }
+
+  private async readDocxRawContent(token: string): Promise<Result<string>> {
+    try {
+      const res = await (
+        this.client.docx.v1.document as unknown as {
+          rawContent: (
+            p: unknown,
+          ) => Promise<{ code?: number; msg?: string; data?: { content?: string } }>;
+        }
+      ).rawContent({
+        path: { document_id: token },
+        params: { lang: 0 },
+      });
+      if (res.code !== 0) {
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, `readContent failed: ${res.msg}`));
+      }
+      return ok(res.data?.content ?? '');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `readContent error: ${msg}`, e));
+    }
+  }
+
+  private async resolveWikiNode(token: string): Promise<
+    Result<{
+      objToken: string;
+      objType: 'doc' | 'docx' | 'sheet' | 'mindnote' | 'bitable' | 'file' | 'slides';
+      title?: string;
+    }>
+  > {
+    try {
+      const res = await this.client.wiki.v2.space.getNode({
+        params: { token, obj_type: 'wiki' },
+      });
+      if (res.code !== 0) {
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, `resolve wiki failed: ${res.msg}`));
+      }
+      const node = res.data?.node;
+      if (!node?.obj_token || !node.obj_type) {
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, 'resolve wiki failed: empty node'));
+      }
+      return ok({
+        objToken: node.obj_token,
+        objType: node.obj_type,
+        ...(node.title ? { title: node.title } : {}),
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `resolve wiki error: ${msg}`, e));
+    }
+  }
+
+  private async readDriveTitle(
+    token: string,
+    kind: 'doc' | 'docx' | 'wiki' | 'slides',
+  ): Promise<Result<string>> {
+    try {
+      const res = await this.client.drive.v1.meta.batchQuery({
+        data: {
+          request_docs: [{ doc_token: token, doc_type: kind }],
+          with_url: true,
+        },
+      });
+      if (res.code !== 0) {
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, `read meta failed: ${res.msg}`));
+      }
+      const title = res.data?.metas?.[0]?.title;
+      return ok(title ? `标题：${title}` : '');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `read meta error: ${msg}`, e));
+    }
+  }
+
+  async readContent(
+    token: string,
+    kind: 'doc' | 'wiki' | 'slides' = 'doc',
+  ): Promise<Result<string>> {
+    if (kind === 'wiki') {
+      const node = await this.resolveWikiNode(token);
+      if (!node.ok) return node;
+      if (node.value.objType === 'doc' || node.value.objType === 'docx') {
+        const raw = await this.readDocxRawContent(node.value.objToken);
+        if (!raw.ok) return raw;
+        const title = node.value.title ? `标题：${node.value.title}\n` : '';
+        return ok(`${title}${raw.value}`);
+      }
+      if (node.value.objType === 'slides') {
+        const title = node.value.title ? `标题：${node.value.title}` : '';
+        if (title) return ok(title);
+        return this.readDriveTitle(node.value.objToken, 'slides');
+      }
+      return ok(node.value.title ? `标题：${node.value.title}` : '');
+    }
+
+    if (kind === 'slides') {
+      const title = await this.readDriveTitle(token, 'slides');
+      if (title.ok && title.value.trim()) return title;
+      return this.readDocxRawContent(token);
+    }
+
+    return this.readDocxRawContent(token);
   }
 
   async createFromMarkdown(title: string, markdown: string): Promise<Result<DocRef>> {

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -2,31 +2,33 @@ import type { Logger, SkillContext } from '@seedhac/contracts';
 import { skillsByName } from '@seedhac/skills';
 import { createBotRuntime } from './bot-runtime.js';
 import { LarkBitableClient } from './bitable-client.js';
+import { larkCardBuilder } from './card-builder.js';
+import { createDocxClient } from './docx-client.js';
 import { VolcanoLLMClient } from './llm-client.js';
 import { SkillRouter } from './skill-router.js';
 import { handleEvent } from './wiring.js';
 
 const logger: Logger = {
   debug: (msg, meta) => console.debug(`[bot] ${msg}`, meta ?? ''),
-  info:  (msg, meta) => console.info(`[bot] ${msg}`, meta ?? ''),
-  warn:  (msg, meta) => console.warn(`[bot] ${msg}`, meta ?? ''),
+  info: (msg, meta) => console.info(`[bot] ${msg}`, meta ?? ''),
+  warn: (msg, meta) => console.warn(`[bot] ${msg}`, meta ?? ''),
   error: (msg, meta) => console.error(`[bot] ${msg}`, meta ?? ''),
 };
 
 function buildDeps() {
-  const appId     = process.env['LARK_APP_ID'];
+  const appId = process.env['LARK_APP_ID'];
   const appSecret = process.env['LARK_APP_SECRET'];
-  if (!appId)     throw new Error('Missing env var: LARK_APP_ID');
+  if (!appId) throw new Error('Missing env var: LARK_APP_ID');
   if (!appSecret) throw new Error('Missing env var: LARK_APP_SECRET');
 
   const runtime = createBotRuntime();
-  const router  = new SkillRouter(process.env['LARK_BOT_OPEN_ID'] ?? '');
+  const router = new SkillRouter(process.env['LARK_BOT_OPEN_ID'] ?? '');
 
   const llm = new VolcanoLLMClient({
-    apiKey:   process.env['ARK_API_KEY'] ?? '',
+    apiKey: process.env['ARK_API_KEY'] ?? '',
     modelIds: {
       lite: process.env['ARK_MODEL_LITE'] ?? '',
-      pro:  process.env['ARK_MODEL_PRO']  ?? '',
+      pro: process.env['ARK_MODEL_PRO'] ?? '',
     },
   });
 
@@ -35,9 +37,9 @@ function buildDeps() {
     appSecret,
     appToken: process.env['BITABLE_APP_TOKEN'] ?? '',
     tableIds: {
-      memory:    process.env['BITABLE_TABLE_MEMORY']    ?? '',
-      decision:  process.env['BITABLE_TABLE_DECISION']  ?? '',
-      todo:      process.env['BITABLE_TABLE_TODO']      ?? '',
+      memory: process.env['BITABLE_TABLE_MEMORY'] ?? '',
+      decision: process.env['BITABLE_TABLE_DECISION'] ?? '',
+      todo: process.env['BITABLE_TABLE_TODO'] ?? '',
       knowledge: process.env['BITABLE_TABLE_KNOWLEDGE'] ?? '',
     },
   });
@@ -54,7 +56,16 @@ async function main(): Promise<void> {
     if (event.type === 'message') {
       const msg = event.payload;
       const intent = router.route(msg);
-      logger.info(`message received: text="${msg.text}" mentions=${JSON.stringify(msg.mentions.map(m => m.user.userId))} → intent=${intent}`);
+      logger.info(
+        `message received: text="${msg.text}" mentions=${JSON.stringify(msg.mentions.map((m) => m.user.userId))} → intent=${intent}`,
+      );
+    }
+    if (event.type === 'cardAction') {
+      logger.info('card action received', {
+        chatId: event.payload.chatId,
+        messageId: event.payload.messageId,
+        value: event.payload.value,
+      });
     }
 
     const ctx: SkillContext = {
@@ -64,6 +75,8 @@ async function main(): Promise<void> {
       bitable,
       retrievers: {},
       logger,
+      docx: createDocxClient(),
+      cardBuilder: larkCardBuilder,
     };
     await handleEvent(ctx, router, skillsByName);
   });
@@ -81,7 +94,7 @@ async function main(): Promise<void> {
     void runtime.stop();
     process.exit(0);
   };
-  process.on('SIGINT',  () => shutdown('SIGINT'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
   process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -1,4 +1,3 @@
-import * as lark from '@larksuiteoapi/node-sdk';
 import type { Logger, SkillContext } from '@seedhac/contracts';
 import { skillsByName } from '@seedhac/skills';
 import { createBotRuntime } from './bot-runtime.js';
@@ -45,8 +44,7 @@ function buildDeps() {
     },
   });
 
-  const larkClient = new lark.Client({ appId, appSecret });
-  const docx = new LarkDocxClient(larkClient);
+  const docx = createDocxClient();
 
   return { runtime, router, llm, bitable, docx };
 }
@@ -80,7 +78,6 @@ async function main(): Promise<void> {
       docx,
       retrievers: {},
       logger,
-      docx: createDocxClient(),
       cardBuilder: larkCardBuilder,
     };
     await handleEvent(ctx, router, skillsByName);

--- a/packages/bot/src/skill-router.ts
+++ b/packages/bot/src/skill-router.ts
@@ -132,6 +132,7 @@ export class SkillRouter {
   constructor(private readonly botOpenId: string) {}
 
   private mentionsBot(msg: Message): boolean {
+    if (!this.botOpenId) return false;
     return msg.mentions.some((m) => m.user.userId === this.botOpenId);
   }
 

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -1,4 +1,5 @@
 import type { Skill, SkillContext, SkillName } from '@seedhac/contracts';
+import type { Message } from '@seedhac/contracts';
 import type { RouteIntent } from './skill-router.js';
 import type { SkillRouter } from './skill-router.js';
 
@@ -14,13 +15,17 @@ export async function handleEvent(
   skills: Readonly<Partial<Record<SkillName, Skill>>>,
 ): Promise<void> {
   const { event, logger, runtime } = ctx;
+  if (event.type === 'cardAction') {
+    await handleCardAction(ctx, skills);
+    return;
+  }
   if (event.type !== 'message') return;
   const intent = router.route(event.payload);
   const skillName = intentToSkill[intent];
   if (!skillName) return;
   const skill = skills[skillName];
   if (!skill) return;
-  if (!await skill.match(ctx)) return;
+  if (!(await skill.match(ctx))) return;
   const result = await skill.run(ctx);
   if (!result.ok) {
     logger.error('skill failed', { code: result.error.code, message: result.error.message });
@@ -30,4 +35,57 @@ export async function handleEvent(
   if (card) await runtime.sendCard({ chatId: event.payload.chatId, card });
   if (text) await runtime.sendText({ chatId: event.payload.chatId, text });
   logger.info(`skill=${skillName} replied to chat=${event.payload.chatId}`);
+}
+
+async function handleCardAction(
+  ctx: SkillContext,
+  skills: Readonly<Partial<Record<SkillName, Skill>>>,
+): Promise<void> {
+  const { event, logger, runtime } = ctx;
+  if (event.type !== 'cardAction') return;
+  const action = event.payload.value['action'];
+  if (action !== 'qa.reanswer') return;
+
+  const chatId = String(event.payload.value['chatId'] ?? event.payload.chatId);
+  const questionMessageId = String(event.payload.value['questionMessageId'] ?? '');
+  if (!chatId || !questionMessageId) {
+    logger.warn('qa.reanswer missing chatId or questionMessageId', { chatId, questionMessageId });
+    return;
+  }
+
+  const qa = skills.qa;
+  if (!qa) return;
+
+  const historyResult = await runtime.fetchHistory({ chatId, pageSize: 50 });
+  if (!historyResult.ok) {
+    logger.error('qa.reanswer history fetch failed', {
+      code: historyResult.error.code,
+      message: historyResult.error.message,
+    });
+    return;
+  }
+
+  const question = historyResult.value.messages.find((m) => m.messageId === questionMessageId);
+  if (!question) {
+    await runtime.sendText({ chatId, text: '找不到原问题了，可以重新 @ 我问一次。' });
+    return;
+  }
+
+  const replayCtx: SkillContext = {
+    ...ctx,
+    event: { type: 'message', payload: question as Message },
+  };
+  const result = await qa.run(replayCtx);
+  if (!result.ok) {
+    logger.error('qa.reanswer skill failed', {
+      code: result.error.code,
+      message: result.error.message,
+    });
+    return;
+  }
+
+  const { card, text } = result.value;
+  if (card) await runtime.sendCard({ chatId, card });
+  if (text) await runtime.sendText({ chatId, text });
+  logger.info(`skill=qa reanswered chat=${chatId}`);
 }

--- a/packages/contracts/src/bitable.ts
+++ b/packages/contracts/src/bitable.ts
@@ -77,4 +77,6 @@ export interface BitableClient {
   update(params: UpdateParams): Promise<Result<void>>;
   delete(params: DeleteParams): Promise<Result<void>>;
   link(params: LinkParams): Promise<Result<void>>;
+  /** 读取任意多维表格的记录，返回可供 LLM 消费的纯文本摘要 */
+  readTable(appToken: string, tableId: string, maxRows?: number): Promise<Result<string>>;
 }

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -32,9 +32,12 @@ export type CardTemplateName =
 export interface CardSource {
   readonly title: string;
   readonly url?: string;
-  /** 来源类型：飞书 Wiki / Bitable / 群历史消息 / 妙记 / Web ... */
-  readonly kind: 'wiki' | 'bitable' | 'chat' | 'minutes' | 'web' | 'other';
+  /** 来源类型：飞书文档 / Wiki / Bitable / 群历史消息 / 妙记 / Web ... */
+  readonly kind: 'doc' | 'wiki' | 'slides' | 'bitable' | 'chat' | 'minutes' | 'web' | 'other';
   readonly snippet?: string;
+  readonly authorName?: string;
+  readonly timestamp?: number;
+  readonly messageId?: string;
 }
 
 export interface CardButton {

--- a/packages/contracts/src/docx.ts
+++ b/packages/contracts/src/docx.ts
@@ -17,4 +17,6 @@ export interface DocxClient {
   getShareLink(docToken: string): Promise<Result<string>>;
   /** 解析 markdown，调 create + appendBlocks，一步完成 */
   createFromMarkdown(title: string, markdown: string): Promise<Result<DocRef>>;
+  /** 读取文档 / wiki / 幻灯片的纯文本内容 */
+  readContent(token: string, kind?: 'doc' | 'wiki' | 'slides'): Promise<Result<string>>;
 }

--- a/packages/contracts/src/skill.ts
+++ b/packages/contracts/src/skill.ts
@@ -11,7 +11,7 @@
 
 import type { BitableClient } from './bitable.js';
 import type { BotRuntime } from './bot-runtime.js';
-import type { Card } from './card.js';
+import type { Card, CardBuilder } from './card.js';
 import type { LLMClient } from './llm.js';
 import type { BotEvent } from './message.js';
 import type { Retriever } from './retriever.js';
@@ -26,8 +26,8 @@ export type SkillName =
   | 'slides'
   | 'archive'
   | 'weekly'
-  | 'requirementDoc'  // 被动监听需求描述 → 生成结构化飞书文档
-  | 'docIterate';     // 持续监听对话 → 增量更新已有需求文档
+  | 'requirementDoc' // 被动监听需求描述 → 生成结构化飞书文档
+  | 'docIterate'; // 持续监听对话 → 增量更新已有需求文档
 
 /** 触发条件描述（声明式，便于在 docs / debug UI 上展示） */
 export interface TriggerSpec {
@@ -61,6 +61,7 @@ export interface SkillContext {
   readonly retrievers: Readonly<Record<string, Retriever>>;
   readonly logger: Logger;
   readonly docx: DocxClient;
+  readonly cardBuilder: CardBuilder;
 }
 
 /** Skill 副作用：写 Bitable / 调外部 webhook / 触发其他 skill 等 */

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -12,14 +12,20 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run src",
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
     "@seedhac/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/skills/src/__tests__/qa.test.ts
+++ b/packages/skills/src/__tests__/qa.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { qaSkill } from '../qa.js';
+import { err, ErrorCode, makeError, ok } from '@seedhac/contracts';
+import type {
+  BotEvent,
+  BotRuntime,
+  Card,
+  CardBuilder,
+  LLMClient,
+  Message,
+  Retriever,
+  SkillContext,
+} from '@seedhac/contracts';
+
+const BOT_ID = 'ou_bot_qa';
+const MOCK_CARD: Card = { templateName: 'qa', content: { mock: true } };
+
+function makeMessage(text: string, overrides: Partial<Message> = {}): Message {
+  return {
+    messageId: 'msg_001',
+    chatId: 'oc_chat_001',
+    chatType: 'group',
+    sender: { userId: 'ou_user_001', name: '张三' },
+    contentType: 'text',
+    text,
+    rawContent: text,
+    mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }],
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeEvent(text: string, overrides?: Partial<Message>): BotEvent {
+  return { type: 'message', payload: makeMessage(text, overrides) };
+}
+
+function makeRuntime(messages?: readonly Message[]): BotRuntime {
+  return {
+    on: vi.fn(),
+    start: vi.fn().mockResolvedValue(ok(undefined)),
+    stop: vi.fn().mockResolvedValue(undefined),
+    sendText: vi
+      .fn()
+      .mockResolvedValue(ok({ messageId: 'r1', chatId: 'oc_chat_001', timestamp: 0 })),
+    sendCard: vi
+      .fn()
+      .mockResolvedValue(ok({ messageId: 'r2', chatId: 'oc_chat_001', timestamp: 0 })),
+    patchCard: vi.fn().mockResolvedValue(ok(undefined)),
+    fetchHistory: vi.fn().mockResolvedValue(
+      ok({
+        messages: messages ?? [
+          makeMessage('谁负责接口联调？', { messageId: 'msg_001' }),
+          makeMessage('王五负责接口联调', {
+            messageId: 'msg_002',
+            sender: { userId: 'ou_user_002' },
+          }),
+          makeMessage('本周五前完成验收', { messageId: 'msg_003' }),
+        ],
+        hasMore: false,
+      }),
+    ),
+  } as unknown as BotRuntime;
+}
+
+function makeLLM(answer = '王五负责接口联调，本周五前完成验收。\nSOURCES: 1,2'): LLMClient {
+  return {
+    ask: vi.fn().mockResolvedValue(ok(answer)),
+    chat: vi.fn(),
+    askStructured: vi.fn(),
+  } as unknown as LLMClient;
+}
+
+function makeCardBuilder(): CardBuilder {
+  return { build: vi.fn().mockReturnValue(MOCK_CARD) };
+}
+
+function makeRetriever(): Retriever {
+  return {
+    source: 'chat',
+    retrieve: vi.fn().mockResolvedValue(
+      ok([
+        {
+          source: 'chat',
+          id: 'msg_002',
+          title: '群聊历史',
+          snippet: '王五负责接口联调，本周五前完成验收',
+          score: 0.9,
+          timestamp: 1_700_000_001_000,
+          meta: { authorName: '王五' },
+        },
+        {
+          source: 'chat',
+          id: 'msg_003',
+          title: '群聊历史',
+          snippet: '李四负责前端页面接入',
+          score: 0.8,
+          timestamp: 1_700_000_002_000,
+          meta: { authorName: '李四' },
+        },
+      ]),
+    ),
+  };
+}
+
+function makeCtx(event: BotEvent, overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    event,
+    runtime: makeRuntime(),
+    llm: makeLLM(),
+    bitable: {
+      find: vi.fn(),
+      insert: vi.fn(),
+      batchInsert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      link: vi.fn(),
+      readTable: vi.fn().mockResolvedValue(ok('')),
+    } as unknown as SkillContext['bitable'],
+    docx: {
+      create: vi.fn(),
+      appendBlocks: vi.fn(),
+      getShareLink: vi.fn(),
+      createFromMarkdown: vi.fn(),
+      readContent: vi.fn().mockResolvedValue(ok('')),
+    } as unknown as SkillContext['docx'],
+    cardBuilder: makeCardBuilder(),
+    retrievers: {},
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe('qaSkill.match()', () => {
+  beforeEach(() => {
+    process.env['LARK_BOT_OPEN_ID'] = BOT_ID;
+  });
+
+  it('returns true for @bot + question intent', () => {
+    expect(qaSkill.match(makeCtx(makeEvent('这个功能怎么用？')))).toBe(true);
+  });
+
+  it('returns false without @mention', () => {
+    const ctx = makeCtx(makeEvent('这个功能怎么用？', { mentions: [] }));
+    expect(qaSkill.match(ctx)).toBe(false);
+  });
+
+  it('returns false for @bot without question intent', () => {
+    expect(qaSkill.match(makeCtx(makeEvent('大家好')))).toBe(false);
+  });
+
+  it('returns false for non-message events', () => {
+    const ctx = makeCtx({
+      type: 'botJoinedChat',
+      payload: { chatId: 'c1', inviter: { userId: 'u1' }, timestamp: 0 },
+    });
+    expect(qaSkill.match(ctx)).toBe(false);
+  });
+});
+
+describe('qaSkill.run()', () => {
+  beforeEach(() => {
+    process.env['LARK_BOT_OPEN_ID'] = BOT_ID;
+  });
+
+  it('uses retriever and LLM to return a qa card', async () => {
+    const retriever = makeRetriever();
+    const ctx = makeCtx(makeEvent('谁负责接口联调？'), {
+      retrievers: { chat: retriever },
+    });
+
+    const result = await qaSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.card?.templateName).toBe('qa');
+      expect(result.value.text).toBeUndefined();
+    }
+    expect(retriever.retrieve).toHaveBeenCalledWith({
+      query: '谁负责接口联调？',
+      chatId: 'oc_chat_001',
+      topK: 5,
+    });
+    expect(ctx.runtime.fetchHistory).toHaveBeenCalledWith({ chatId: 'oc_chat_001', pageSize: 30 });
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith('qa', {
+      question: '谁负责接口联调？',
+      answer: '王五负责接口联调，本周五前完成验收。',
+      sources: [
+        expect.objectContaining({
+          kind: 'chat',
+          title: '群聊历史',
+          snippet: '王五负责接口联调，本周五前完成验收',
+          authorName: '王五',
+          timestamp: 1_700_000_001_000,
+          messageId: 'msg_002',
+        }),
+        expect.objectContaining({
+          kind: 'chat',
+          title: '群聊历史',
+          snippet: '李四负责前端页面接入',
+          authorName: '李四',
+          timestamp: 1_700_000_002_000,
+          messageId: 'msg_003',
+        }),
+      ],
+      buttons: [
+        expect.objectContaining({
+          text: '重新回答',
+          value: {
+            action: 'qa.reanswer',
+            questionMessageId: 'msg_001',
+            chatId: 'oc_chat_001',
+          },
+        }),
+      ],
+    });
+  });
+
+  it('falls back to fetchHistory when no retriever is injected', async () => {
+    const ctx = makeCtx(makeEvent('谁负责接口联调？'));
+
+    const result = await qaSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.runtime.fetchHistory).toHaveBeenCalledWith({ chatId: 'oc_chat_001', pageSize: 30 });
+    expect(ctx.llm.ask).toHaveBeenCalledWith(expect.stringContaining('王五负责接口联调'), {
+      model: 'pro',
+    });
+    expect(ctx.llm.ask).not.toHaveBeenCalledWith(expect.stringContaining('ou_user_002'), {
+      model: 'pro',
+    });
+    expect(ctx.llm.ask).not.toHaveBeenCalledWith(
+      expect.stringContaining('谁负责接口联调？\n王五'),
+      {
+        model: 'pro',
+      },
+    );
+    expect(ctx.llm.ask).not.toHaveBeenCalledWith(
+      expect.stringContaining('张三: 谁负责接口联调？'),
+      {
+        model: 'pro',
+      },
+    );
+  });
+
+  it('reads linked Feishu docs and bitables from recent history as QA context', async () => {
+    const docUrl = 'https://bytedance.larkoffice.com/wiki/doccnabc123456';
+    const bitableUrl =
+      'https://bytedance.larkoffice.com/base/appabc123456?view=vew1&table=tblxyz987';
+    const history = [
+      makeMessage(`需求文档在这里：${docUrl}`, {
+        messageId: 'doc_share',
+        sender: { userId: 'ou_user_002', name: '王五' },
+      }),
+      makeMessage(`分工表在这里：${bitableUrl}`, {
+        messageId: 'table_share',
+        sender: { userId: 'ou_user_003', name: '李四' },
+      }),
+    ];
+    const ctx = makeCtx(makeEvent('验收标准和接口联调负责人是什么？'), {
+      runtime: makeRuntime(history),
+      llm: makeLLM('验收标准是 5 月 6 日前完成自测；接口联调负责人是王五。\nSOURCES: 1,2'),
+    });
+    vi.mocked(ctx.docx.readContent).mockResolvedValue(ok('验收标准：5 月 6 日前完成自测。'));
+    vi.mocked(ctx.bitable.readTable).mockResolvedValue(ok('负责人 | 任务\n王五 | 接口联调'));
+
+    const result = await qaSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.docx.readContent).toHaveBeenCalledWith('doccnabc123456', 'wiki');
+    expect(ctx.bitable.readTable).toHaveBeenCalledWith('appabc123456', 'tblxyz987', 50);
+    expect(ctx.llm.ask).toHaveBeenCalledWith(
+      expect.stringContaining('验收标准：5 月 6 日前完成自测'),
+      {
+        model: 'pro',
+      },
+    );
+    expect(ctx.llm.ask).toHaveBeenCalledWith(expect.stringContaining('王五 | 接口联调'), {
+      model: 'pro',
+    });
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'qa',
+      expect.objectContaining({
+        sources: [
+          expect.objectContaining({
+            kind: 'wiki',
+            title: expect.stringContaining('飞书 Wiki'),
+            url: docUrl,
+            snippet: expect.stringContaining('验收标准'),
+          }),
+          expect.objectContaining({
+            kind: 'bitable',
+            title: '多维表格 tblxyz987',
+            url: bitableUrl,
+            snippet: expect.stringContaining('王五 | 接口联调'),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('returns text instead of card when LLM reports insufficient context', async () => {
+    const ctx = makeCtx(makeEvent('这个指标在哪里？'), {
+      llm: makeLLM('INSUFFICIENT_CONTEXT'),
+    });
+
+    const result = await qaSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.text).toBe('暂时找不到相关记录，建议直接在群里问一下。');
+      expect(result.value.card).toBeUndefined();
+    }
+    expect(ctx.cardBuilder.build).not.toHaveBeenCalled();
+  });
+
+  it('returns err when LLM times out', async () => {
+    const ctx = makeCtx(makeEvent('谁负责接口联调？'), {
+      llm: {
+        ask: vi.fn().mockResolvedValue(err(makeError(ErrorCode.LLM_TIMEOUT, 'llm timed out'))),
+        chat: vi.fn(),
+        askStructured: vi.fn(),
+      } as unknown as LLMClient,
+    });
+
+    const result = await qaSkill.run(ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(ErrorCode.LLM_TIMEOUT);
+    expect(ctx.cardBuilder.build).not.toHaveBeenCalled();
+  });
+});

--- a/packages/skills/src/prompts/qa.ts
+++ b/packages/skills/src/prompts/qa.ts
@@ -1,0 +1,13 @@
+export const QA_PROMPT = (question: string, context: readonly string[]): string => {
+  const items = context.slice(0, 10);
+  const numbered = items.map((c, i) => `[${i + 1}] ${c}`).join('\n');
+  return `你是一个项目协作助手，熟悉团队的历史讨论。根据以下上下文回答问题。
+如果上下文不足以回答，输出"INSUFFICIENT_CONTEXT"（不要解释）。
+回答简洁，2-4句话即可。回答结尾另起一行，输出你实际引用的来源编号：
+SOURCES: 1,3（逗号分隔；未引用任何来源则输出 SOURCES: none）
+
+上下文：
+${numbered}
+
+问题：${question}`;
+};

--- a/packages/skills/src/qa.ts
+++ b/packages/skills/src/qa.ts
@@ -5,25 +5,415 @@
  * 数据流：群历史检索 / Wiki / Bitable → LLM 整合 → qa 卡片
  */
 
-import type { Message, Skill } from '@seedhac/contracts';
+import type { CardSource, Message, Skill, SkillContext } from '@seedhac/contracts';
 import { ok } from '@seedhac/contracts';
+import { QA_PROMPT } from './prompts/qa.js';
+
+const QUESTION_PATTERN = /[?？]|是什么|怎么|为什么|如何|谁负责|哪个|哪些|能不能|可以吗|吗[？?]?/;
+
+interface ContextItem {
+  readonly kind: CardSource['kind'];
+  readonly text: string;
+  readonly title: string;
+  readonly url?: string;
+  readonly authorName?: string;
+  readonly timestamp?: number;
+  readonly messageId?: string;
+}
+
+function mentionsBot(msg: Message): boolean {
+  const botOpenId = process.env['LARK_BOT_OPEN_ID'];
+  if (!botOpenId) return false;
+  return msg.mentions.some((m) => m.user.userId === botOpenId);
+}
+
+/**
+ * Bigram overlap score between a message and the question (0–1).
+ * Works for Chinese without a tokenizer: every 2-char substring of the question
+ * is a "keyword"; we count how many appear in the message.
+ */
+function bigramScore(msgText: string, question: string): number {
+  if (question.length < 2) return 0;
+  const bigrams = new Set<string>();
+  for (let i = 0; i < question.length - 1; i++) {
+    bigrams.add(question.slice(i, i + 2));
+  }
+  let hits = 0;
+  for (const bg of bigrams) {
+    if (msgText.includes(bg)) hits++;
+  }
+  return hits / bigrams.size;
+}
+
+function historyContextItem(msg: Message): ContextItem {
+  const preview = msg.text.length > 40 ? `${msg.text.slice(0, 40)}…` : msg.text;
+  return {
+    kind: 'chat',
+    text: msg.text,
+    title: preview,
+    ...(msg.sender.name ? { authorName: msg.sender.name } : {}),
+    timestamp: msg.timestamp,
+    messageId: msg.messageId,
+  };
+}
+
+// ─── Feishu URL parsing ───────────────────────────────────────────────────────
+
+/** Matches docx / wiki / slide / bitable URLs from any Feishu/Lark tenant. */
+const FEISHU_DOC_RE =
+  /https?:\/\/[^/\s)\]]*(?:feishu\.cn|lark\.cn|larkoffice\.com)\/(docx?|wiki|slides?)\/([A-Za-z0-9_-]{5,})/g;
+const FEISHU_BITABLE_RE =
+  /https?:\/\/[^/\s)\]]*(?:feishu\.cn|lark\.cn|larkoffice\.com)\/(?:base|bitable)\/([A-Za-z0-9_-]{5,})([^\s)\]]*)?/g;
+
+type ParsedUrl =
+  | { kind: 'doc'; token: string; url: string }
+  | { kind: 'wiki'; token: string; url: string }
+  | { kind: 'slides'; token: string; url: string }
+  | { kind: 'bitable'; appToken: string; tableId: string; url: string };
+
+function collectStrings(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) collectStrings(item, out);
+  }
+}
+
+function normalizeHaystack(value: string): string {
+  const slashUnescaped = value.replaceAll('\\/', '/');
+  try {
+    return `${slashUnescaped}\n${decodeURIComponent(slashUnescaped)}`;
+  } catch {
+    return slashUnescaped;
+  }
+}
+
+function messageHaystack(msg: Message): string {
+  const parts = [msg.text, msg.rawContent].filter((s) => s.length > 0);
+  if (msg.rawContent.length > 0) {
+    try {
+      const strings: string[] = [];
+      collectStrings(JSON.parse(msg.rawContent), strings);
+      parts.push(...strings);
+    } catch {
+      // rawContent is not always JSON; the original raw string above is enough.
+    }
+  }
+  return normalizeHaystack(parts.join('\n'));
+}
+
+function parseFeishuUrls(messages: readonly Message[]): ParsedUrl[] {
+  const seen = new Set<string>();
+  const results: ParsedUrl[] = [];
+
+  for (const msg of messages) {
+    const haystack = messageHaystack(msg);
+
+    let m: RegExpExecArray | null;
+    FEISHU_DOC_RE.lastIndex = 0;
+    while ((m = FEISHU_DOC_RE.exec(haystack)) !== null) {
+      const type = m[1] ?? '';
+      const token = m[2] ?? '';
+      if (!token || seen.has(token)) continue;
+      seen.add(token);
+      const kind: 'doc' | 'wiki' | 'slides' = type.startsWith('doc')
+        ? 'doc'
+        : type === 'wiki'
+          ? 'wiki'
+          : 'slides';
+      results.push({ kind, token, url: m[0] });
+    }
+
+    FEISHU_BITABLE_RE.lastIndex = 0;
+    while ((m = FEISHU_BITABLE_RE.exec(haystack)) !== null) {
+      const appToken = m[1] ?? '';
+      const suffix = m[2] ?? '';
+      const tableId = /[?&]table=([A-Za-z0-9_-]+)/.exec(suffix)?.[1] ?? '';
+      if (!appToken || seen.has(appToken) || !tableId) continue;
+      seen.add(appToken);
+      results.push({ kind: 'bitable', appToken, tableId, url: m[0] });
+    }
+  }
+
+  return results.slice(0, 5); // limit API calls
+}
+
+async function fetchLinkedContent(
+  messages: readonly Message[],
+  ctx: SkillContext,
+): Promise<ContextItem[]> {
+  const urls = parseFeishuUrls(messages);
+  ctx.logger.info('qa linked content scan', {
+    historyCount: messages.length,
+    urlCount: urls.length,
+    urls: urls.map((u) =>
+      u.kind === 'bitable'
+        ? { kind: u.kind, appToken: u.appToken, tableId: u.tableId }
+        : { kind: u.kind, token: u.token },
+    ),
+  });
+  if (urls.length === 0) {
+    ctx.logger.warn('qa found no Feishu URLs in recent history', {
+      samples: messages.slice(0, 5).map((m) => ({
+        type: m.contentType,
+        text: m.text.slice(0, 120),
+        rawContent: m.rawContent.slice(0, 200),
+      })),
+    });
+    return [];
+  }
+
+  const items: ContextItem[] = [];
+  for (const u of urls) {
+    if (u.kind === 'doc' || u.kind === 'wiki' || u.kind === 'slides') {
+      const res = await ctx.docx.readContent(u.token, u.kind);
+      if (!res.ok) {
+        ctx.logger.warn('qa linked doc read failed', {
+          kind: u.kind,
+          token: u.token,
+          code: res.error.code,
+          message: res.error.message,
+        });
+        continue;
+      }
+      if (!res.value.trim()) {
+        ctx.logger.warn('qa linked doc read returned empty content', {
+          kind: u.kind,
+          token: u.token,
+        });
+        continue;
+      }
+      ctx.logger.info('qa linked doc read ok', {
+        kind: u.kind,
+        token: u.token,
+        chars: res.value.length,
+      });
+      items.push({
+        kind: u.kind,
+        text: res.value.slice(0, 3000), // cap at 3k chars per doc
+        title:
+          u.kind === 'doc'
+            ? `飞书文档 ${u.token.slice(-6)}`
+            : u.kind === 'wiki'
+              ? `飞书 Wiki ${u.token.slice(-6)}`
+              : `飞书幻灯片 ${u.token.slice(-6)}`,
+        url: u.url,
+        messageId: u.token,
+      });
+    } else {
+      const res = await ctx.bitable.readTable(u.appToken, u.tableId, 50);
+      if (!res.ok) {
+        ctx.logger.warn('qa linked bitable read failed', {
+          appToken: u.appToken,
+          tableId: u.tableId,
+          code: res.error.code,
+          message: res.error.message,
+        });
+        continue;
+      }
+      if (!res.value.trim()) {
+        ctx.logger.warn('qa linked bitable read returned empty content', {
+          appToken: u.appToken,
+          tableId: u.tableId,
+        });
+        continue;
+      }
+      ctx.logger.info('qa linked bitable read ok', {
+        appToken: u.appToken,
+        tableId: u.tableId,
+        chars: res.value.length,
+      });
+      items.push({
+        kind: 'bitable',
+        text: res.value.slice(0, 3000),
+        title: `多维表格 ${u.tableId}`,
+        url: u.url,
+        messageId: u.appToken,
+      });
+    }
+  }
+  return items;
+}
 
 export const qaSkill: Skill = {
   name: 'qa',
   trigger: {
     events: ['message'],
     requireMention: true,
-    keywords: ['?', '？', '吗', '呢'],
+    keywords: ['?', '？', '是什么', '怎么', '为什么', '如何', '谁负责', '哪个', '能不能'],
     description: '@bot + 疑问句 → 检索群历史回答',
   },
   match: (ctx) => {
-    const msg = ctx.event.payload as Message;
-    return msg.mentions.some((m) => m.user.userId === process.env['LARK_BOT_OPEN_ID']);
+    if (ctx.event.type !== 'message') return false;
+    const msg = ctx.event.payload;
+    if (!mentionsBot(msg)) return false;
+    return QUESTION_PATTERN.test(msg.text);
   },
   run: async (ctx) => {
     const msg = ctx.event.payload as Message;
+    const { chatId, text } = msg;
+
+    let contextItems: ContextItem[] = [];
+    let usedRetriever = false;
+
+    // Fetch history once — reused for both chat context and URL scanning.
+    const historyResult = await ctx.runtime.fetchHistory({ chatId, pageSize: 30 });
+    const historyMessages = historyResult.ok ? historyResult.value.messages : [];
+    if (!historyResult.ok) {
+      ctx.logger.warn('qa history fetch failed', {
+        code: historyResult.error.code,
+        message: historyResult.error.message,
+      });
+    }
+
+    const chatRetriever = Object.values(ctx.retrievers).find(
+      (r) => r.source === 'chat' || r.source === 'vector',
+    );
+
+    if (chatRetriever) {
+      const hitsResult = await chatRetriever.retrieve({ query: text, chatId, topK: 5 });
+      if (hitsResult.ok) {
+        contextItems = hitsResult.value
+          .filter((h) => h.snippet.length > 0)
+          .map((h) => ({
+            kind: h.source === 'vector' ? ('chat' as const) : h.source,
+            text: h.snippet,
+            title: h.title || '相关群聊记录',
+            ...(h.url ? { url: h.url } : {}),
+            ...(typeof h.meta?.['authorName'] === 'string'
+              ? { authorName: h.meta['authorName'] }
+              : {}),
+            ...(h.timestamp !== undefined ? { timestamp: h.timestamp } : {}),
+            messageId: h.id,
+          }));
+        usedRetriever = contextItems.length > 0;
+      } else {
+        ctx.logger.warn('qa retriever failed, falling back to history', {
+          code: hitsResult.error.code,
+          message: hitsResult.error.message,
+        });
+      }
+    }
+
+    if (contextItems.length === 0 && historyMessages.length > 0) {
+      const botOpenId = process.env['LARK_BOT_OPEN_ID'];
+      const candidates = historyMessages
+        .filter((m) => m.text.length > 0)
+        .filter((m) => m.messageId !== msg.messageId)
+        .filter((m) => m.text.trim() !== text.trim())
+        .filter((m) => m.sender.userId !== botOpenId)
+        .map((m) => ({ m, score: bigramScore(m.text, text) }));
+
+      // Sliding window: anchors = bigram matches; expand ±2 positions within 5-min
+      // window to capture pronoun-reference messages (e.g. "他" referring to a name).
+      const SLIDE = 2;
+      const TIME_MS = 5 * 60 * 1000;
+      const scores = new Map<number, number>();
+      candidates.forEach((c, i) => {
+        if (c.score > 0) scores.set(i, c.score);
+      });
+      for (const [ai, anchorScore] of [...scores.entries()]) {
+        const anchor = candidates[ai];
+        if (anchor === undefined) continue;
+        for (let d = 1; d <= SLIDE; d++) {
+          for (const ni of [ai - d, ai + d]) {
+            if (ni < 0 || ni >= candidates.length || scores.has(ni)) continue;
+            const neighbor = candidates[ni];
+            if (neighbor === undefined) continue;
+            if (Math.abs(neighbor.m.timestamp - anchor.m.timestamp) <= TIME_MS) {
+              scores.set(ni, anchorScore * 0.5 ** d);
+            }
+          }
+        }
+      }
+
+      contextItems = [...scores.entries()]
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 5)
+        .flatMap(([i]) => {
+          const c = candidates[i];
+          return c !== undefined ? [historyContextItem(c.m)] : [];
+        });
+    }
+
+    // Scan ALL history messages for Feishu doc/bitable/slide URLs and read their content.
+    // Done regardless of whether chat context was found — documents may contain answers
+    // even when the share message has no keyword overlap with the question.
+    const linkedItems = await fetchLinkedContent(historyMessages, ctx);
+    if (linkedItems.length > 0) {
+      contextItems = [...linkedItems, ...contextItems];
+    }
+
+    // No relevant context found anywhere — bail early without calling LLM.
+    if (contextItems.length === 0) {
+      return ok({ text: '暂时找不到相关记录，建议直接在群里问一下。' });
+    }
+
+    const contextTexts = contextItems.map((item) => `${item.title}\n${item.text}`);
+    const answerResult = await ctx.llm.ask(QA_PROMPT(text, contextTexts), { model: 'pro' });
+    if (!answerResult.ok) return answerResult;
+
+    const raw = answerResult.value.trim();
+    if (raw.includes('INSUFFICIENT_CONTEXT')) {
+      return ok({ text: '暂时找不到相关记录，建议直接在群里问一下。' });
+    }
+
+    // LLM outputs "SOURCES: 1,3" at the end — parse and strip it.
+    const sourcesMatch = /\nSOURCES:\s*([^\n]+)/.exec(raw);
+    const answer = raw.replace(/\nSOURCES:[^\n]*/g, '').trim();
+    const citedGroup = sourcesMatch?.[1] ?? '';
+    const citedItems: ContextItem[] =
+      citedGroup !== '' && citedGroup.trim() !== 'none'
+        ? citedGroup
+            .split(',')
+            .map((s) => parseInt(s.trim(), 10) - 1)
+            .filter((i) => !isNaN(i) && i >= 0 && i < contextItems.length)
+            .flatMap((i) => {
+              const item = contextItems[i];
+              return item !== undefined ? [item] : [];
+            })
+        : [];
+
+    const displayItems =
+      citedItems.length > 0
+        ? citedItems
+        : citedGroup.trim() === 'none'
+          ? []
+          : contextItems.slice(0, 3);
+
+    const sources = displayItems.map((item) => ({
+      title: item.title,
+      kind: item.kind,
+      snippet: item.text.length > 300 ? `${item.text.slice(0, 300)}…` : item.text,
+      ...(item.url ? { url: item.url } : {}),
+      ...(item.authorName ? { authorName: item.authorName } : {}),
+      ...(item.timestamp !== undefined ? { timestamp: item.timestamp } : {}),
+      ...(item.messageId ? { messageId: item.messageId } : {}),
+    }));
+
+    const card = ctx.cardBuilder.build('qa', {
+      question: text,
+      answer,
+      sources,
+      buttons: [
+        {
+          text: '重新回答',
+          value: { action: 'qa.reanswer', questionMessageId: msg.messageId, chatId },
+        },
+      ],
+    });
+
     return ok({
-      text: `（Mock）收到问题：「${msg.text}」\n真实回答逻辑待 #NEW-4 实现。`,
+      card,
+      reasoning: usedRetriever
+        ? '命中群聊检索结果后由豆包 Pro 合成回答'
+        : '未命中检索器，降级读取最近群聊历史后由豆包 Pro 合成回答',
     });
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,10 @@ importers:
       '@seedhac/contracts':
         specifier: workspace:*
         version: link:../contracts
+    devDependencies:
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 


### PR DESCRIPTION
## Summary
- Implement the QA skill with chat history fallback, LLM answer synthesis, and cited sources.
- Read linked Feishu doc/wiki/slides metadata and Bitable records from recent group history.
- Render multiple readable QA sources in cards and wire card re-answer callbacks.

## Validation
- pnpm --filter @seedhac/skills test
- pnpm --filter @seedhac/bot test
- pnpm typecheck
- pnpm build

Closes #35