### PR TITLE
docs(bot-memory): M4 记忆系统与 Skill 行为规范文档 #69

### DIFF
--- a/docs/bot-memory/MEMORY-SCHEMA.md
+++ b/docs/bot-memory/MEMORY-SCHEMA.md
@@ -1,0 +1,78 @@
+# Bitable Memory Schema
+
+四张核心表的字段定义。代码层面对应 `BitableTableKind`（`packages/contracts/src/bitable.ts`）。
+
+---
+
+## memory 表
+
+每次 Skill 成功执行后写入一条记录，供后续 `memory.read` 检索。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `chatId` | 文本 | 飞书群 chat_id |
+| `skillName` | 单选 | qa / recall / summary / slides / archive / weekly |
+| `triggeredAt` | 日期时间 | 触发时间（ISO 8601） |
+| `messageId` | 文本 | 触发消息的 message_id |
+| `query` | 文本 | 用户原始意图（GapDetector 提取或原文） |
+| `reasoning` | 长文本 | Skill 决策原因（SkillResult.reasoning） |
+| `resultSummary` | 长文本 | 输出卡片的摘要文字（≤200 字） |
+| `relatedDecisions` | 关联字段 | → decision 表（知识图谱边） |
+| `relatedTodos` | 关联字段 | → todo 表（知识图谱边） |
+
+---
+
+## decision 表
+
+由 archive Skill 从群历史中抽取的决策条目。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `chatId` | 文本 | 所在群 |
+| `archivedAt` | 日期时间 | 归档时间 |
+| `title` | 文本 | 决策标题（≤50 字） |
+| `content` | 长文本 | 决策详情 |
+| `deciders` | 文本 | 决策人（open_id 逗号分隔） |
+| `status` | 单选 | open / closed / superseded |
+| `relatedMemory` | 关联字段 | → memory 表（归档记录） |
+| `relatedKnowledge` | 关联字段 | → knowledge 表（1-2 跳图谱） |
+
+---
+
+## todo 表
+
+由 archive Skill 从群历史中抽取的待办条目。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `chatId` | 文本 | 所在群 |
+| `archivedAt` | 日期时间 | 归档时间 |
+| `title` | 文本 | 待办标题 |
+| `assignee` | 文本 | 负责人 open_id |
+| `due` | 日期 | 截止日期（可选） |
+| `status` | 单选 | open / done / cancelled |
+| `relatedMemory` | 关联字段 | → memory 表 |
+
+---
+
+## knowledge 表
+
+双向关联节点，作为知识图谱的顶点，支持 1-2 跳关系查询。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `chatId` | 文本 | 所在群 |
+| `kind` | 单选 | project / person / metric / concept / event |
+| `name` | 文本 | 节点名称（实体名） |
+| `description` | 长文本 | 节点描述 |
+| `relatedDecisions` | 关联字段 | → decision 表 |
+| `relatedMemory` | 关联字段 | → memory 表 |
+
+---
+
+## 写入规则
+
+- `batchInsert` 须满足原子性：全部成功或全部回滚（对应红线 R4）
+- 单批上限 500 条（飞书硬上限）
+- 所有写操作通过 `BitableClient` 接口，禁止直接调飞书 REST API
+- `chatId` 作为行级数据隔离边界，不允许跨群查询

--- a/docs/bot-memory/MEMORY-SCHEMA.md
+++ b/docs/bot-memory/MEMORY-SCHEMA.md
@@ -6,19 +6,20 @@
 
 ## memory 表
 
-每次 Skill 成功执行后写入一条记录，供后续 `memory.read` 检索。
+语义化记忆存储，字段对应 `MemoryRecord`（`packages/contracts/src/bitable.ts`）。
+由 `MemoryStore.write()` 写入，由 `memory.read` / `memory.search` 工具读取。
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `chatId` | 文本 | 飞书群 chat_id |
-| `skillName` | 单选 | qa / recall / summary / slides / archive / weekly |
-| `triggeredAt` | 日期时间 | 触发时间（ISO 8601） |
-| `messageId` | 文本 | 触发消息的 message_id |
-| `query` | 文本 | 用户原始意图（GapDetector 提取或原文） |
-| `reasoning` | 长文本 | Skill 决策原因（SkillResult.reasoning） |
-| `resultSummary` | 长文本 | 输出卡片的摘要文字（≤200 字） |
-| `relatedDecisions` | 关联字段 | → decision 表（知识图谱边） |
-| `relatedTodos` | 关联字段 | → todo 表（知识图谱边） |
+| `kind` | 单选 | `project` / `chat` / `user` / `skill_log` |
+| `chat_id` | 文本 | 飞书群 chat_id；全局/项目级记忆用 `'GLOBAL'` |
+| `user_id` | 文本 | 可选，`user` / `skill_log` 类记忆需要 |
+| `key` | 文本 | 幂等键；`(chat_id, kind, key)` 相同视为同一条（触发 upsert） |
+| `content` | 长文本 | 正文，写入时硬截断至 2KB |
+| `importance` | 数字 | 重要性 0–10；由 LLM 异步评分，未评分前为 `-1` |
+| `last_access` | 数字 | 毫秒时间戳；read/search 命中时刷新，驱动 LRU recency |
+| `created_at` | 数字 | 毫秒时间戳；写入时一次性写入，不可修改 |
+| `source_skill` | 文本 | 写入该条记忆的 Skill 名（审计用） |
 
 ---
 
@@ -75,4 +76,4 @@
 - `batchInsert` 须满足原子性：全部成功或全部回滚（对应红线 R4）
 - 单批上限 500 条（飞书硬上限）
 - 所有写操作通过 `BitableClient` 接口，禁止直接调飞书 REST API
-- `chatId` 作为行级数据隔离边界，不允许跨群查询
+- `chat_id` 作为行级数据隔离边界，不允许跨群查询（对应红线 R2）

--- a/docs/bot-memory/OVERVIEW.md
+++ b/docs/bot-memory/OVERVIEW.md
@@ -23,14 +23,16 @@ Lark Loom 是飞书群聊 AI 助手。Bot 的核心差异化在于**事中主动
 
 ## 工具索引（模型可调用）
 
-| 工具 | 作用 |
-|------|------|
-| `memory.read` | 按 chatId + 关键词查 Bitable memory 表 |
-| `skill.read` | 获取指定 Skill 的行为规范文档（本目录下 `skills/*.md`） |
-| `bitable.find` | 通用多维表格查询 |
-| `bitable.insert` | 写入 memory / decision / todo / knowledge 表 |
-| `retriever.search` | 向量检索（Chroma）或 Bitable 全文检索 |
-| `docx.read` | 读取飞书文档正文（Wiki / 云文档） |
+M3 注册的 4 个工具（`packages/bot/src/memory/tool-handlers.ts`）：
+
+| 工具 | 签名 | 作用 |
+|------|------|------|
+| `memory.read` | `memory.read(kind, key)` | 按 (kind, key) 精确读取当前群的一条记忆 |
+| `memory.search` | `memory.search(query, limit?)` | 按关键词模糊检索当前群的记忆，返回若干条 |
+| `skill.list` | `skill.list()` | 列出所有已注册 Skill 的名称与一句话描述 |
+| `skill.read` | `skill.read(name)` | 获取指定 Skill 的完整行为规范文档（本目录 `skills/*.md`，≤ 2KB） |
+
+> `chat_id` 由服务端从会话上下文注入，模型无需传入（R2：不允许跨群读取）。
 
 ---
 

--- a/docs/bot-memory/OVERVIEW.md
+++ b/docs/bot-memory/OVERVIEW.md
@@ -1,0 +1,59 @@
+# Lark Loom Bot — 记忆与上下文系统总览
+
+## 定位
+
+Lark Loom 是飞书群聊 AI 助手。Bot 的核心差异化在于**事中主动介入**：不等用户问，当对话中出现信息缺口时自动浮出历史记录。
+
+记忆系统采用 Harness 架构：**无固定系统提示**，模型在推理时按需调用 `memory.read` / `skill.read` 工具，拿到的内容直接进 context window，用完丢弃。
+
+---
+
+## 红线（不可逾越）
+
+| 编号 | 规则 |
+|------|------|
+| R1 | 不主动推送未被触发的 Skill 结果（recall 除外，但须有明确信息缺口） |
+| R2 | 不读取非本群的聊天记录 |
+| R3 | 不在卡片中暴露原始 Bitable record_id 给普通用户 |
+| R4 | Bitable 写操作须全成功或全失败（batchInsert 原子性） |
+| R5 | 不调用 10 QPS 以上的飞书 API |
+| R6 | 不存储任何个人敏感信息（手机号、身份证等） |
+
+---
+
+## 工具索引（模型可调用）
+
+| 工具 | 作用 |
+|------|------|
+| `memory.read` | 按 chatId + 关键词查 Bitable memory 表 |
+| `skill.read` | 获取指定 Skill 的行为规范文档（本目录下 `skills/*.md`） |
+| `bitable.find` | 通用多维表格查询 |
+| `bitable.insert` | 写入 memory / decision / todo / knowledge 表 |
+| `retriever.search` | 向量检索（Chroma）或 Bitable 全文检索 |
+| `docx.read` | 读取飞书文档正文（Wiki / 云文档） |
+
+---
+
+## 四张核心表
+
+| 表 | 用途 |
+|----|------|
+| `memory` | 每次 Skill 调用的决策摘要与 reasoning |
+| `decision` | archive Skill 抽出的决策条目 |
+| `todo` | archive Skill 抽出的待办事项 |
+| `knowledge` | 双向关联节点（知识图谱 1-2 跳） |
+
+字段详见 [MEMORY-SCHEMA.md](./MEMORY-SCHEMA.md)。
+
+---
+
+## Skill 列表
+
+| Skill | 触发方式 | 文档 |
+|-------|---------|------|
+| qa | @bot + 疑问句 | [skills/qa.md](./skills/qa.md) |
+| recall | 群消息出现模糊指代词 | [skills/recall.md](./skills/recall.md) |
+| summary | @bot 整理/纪要/总结 | [skills/summary.md](./skills/summary.md) |
+| slides | @bot 做 PPT/幻灯片 | [skills/slides.md](./skills/slides.md) |
+| archive | @bot 复盘/归档 | [skills/archive.md](./skills/archive.md) |
+| weekly | cron 周五 17:00 | [skills/weekly.md](./skills/weekly.md) |

--- a/docs/bot-memory/skills/archive.md
+++ b/docs/bot-memory/skills/archive.md
@@ -1,0 +1,67 @@
+# Skill: archive — 复盘归档
+
+## 触发条件
+
+- **事件**：`message`
+- **必须 @bot**：是
+- **关键词**：`复盘`、`归档`
+- **描述**：Bot 拉取群历史，抽取决策/数据/待办并写入 Bitable，形成知识图谱节点
+
+## 数据流
+
+```
+@bot 复盘 / 归档
+  → match()：关键词命中
+  → run()：
+      1. 拉取群历史（默认全部或时间窗）
+      2. LLM 抽取三类条目：
+         - decisions：决策列表
+         - todos：待办列表
+         - summary：本次讨论摘要
+      3. 批量写入 Bitable：
+         - decision 表（每条决策一行）
+         - todo 表（每条待办一行）
+         - memory 表（本次归档记录）
+      4. link()：建立 memory ↔ decision / todo 双向关联
+      5. CardBuilder 渲染 archive 卡片（含 Bitable 跳转链接）
+```
+
+## 卡片格式（CardBuilder template: `archive`）
+
+| 字段 | 说明 |
+|------|------|
+| `recordId` | memory 表记录 ID（内部用，不暴露给用户） |
+| `title` | 归档标题（LLM 生成） |
+| `bitableUrl` | Bitable 多维表格跳转链接 |
+| `tags` | 标签列表（LLM 提取的主题标签） |
+| `summary` | 本次讨论摘要（≤200 字） |
+
+## Bitable 写入规则
+
+- `batchInsert` 须原子性（decision + todo 全成功或全失败，对应红线 R4）
+- `link()` 在 insert 成功后才调用
+- `chatId` 必须写入每条记录（隔离边界）
+- `status` 默认为 `open`
+
+## 知识图谱
+
+archive 是知识图谱的**主要入口**：
+- decision 节点 → 关联 knowledge 节点（人物/项目/指标）
+- 后续 recall 可沿图谱 1-2 跳检索相关决策
+
+## 红线
+
+- 不修改历史归档记录（只追加，不删改）
+- `recordId` 不出现在卡片正文中（仅作内部标识）
+- 群历史为空时拒绝归档，返回"无可归档的消息"
+- batchInsert 失败须回滚并告知用户，不写半截数据
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'archive'`
+- `query`：用户指令（"复盘"/"归档"）
+- `reasoning`：共抽出多少条决策/待办，使用了多少条历史消息
+- `resultSummary`：归档标题 + 决策数 + 待办数
+- `relatedDecisions`：本次写入的 decision 记录 ID 列表
+- `relatedTodos`：本次写入的 todo 记录 ID 列表

--- a/docs/bot-memory/skills/qa.md
+++ b/docs/bot-memory/skills/qa.md
@@ -22,18 +22,19 @@
 
 ## 卡片格式（CardBuilder template: `qa`）
 
-| 字段 | 说明 |
-|------|------|
-| `question` | 用户原始问题（脱敏后） |
-| `answer` | LLM 生成的回答正文 |
-| `sources` | 引用来源列表（文档名 + 跳转链接，≤5 条） |
-| `confidence` | 高 / 中 / 低（LLM 自评） |
+对应合约类型 `QaCardInput`（`packages/contracts/src/card.ts`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `question` | `string` | 用户原始问题 |
+| `answer` | `string` | LLM 生成的回答正文 |
+| `sources` | `CardSource[]` | 引用来源列表（名称 + 跳转链接，≤5 条） |
+| `buttons?` | `CardButton[]` | 可选操作按钮（如"查看原文"） |
 
 ## 红线
 
 - 检索无结果时不捏造答案，必须明确回复"未找到相关记录"
 - 不跨群读取历史记录
-- confidence=低 时需在卡片上标注"仅供参考"
 
 ## Memory 写入
 

--- a/docs/bot-memory/skills/qa.md
+++ b/docs/bot-memory/skills/qa.md
@@ -1,0 +1,44 @@
+# Skill: qa — 被动问答
+
+## 触发条件
+
+- **事件**：`message`
+- **必须 @bot**：是
+- **关键词**：`?`、`？`、`吗`、`呢`（疑问句特征）
+- **描述**：用户 @bot 并附带疑问句，Bot 检索相关内容后回答
+
+## 数据流
+
+```
+@bot + 疑问句
+  → match()：关键词命中疑问句尾
+  → run()：
+      1. 拉取群历史（最近 N 条）
+      2. 并行检索：群聊 Bitable memory + 向量检索（Chroma）+ docx Wiki
+      3. LLM 整合多路结果 → 生成回答
+      4. CardBuilder 渲染 qa 卡片
+      5. SideEffect：写 memory 表（reasoning + resultSummary）
+```
+
+## 卡片格式（CardBuilder template: `qa`）
+
+| 字段 | 说明 |
+|------|------|
+| `question` | 用户原始问题（脱敏后） |
+| `answer` | LLM 生成的回答正文 |
+| `sources` | 引用来源列表（文档名 + 跳转链接，≤5 条） |
+| `confidence` | 高 / 中 / 低（LLM 自评） |
+
+## 红线
+
+- 检索无结果时不捏造答案，必须明确回复"未找到相关记录"
+- 不跨群读取历史记录
+- confidence=低 时需在卡片上标注"仅供参考"
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'qa'`
+- `query`：用户问题
+- `reasoning`：选择哪些来源、为何排除其他
+- `resultSummary`：回答前 200 字

--- a/docs/bot-memory/skills/recall.md
+++ b/docs/bot-memory/skills/recall.md
@@ -41,11 +41,14 @@
 
 ## 卡片格式（CardBuilder template: `recall`）
 
-| 字段 | 说明 |
-|------|------|
-| `query` | GapDetector 提取的检索意图 |
-| `hits` | 召回结果列表（标题 + 摘要 + 时间，≤3 条） |
-| `reason` | 为何在此时浮出（给用户的解释） |
+对应合约类型 `RecallCardInput`（`packages/contracts/src/card.ts`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `trigger` | `string` | 触发召回的原始消息片段（GapDetector 提取） |
+| `summary` | `string` | 召回结果摘要文字 |
+| `sources` | `CardSource[]` | 召回来源列表（名称 + 跳转链接，≤3 条） |
+| `buttons?` | `CardButton[]` | 可选操作按钮（如"展开详情"） |
 
 ## 红线
 

--- a/docs/bot-memory/skills/recall.md
+++ b/docs/bot-memory/skills/recall.md
@@ -1,0 +1,63 @@
+# Skill: recall — 主动浮信息 🔥
+
+## 触发条件
+
+- **事件**：`message`
+- **必须 @bot**：否（被动监听所有消息）
+- **关键词**：`上次`、`之前`、`我记得`、`那个`、`上回`、`是多少来着`
+- **描述**：群消息中出现模糊指代词，Bot 主动召回历史信息（**事中介入**）
+
+## 数据流
+
+```
+群消息（无需 @bot）
+  → match()：
+      1. 关键词预筛（快速路径）
+      2. GapDetector（豆包 Lite）检测信息缺口
+         → 返回 { shouldRecall, reason, query }
+      3. shouldRecall=false → 跳过，不打扰
+  → run()（仅 shouldRecall=true）：
+      1. 从 gapCache 取 match() 的检测结果（避免重复调 LLM）
+      2. cache miss 时重新调 GapDetector
+      3. 并行检索：Bitable memory + 向量检索
+      4. 无结果 → 静默退出（不发卡片）
+      5. 有结果 → CardBuilder 渲染 recall 卡片
+      6. SideEffect：写 memory 表
+```
+
+## GapDetector 行为规范
+
+- 使用豆包 Lite（低延迟小模型），单次调用 ≤ 2s
+- 输入：最近 N 条消息批次
+- 输出：`{ shouldRecall: boolean; reason: string; query: string }`
+- 保守判断：宁可漏召回，不可误触发骚扰用户
+- `messages.length === 0` 时直接返回 `shouldRecall=false`
+
+## gapCache 规则
+
+- 类型：`Map<messageId, GapDetection>`，最大 200 条
+- 超出上限时 FIFO 淘汰最旧条目
+- match() 写入，run() 读取；cache miss 时 run() 重新检测
+
+## 卡片格式（CardBuilder template: `recall`）
+
+| 字段 | 说明 |
+|------|------|
+| `query` | GapDetector 提取的检索意图 |
+| `hits` | 召回结果列表（标题 + 摘要 + 时间，≤3 条） |
+| `reason` | 为何在此时浮出（给用户的解释） |
+
+## 红线
+
+- **绝对不能骚扰**：shouldRecall=false 时必须静默，不发任何消息
+- 召回结果为空时静默退出，不发"未找到"提示
+- 不跨群读取历史记录
+- match() 必须快（关键词预筛 → LLM 兜底），不阻塞消息处理
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'recall'`
+- `query`：GapDetector 提取的检索意图
+- `reasoning`：shouldRecall 的判断依据
+- `resultSummary`：命中的前 N 条摘要

--- a/docs/bot-memory/skills/slides.md
+++ b/docs/bot-memory/skills/slides.md
@@ -1,0 +1,66 @@
+# Skill: slides — 幻灯片生成
+
+## 触发条件
+
+- **事件**：`message`
+- **必须 @bot**：是
+- **关键词**：`做 PPT`、`生成幻灯片`、`slides`
+- **描述**：Bot 根据群聊上下文生成 PPT 大纲，创建飞书文档，用户一键转 PPT
+
+## 数据流
+
+```
+@bot 做 PPT / 幻灯片
+  → match()：关键词命中
+  → run()：
+      1. 拉取群历史（默认最近 100 条）
+      2. LLM 生成 PPT 大纲（Markdown 格式，H1=封面/H2=章节/H3=要点）
+      3. 调 docx.create（飞书 docx-v1 API）创建 Markdown 云文档
+      4. CardBuilder 渲染 slides 卡片（含文档跳转链接）
+      5. SideEffect：写 memory 表
+```
+
+## 飞书 Docx API 说明
+
+- 通过 `@larksuiteoapi/node-sdk` 调用，使用 bot tenant token
+- 创建文档后返回 `docUrl`（飞书文档跳转链接）
+- 用户在飞书文档内点击"转为 PPT"即可一键生成幻灯片（飞书原生功能）
+
+## 卡片格式（CardBuilder template: `slides`）
+
+| 字段 | 说明 |
+|------|------|
+| `title` | PPT 标题（LLM 从大纲提取） |
+| `outline` | 章节列表（H2 标题，≤8 项） |
+| `docUrl` | 飞书文档跳转链接 |
+| `hint` | 提示文案："点击链接在飞书文档中查看并转为 PPT" |
+
+## 大纲格式规范
+
+LLM 生成的 Markdown 须符合以下结构，飞书 docx API 能正确解析：
+
+```markdown
+# 封面标题
+
+## 第一章
+
+### 要点 1
+### 要点 2
+
+## 第二章
+...
+```
+
+## 红线
+
+- docx 创建失败时返回错误卡片，不静默失败
+- 不直接生成 PPT 文件（二进制），只生成飞书 Markdown 文档
+- 大纲章节数 ≤ 8，每章要点 ≤ 5（防止内容过长）
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'slides'`
+- `query`：用户原始指令
+- `reasoning`：大纲章节逻辑说明
+- `resultSummary`：生成的 PPT 标题 + 章节数

--- a/docs/bot-memory/skills/slides.md
+++ b/docs/bot-memory/skills/slides.md
@@ -28,12 +28,14 @@
 
 ## 卡片格式（CardBuilder template: `slides`）
 
-| 字段 | 说明 |
-|------|------|
-| `title` | PPT 标题（LLM 从大纲提取） |
-| `outline` | 章节列表（H2 标题，≤8 项） |
-| `docUrl` | 飞书文档跳转链接 |
-| `hint` | 提示文案："点击链接在飞书文档中查看并转为 PPT" |
+对应合约类型 `SlidesCardInput`（`packages/contracts/src/card.ts`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `title` | `string` | PPT 标题（LLM 从大纲提取） |
+| `presentationUrl` | `string` | 飞书演示文稿跳转链接 |
+| `pageCount` | `number` | 幻灯片页数 |
+| `preview?` | `{ title: string; bullets: string[] }[]` | 章节预览（可选，≤8 章） |
 
 ## 大纲格式规范
 

--- a/docs/bot-memory/skills/summary.md
+++ b/docs/bot-memory/skills/summary.md
@@ -1,0 +1,54 @@
+# Skill: summary — 会议纪要
+
+## 触发条件
+
+- **事件**：`message`
+- **必须 @bot**：是
+- **关键词**：`整理`、`纪要`、`总结`
+- **描述**：用户 @bot 要求整理，Bot 拉取群历史生成 4 段式纪要
+
+## 数据流
+
+```
+@bot 整理 / 纪要 / 总结
+  → match()：关键词命中
+  → run()：
+      1. 解析时间窗（消息中提取"今天"/"最近 2 小时"等，默认最近 100 条）
+      2. 拉取群历史（runtime.getHistory）
+      3. LLM 抽取 4 段：议题 / 决议 / 待办 / 待跟进
+      4. CardBuilder 渲染 summary 卡片
+      5. SideEffect：写 memory 表
+```
+
+## 卡片格式（CardBuilder template: `summary`）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `title` | string | 纪要标题（LLM 生成，≤30 字） |
+| `topics` | string[] | 议题列表 |
+| `decisions` | string[] | 决议列表 |
+| `todos` | `{ title; assignee?; due? }[]` | 待办列表 |
+| `followUps` | string[] | 待跟进事项 |
+
+## 时间窗解析规则
+
+| 用户说 | 拉取范围 |
+|--------|---------|
+| 无特别说明 | 最近 100 条消息 |
+| "今天" | 当日 00:00 至今 |
+| "最近 2 小时" | 当前时间 -2h 至今 |
+| 显式时间段 | 按指定范围 |
+
+## 红线
+
+- 不捏造参与人——只提 LLM 在历史消息中明确看到的人名
+- `todos[].due` 为 `string | undefined`，TypeScript 禁止传 `undefined` 给 CardBuilder（用条件展开）
+- 群历史为空时回复"暂无可整理的消息"，不生成空卡片
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'summary'`
+- `query`：用户原始指令
+- `reasoning`：时间窗如何确定、共处理多少条消息
+- `resultSummary`：决议 + 待办数量摘要

--- a/docs/bot-memory/skills/summary.md
+++ b/docs/bot-memory/skills/summary.md
@@ -27,7 +27,7 @@
 | `title` | string | 纪要标题（LLM 生成，≤30 字） |
 | `topics` | string[] | 议题列表 |
 | `decisions` | string[] | 决议列表 |
-| `todos` | `{ title; assignee?; due? }[]` | 待办列表 |
+| `todos` | `{ text: string; assignee?: string; due?: string }[]` | 待办列表 |
 | `followUps` | string[] | 待跟进事项 |
 
 ## 时间窗解析规则

--- a/docs/bot-memory/skills/weekly.md
+++ b/docs/bot-memory/skills/weekly.md
@@ -24,13 +24,15 @@ cron 触发（周五 17:00）
 
 ## 卡片格式（CardBuilder template: `weekly`）
 
-| 字段 | 说明 |
-|------|------|
-| `weekRange` | 周期（如 "2026-04-27 ~ 2026-05-01"） |
-| `highlights` | 本周亮点（≤5 条） |
-| `decisions` | 本周重要决策（≤5 条） |
-| `todos` | 未完成待办（从 Bitable todo 表拉取 status=open） |
-| `nextWeek` | 下周预告（LLM 从讨论中提取，可选） |
+对应合约类型 `WeeklyCardInput`（`packages/contracts/src/card.ts`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `weekRange` | `string` | 周期（如 "2026-04-27 ~ 2026-05-01"） |
+| `highlights` | `string[]` | 本周亮点（≤5 条） |
+| `decisions` | `string[]` | 本周重要决策（≤5 条） |
+| `todos` | `string[]` | 未完成待办文本列表（从 Bitable todo 表拉取 status=open） |
+| `metrics?` | `Record<string, number>` | 关键指标（可选，如消息数/决策数） |
 
 ## 定时配置
 

--- a/docs/bot-memory/skills/weekly.md
+++ b/docs/bot-memory/skills/weekly.md
@@ -1,0 +1,62 @@
+# Skill: weekly — 定时周报
+
+## 触发条件
+
+- **事件**：无（不监听 `message` 事件）
+- **触发源**：runtime scheduler 按 cron 表达式推 `BotEvent`
+- **Cron**：`0 17 * * 5`（每周五 17:00 北京时间）
+- **必须 @bot**：否
+- **描述**：每周五自动扫描本周群消息，生成 highlights / 决策 / 待办周报卡片
+
+## 数据流
+
+```
+cron 触发（周五 17:00）
+  → runtime scheduler 推 BotEvent（type: 'schedule'）
+  → match()：type === 'schedule' && skillName === 'weekly' → true
+  → run()：
+      1. 拉取本周消息（周一 00:00 至周五 17:00）
+      2. LLM 抽取：highlights / 决策 / 待办 / 下周预告
+      3. CardBuilder 渲染 weekly 卡片
+      4. runtime 推送到各目标群（可配置群列表）
+      5. SideEffect：写 memory 表
+```
+
+## 卡片格式（CardBuilder template: `weekly`）
+
+| 字段 | 说明 |
+|------|------|
+| `weekRange` | 周期（如 "2026-04-27 ~ 2026-05-01"） |
+| `highlights` | 本周亮点（≤5 条） |
+| `decisions` | 本周重要决策（≤5 条） |
+| `todos` | 未完成待办（从 Bitable todo 表拉取 status=open） |
+| `nextWeek` | 下周预告（LLM 从讨论中提取，可选） |
+
+## 定时配置
+
+- cron 表达式：`0 17 * * 5`（UTC+8，对应 UTC `0 9 * * 5`，需注意时区）
+- 目标群列表由环境变量 `WEEKLY_CHAT_IDS` 配置（逗号分隔的 chat_id）
+- 单次运行超时：60s
+
+## 未完成待办来源
+
+weekly 主动查询 Bitable `todo` 表：
+```
+where: { chatId: <当前群>, status: 'open' }
+```
+查询结果合并进卡片，让成员在周报中看到积压待办。
+
+## 红线
+
+- 仅在目标群推送，不广播到所有群
+- 群消息为空时跳过，不发空周报
+- todos 为空时卡片中不显示该模块（不要显示"无待办"占位）
+- 推送失败须记录日志，不重试（下周自动再触发）
+
+## Memory 写入
+
+写入 `memory` 表，字段：
+- `skillName = 'weekly'`
+- `query`：`'weekly-cron'`（标识为定时触发）
+- `reasoning`：共处理多少条消息、抽出多少条 highlights/决策
+- `resultSummary`：highlights 前 3 条标题


### PR DESCRIPTION
## Summary                                                                    
                                                                                
  - `docs/bot-memory/OVERVIEW.md` — 项目定位、6                                 
  条红线（R1-R6）、模型可调用工具索引、四张核心 Bitable 表说明                  
  四表完整字段定义与写入规则                                                 
  - `docs/bot-memory/skills/{qa,recall,summary,slides,archive,weekly}.md` — 每个
   Skill 的触发条件、数据流、卡片字段（对齐 contracts/card.ts                   
  实际类型）、红线约束、Memory 写入规范                                         
                                                                                
  ## Test plan
                                                                                
  - [ ] OVERVIEW.md 红线 R1-R6 与 CLAUDE.md 对齐
  - [ ] MEMORY-SCHEMA.md 字段与 `packages/contracts/src/bitable.ts` 的          
  `BitableTableKind` 一致                                             
  - [ ] 各 Skill 卡片字段与 `packages/contracts/src/card.ts` 对应 Input 类型一致
  - [ ] recall.md 中 GapDetector / gapCache 规则与 feat/skill-recall 实现对齐