### PR TITLE
feat(llm): chatWithTools 接入 Function Calling (M1, closes #66)

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -13,7 +13,8 @@
     "dev:smoke": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-cards.ts",
     "dev:smoke-llm": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-llm.ts",
     "dev:smoke-docx": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-docx.ts",                            
-    "dev:smoke-bot-runtime": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-bot-runtime.ts",     
+    "dev:smoke-bot-runtime": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-bot-runtime.ts",
+    "dev:smoke-tool-call": "node --env-file=../../.env --import tsx/esm src/scripts/smoke-tool-call.ts",
     "start": "node --env-file=../../.env dist/index.js",
     "test": "vitest run"
   },

--- a/packages/bot/src/__tests__/llm-client.test.ts
+++ b/packages/bot/src/__tests__/llm-client.test.ts
@@ -505,4 +505,211 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       expect(result.value.toolCalls).toHaveLength(2);
     }
   });
+
+  // H1: assistant 同时返回 content + tool_calls 时，content 必须保留进对话历史
+  it('preserves non-empty assistant content alongside tool_calls (H1)', async () => {
+    mockFetchSequence(
+      {
+        choices: [
+          {
+            message: {
+              content: '我先查一下天气',
+              tool_calls: [
+                { id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"X"}' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5 },
+      },
+      arkTextResponse('天气晴朗'),
+    );
+
+    await makeClient().chatWithTools(
+      [{ role: 'user', content: 'weather?' }],
+      {
+        tools: TOOLS,
+        executor: async (call) => ({
+          toolCallId: call.id,
+          name: call.name,
+          content: '{}',
+        }),
+      },
+    );
+
+    // 第二次请求里应保留第一轮的 assistant.content（不是空字符串被吞掉）
+    const secondBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1]![1] as RequestInit).body as string,
+    );
+    const assistantMsg = secondBody.messages.find(
+      (m: { role: string; tool_calls?: unknown }) => m.role === 'assistant' && m.tool_calls,
+    );
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg.content).toBe('我先查一下天气');
+  });
+
+  // H1 反向：assistant 只调工具不说话时 content 字段应被省略而非空串
+  it('omits content field when assistant only calls tools (H1)', async () => {
+    mockFetchSequence(
+      arkToolCallResponse('get_weather', { city: 'Y' }, 'c1'),
+      arkTextResponse('done'),
+    );
+
+    await makeClient().chatWithTools(
+      [{ role: 'user', content: 'go' }],
+      {
+        tools: TOOLS,
+        executor: async (call) => ({
+          toolCallId: call.id,
+          name: call.name,
+          content: '{}',
+        }),
+      },
+    );
+
+    const secondBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1]![1] as RequestInit).body as string,
+    );
+    const assistantMsg = secondBody.messages.find(
+      (m: { role: string; tool_calls?: unknown }) => m.role === 'assistant' && m.tool_calls,
+    );
+    expect(assistantMsg).toBeDefined();
+    expect('content' in assistantMsg).toBe(false);
+  });
+
+  // L1: 模型返回的 arguments 是非法 JSON 时，executor 抛错应被隔离
+  it('isolates executor errors caused by malformed arguments JSON (L1)', async () => {
+    mockFetchSequence(
+      {
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [
+                { id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{not valid json' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5 },
+      },
+      arkTextResponse('参数无效，已重试'),
+    );
+
+    const executor = vi.fn(async (call: ToolCall): Promise<ToolResult> => {
+      // 调用方按合约自行 parse — 故意暴露错误
+      JSON.parse(call.argumentsRaw);
+      return { toolCallId: call.id, name: call.name, content: '{}' };
+    });
+
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'go' }],
+      { tools: TOOLS, executor },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe('参数无效，已重试');
+    }
+    // executor 抛错被包成 ToolResult，第二次请求里能看到 role=tool 的错误结果
+    const secondBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1]![1] as RequestInit).body as string,
+    );
+    const toolMsg = secondBody.messages.find((m: { role: string }) => m.role === 'tool');
+    expect(toolMsg.content).toMatch(/error|Unexpected/i);
+  });
+});
+
+// ---------- M4: retry path × tool round 串联 ----------
+
+describe('VolcanoLLMClient retry × tool round interaction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // 第 1 轮 fetch 失败一次后重试成功 → 第 2 轮（tool 回灌后）正常完成
+  it('chatWithTools recovers when callApi retries inside a tool round (M4)', async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () => {
+        callCount++;
+        // 第 1 次：transient 失败；第 2 次：tool_call 响应；第 3 次：最终文本
+        if (callCount === 1) throw new Error('transient network');
+        if (callCount === 2) {
+          return {
+            ok: true,
+            json: async () => arkToolCallResponse('get_weather', { city: 'Z' }, 'c1'),
+            text: async () => '',
+          };
+        }
+        return {
+          ok: true,
+          json: async () => arkTextResponse('recovered + answered'),
+          text: async () => '',
+        };
+      }),
+    );
+
+    const promise = makeClient().chatWithTools(
+      [{ role: 'user', content: 'weather?' }],
+      {
+        tools: TOOLS,
+        executor: async (call) => ({
+          toolCallId: call.id,
+          name: call.name,
+          content: '{"ok":true}',
+        }),
+      },
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe('recovered + answered');
+      expect(result.value.rounds).toBe(2);
+    }
+    expect(callCount).toBe(3); // 1 retry + 1 tool round + 1 final
+  }, 10_000);
+
+  // H2: 跨 attempt 出现过 timeout 但最后一次是 HTTP 500 → 应返回 LLM_TIMEOUT 而非掩盖
+  it('returns LLM_TIMEOUT when AbortError occurred at any attempt (H2)', async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+        callCount++;
+        if (callCount <= 2) {
+          // 模拟 timeout：listen abort signal 抛 AbortError
+          await new Promise<void>((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => {
+              const e = new Error('aborted');
+              e.name = 'AbortError';
+              reject(e);
+            });
+            // 永远不 resolve，让 timeout 触发 abort
+          });
+          return undefined;
+        }
+        // 第 3 次返 HTTP 500
+        return { ok: false, status: 500, text: async () => 'oops' };
+      }),
+    );
+
+    const promise = makeClient().ask('hi', { timeoutMs: 50 });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.LLM_TIMEOUT);
+    }
+  }, 10_000);
 });

--- a/packages/bot/src/__tests__/llm-client.test.ts
+++ b/packages/bot/src/__tests__/llm-client.test.ts
@@ -349,10 +349,10 @@ describe('VolcanoLLMClient.chatWithTools', () => {
   });
 
   it('rejects when tools is empty', async () => {
-    const result = await makeClient().chatWithTools(
-      [{ role: 'user', content: 'hi' }],
-      { tools: [], executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }) },
-    );
+    const result = await makeClient().chatWithTools([{ role: 'user', content: 'hi' }], {
+      tools: [],
+      executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }),
+    });
     expect(result.ok).toBe(false);
   });
 
@@ -388,14 +388,11 @@ describe('VolcanoLLMClient.chatWithTools', () => {
 
   it('passes tools and tool_choice in API request', async () => {
     mockFetchOk('done');
-    await makeClient().chatWithTools(
-      [{ role: 'user', content: 'hi' }],
-      {
-        tools: TOOLS,
-        toolChoice: 'auto',
-        executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }),
-      },
-    );
+    await makeClient().chatWithTools([{ role: 'user', content: 'hi' }], {
+      tools: TOOLS,
+      toolChoice: 'auto',
+      executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }),
+    });
     const body = JSON.parse((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).body as string);
     expect(body.tools).toHaveLength(1);
     expect(body.tools[0]).toEqual({
@@ -409,6 +406,21 @@ describe('VolcanoLLMClient.chatWithTools', () => {
     expect(body.tool_choice).toBe('auto');
   });
 
+  it('converts a concrete toolChoice name to OpenAI-compatible function choice', async () => {
+    mockFetchOk('done');
+    await makeClient().chatWithTools([{ role: 'user', content: 'hi' }], {
+      tools: TOOLS,
+      toolChoice: 'get_weather',
+      executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }),
+    });
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.tool_choice).toEqual({
+      type: 'function',
+      function: { name: 'get_weather' },
+    });
+  });
+
   it('stops at maxToolCallRounds and returns last content', async () => {
     // 模型一直要求调工具，永远不收敛
     mockFetchSequence(
@@ -417,18 +429,15 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       arkToolCallResponse('get_weather', { city: 'C' }, 'c3'),
     );
 
-    const result = await makeClient().chatWithTools(
-      [{ role: 'user', content: 'go' }],
-      {
-        tools: TOOLS,
-        maxToolCallRounds: 3,
-        executor: async (call) => ({
-          toolCallId: call.id,
-          name: call.name,
-          content: '{}',
-        }),
-      },
-    );
+    const result = await makeClient().chatWithTools([{ role: 'user', content: 'go' }], {
+      tools: TOOLS,
+      maxToolCallRounds: 3,
+      executor: async (call) => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: '{}',
+      }),
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -448,10 +457,10 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       throw new Error('upstream down');
     });
 
-    const result = await makeClient().chatWithTools(
-      [{ role: 'user', content: 'weather?' }],
-      { tools: TOOLS, executor },
-    );
+    const result = await makeClient().chatWithTools([{ role: 'user', content: 'weather?' }], {
+      tools: TOOLS,
+      executor,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -474,8 +483,16 @@ describe('VolcanoLLMClient.chatWithTools', () => {
             message: {
               content: '',
               tool_calls: [
-                { id: 'a', type: 'function', function: { name: 'get_weather', arguments: '{"city":"A"}' } },
-                { id: 'b', type: 'function', function: { name: 'get_weather', arguments: '{"city":"B"}' } },
+                {
+                  id: 'a',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{"city":"A"}' },
+                },
+                {
+                  id: 'b',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{"city":"B"}' },
+                },
               ],
             },
             finish_reason: 'tool_calls',
@@ -494,10 +511,10 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       }),
     );
 
-    const result = await makeClient().chatWithTools(
-      [{ role: 'user', content: 'A and B?' }],
-      { tools: TOOLS, executor },
-    );
+    const result = await makeClient().chatWithTools([{ role: 'user', content: 'A and B?' }], {
+      tools: TOOLS,
+      executor,
+    });
 
     expect(result.ok).toBe(true);
     expect(executor).toHaveBeenCalledTimes(2);
@@ -515,7 +532,11 @@ describe('VolcanoLLMClient.chatWithTools', () => {
             message: {
               content: '我先查一下天气',
               tool_calls: [
-                { id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"X"}' } },
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{"city":"X"}' },
+                },
               ],
             },
             finish_reason: 'tool_calls',
@@ -526,17 +547,14 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       arkTextResponse('天气晴朗'),
     );
 
-    await makeClient().chatWithTools(
-      [{ role: 'user', content: 'weather?' }],
-      {
-        tools: TOOLS,
-        executor: async (call) => ({
-          toolCallId: call.id,
-          name: call.name,
-          content: '{}',
-        }),
-      },
-    );
+    await makeClient().chatWithTools([{ role: 'user', content: 'weather?' }], {
+      tools: TOOLS,
+      executor: async (call) => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: '{}',
+      }),
+    });
 
     // 第二次请求里应保留第一轮的 assistant.content（不是空字符串被吞掉）
     const secondBody = JSON.parse(
@@ -556,17 +574,14 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       arkTextResponse('done'),
     );
 
-    await makeClient().chatWithTools(
-      [{ role: 'user', content: 'go' }],
-      {
-        tools: TOOLS,
-        executor: async (call) => ({
-          toolCallId: call.id,
-          name: call.name,
-          content: '{}',
-        }),
-      },
-    );
+    await makeClient().chatWithTools([{ role: 'user', content: 'go' }], {
+      tools: TOOLS,
+      executor: async (call) => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: '{}',
+      }),
+    });
 
     const secondBody = JSON.parse(
       (vi.mocked(fetch).mock.calls[1]![1] as RequestInit).body as string,
@@ -587,7 +602,11 @@ describe('VolcanoLLMClient.chatWithTools', () => {
             message: {
               content: '',
               tool_calls: [
-                { id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{not valid json' } },
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{not valid json' },
+                },
               ],
             },
             finish_reason: 'tool_calls',
@@ -604,10 +623,10 @@ describe('VolcanoLLMClient.chatWithTools', () => {
       return { toolCallId: call.id, name: call.name, content: '{}' };
     });
 
-    const result = await makeClient().chatWithTools(
-      [{ role: 'user', content: 'go' }],
-      { tools: TOOLS, executor },
-    );
+    const result = await makeClient().chatWithTools([{ role: 'user', content: 'go' }], {
+      tools: TOOLS,
+      executor,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -657,17 +676,14 @@ describe('VolcanoLLMClient retry × tool round interaction', () => {
       }),
     );
 
-    const promise = makeClient().chatWithTools(
-      [{ role: 'user', content: 'weather?' }],
-      {
-        tools: TOOLS,
-        executor: async (call) => ({
-          toolCallId: call.id,
-          name: call.name,
-          content: '{"ok":true}',
-        }),
-      },
-    );
+    const promise = makeClient().chatWithTools([{ role: 'user', content: 'weather?' }], {
+      tools: TOOLS,
+      executor: async (call) => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: '{"ok":true}',
+      }),
+    });
     await vi.runAllTimersAsync();
     const result = await promise;
 

--- a/packages/bot/src/__tests__/llm-client.test.ts
+++ b/packages/bot/src/__tests__/llm-client.test.ts
@@ -284,3 +284,225 @@ describe('VolcanoLLMClient', () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 });
+
+// ---------- chatWithTools ----------
+
+import type { LLMTool, ToolCall, ToolResult } from '@seedhac/contracts';
+
+const TOOLS: LLMTool[] = [
+  {
+    name: 'get_weather',
+    description: 'Get current weather for a city',
+    parameters: {
+      type: 'object',
+      properties: { city: { type: 'string' } },
+      required: ['city'],
+    },
+  },
+];
+
+/** 构造一个 Ark 风格的 tool_calls 响应 */
+function arkToolCallResponse(name: string, args: object, id = 'call_1'): object {
+  return {
+    choices: [
+      {
+        message: {
+          content: '',
+          tool_calls: [
+            { id, type: 'function', function: { name, arguments: JSON.stringify(args) } },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: 20, completion_tokens: 5 },
+  };
+}
+
+function arkTextResponse(content: string): object {
+  return {
+    choices: [{ message: { content }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
+  };
+}
+
+/** 让 fetch 按调用顺序依次返回不同 JSON */
+function mockFetchSequence(...responses: object[]): void {
+  const fn = vi.fn();
+  for (const r of responses) {
+    fn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => r,
+      text: async () => JSON.stringify(r),
+    });
+  }
+  vi.stubGlobal('fetch', fn);
+}
+
+describe('VolcanoLLMClient.chatWithTools', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('rejects when tools is empty', async () => {
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'hi' }],
+      { tools: [], executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }) },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('runs single tool round and returns final content', async () => {
+    mockFetchSequence(
+      arkToolCallResponse('get_weather', { city: 'Beijing' }, 'c1'),
+      arkTextResponse('Beijing is 22°C, sunny.'),
+    );
+
+    const executor = vi.fn(
+      async (call: ToolCall): Promise<ToolResult> => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: JSON.stringify({ temp: 22, sky: 'sunny' }),
+      }),
+    );
+
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'weather in Beijing?' }],
+      { tools: TOOLS, executor },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe('Beijing is 22°C, sunny.');
+      expect(result.value.toolCalls).toHaveLength(1);
+      expect(result.value.toolCalls[0]!.name).toBe('get_weather');
+      expect(result.value.rounds).toBe(2);
+    }
+    expect(executor).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes tools and tool_choice in API request', async () => {
+    mockFetchOk('done');
+    await makeClient().chatWithTools(
+      [{ role: 'user', content: 'hi' }],
+      {
+        tools: TOOLS,
+        toolChoice: 'auto',
+        executor: async () => ({ toolCallId: 'x', name: 'x', content: '{}' }),
+      },
+    );
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0]).toEqual({
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: 'Get current weather for a city',
+        parameters: TOOLS[0]!.parameters,
+      },
+    });
+    expect(body.tool_choice).toBe('auto');
+  });
+
+  it('stops at maxToolCallRounds and returns last content', async () => {
+    // 模型一直要求调工具，永远不收敛
+    mockFetchSequence(
+      arkToolCallResponse('get_weather', { city: 'A' }, 'c1'),
+      arkToolCallResponse('get_weather', { city: 'B' }, 'c2'),
+      arkToolCallResponse('get_weather', { city: 'C' }, 'c3'),
+    );
+
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'go' }],
+      {
+        tools: TOOLS,
+        maxToolCallRounds: 3,
+        executor: async (call) => ({
+          toolCallId: call.id,
+          name: call.name,
+          content: '{}',
+        }),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rounds).toBe(3);
+      expect(result.value.toolCalls).toHaveLength(3);
+    }
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('isolates executor errors and feeds them back to model', async () => {
+    mockFetchSequence(
+      arkToolCallResponse('get_weather', { city: 'X' }, 'c1'),
+      arkTextResponse('Sorry, weather lookup failed.'),
+    );
+
+    const executor = vi.fn(async (): Promise<ToolResult> => {
+      throw new Error('upstream down');
+    });
+
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'weather?' }],
+      { tools: TOOLS, executor },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe('Sorry, weather lookup failed.');
+    }
+    // 第二次调用时 conversation 里应包含一条 role=tool 的错误结果
+    const secondBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1]![1] as RequestInit).body as string,
+    );
+    const toolMsg = secondBody.messages.find((m: { role: string }) => m.role === 'tool');
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg.content).toContain('upstream down');
+  });
+
+  it('handles multiple parallel tool_calls in one round', async () => {
+    mockFetchSequence(
+      {
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [
+                { id: 'a', type: 'function', function: { name: 'get_weather', arguments: '{"city":"A"}' } },
+                { id: 'b', type: 'function', function: { name: 'get_weather', arguments: '{"city":"B"}' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5 },
+      },
+      arkTextResponse('Both done.'),
+    );
+
+    const executor = vi.fn(
+      async (call: ToolCall): Promise<ToolResult> => ({
+        toolCallId: call.id,
+        name: call.name,
+        content: JSON.stringify({ city: JSON.parse(call.argumentsRaw).city }),
+      }),
+    );
+
+    const result = await makeClient().chatWithTools(
+      [{ role: 'user', content: 'A and B?' }],
+      { tools: TOOLS, executor },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(executor).toHaveBeenCalledTimes(2);
+    if (result.ok) {
+      expect(result.value.toolCalls).toHaveLength(2);
+    }
+  });
+});

--- a/packages/bot/src/llm-client.ts
+++ b/packages/bot/src/llm-client.ts
@@ -16,6 +16,10 @@ import {
   type AskOptions,
   type SchemaLike,
   type Result,
+  type ToolCall,
+  type ToolResult,
+  type ChatWithToolsOptions,
+  type ChatWithToolsResult,
   ok,
   err,
   ErrorCode,
@@ -35,16 +39,27 @@ export interface LLMConfig {
 
 // ---------- Internal types ----------
 
+interface ArkToolCallWire {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
 interface ArkMessage {
-  role: 'system' | 'user' | 'assistant';
+  role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
+  tool_calls?: ArkToolCallWire[];
+  tool_call_id?: string;
+  name?: string;
 }
 
 interface ArkResponse {
   choices: Array<{
     message: {
-      content: string;
+      content: string | null;
+      tool_calls?: ArkToolCallWire[];
     };
+    finish_reason?: string;
   }>;
   usage?: {
     prompt_tokens: number;
@@ -52,11 +67,19 @@ interface ArkResponse {
   };
 }
 
+interface ArkRawResult {
+  content: string;
+  toolCalls: ToolCall[];
+  promptTokens: number;
+  completionTokens: number;
+}
+
 // ---------- Constants ----------
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
 const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3';
+const DEFAULT_MAX_TOOL_CALL_ROUNDS = 5;
 
 // ---------- Utilities ----------
 
@@ -68,6 +91,22 @@ function sleep(ms: number): Promise<void> {
 function stripCodeFence(raw: string): string {
   const match = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
   return match ? match[1]!.trim() : raw.trim();
+}
+
+function toArkMessage(m: ChatMessage): ArkMessage {
+  const base: ArkMessage = { role: m.role, content: m.content };
+  if (m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0) {
+    base.tool_calls = m.toolCalls.map((tc) => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.name, arguments: tc.argumentsRaw },
+    }));
+  }
+  if (m.role === 'tool') {
+    if (m.toolCallId !== undefined) base.tool_call_id = m.toolCallId;
+    if (m.name !== undefined) base.name = m.name;
+  }
+  return base;
 }
 
 function logCall(params: {
@@ -103,7 +142,7 @@ export class VolcanoLLMClient implements LLMClient {
   private async callApi(
     messages: ArkMessage[],
     opts: AskOptions = {},
-  ): Promise<Result<{ content: string; promptTokens: number; completionTokens: number }>> {
+  ): Promise<Result<ArkRawResult>> {
     const modelId = this.modelId(opts.model ?? 'pro');
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -112,6 +151,17 @@ export class VolcanoLLMClient implements LLMClient {
       messages,
       ...(opts.maxTokens !== undefined && { max_tokens: opts.maxTokens }),
       ...(opts.temperature !== undefined && { temperature: opts.temperature }),
+      ...(opts.tools && opts.tools.length > 0 && {
+        tools: opts.tools.map((t) => ({
+          type: 'function',
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          },
+        })),
+        tool_choice: opts.toolChoice ?? 'auto',
+      }),
     });
 
     let lastErr: unknown;
@@ -140,7 +190,14 @@ export class VolcanoLLMClient implements LLMClient {
         }
 
         const data = (await resp.json()) as ArkResponse;
-        const content = data.choices[0]?.message?.content ?? '';
+        const choiceMessage = data.choices[0]?.message;
+        const content = choiceMessage?.content ?? '';
+        const toolCallsWire = choiceMessage?.tool_calls ?? [];
+        const toolCalls: ToolCall[] = toolCallsWire.map((tc) => ({
+          id: tc.id,
+          name: tc.function.name,
+          argumentsRaw: tc.function.arguments,
+        }));
         const promptTokens = data.usage?.prompt_tokens ?? 0;
         const completionTokens = data.usage?.completion_tokens ?? 0;
 
@@ -151,7 +208,7 @@ export class VolcanoLLMClient implements LLMClient {
           durationMs: Date.now() - startMs,
         });
 
-        return ok({ content, promptTokens, completionTokens });
+        return ok({ content, toolCalls, promptTokens, completionTokens });
       } catch (e) {
         clearTimeout(timer);
         lastErr = e;
@@ -184,13 +241,90 @@ export class VolcanoLLMClient implements LLMClient {
   }
 
   async chat(messages: readonly ChatMessage[], opts?: AskOptions): Promise<Result<string>> {
-    const arkMessages: ArkMessage[] = messages.map((m) => ({
-      role: m.role,
-      content: m.content,
-    }));
+    const arkMessages: ArkMessage[] = messages.map(toArkMessage);
     const result = await this.callApi(arkMessages, opts);
     if (!result.ok) return result;
     return ok(result.value.content);
+  }
+
+  async chatWithTools(
+    messages: readonly ChatMessage[],
+    opts: ChatWithToolsOptions,
+  ): Promise<Result<ChatWithToolsResult>> {
+    if (!opts.tools || opts.tools.length === 0) {
+      return err(
+        makeError(
+          ErrorCode.INVALID_INPUT,
+          'chatWithTools requires opts.tools to be non-empty',
+        ),
+      );
+    }
+    const maxRounds = Math.max(1, opts.maxToolCallRounds ?? DEFAULT_MAX_TOOL_CALL_ROUNDS);
+    const conversation: ArkMessage[] = messages.map(toArkMessage);
+    const allToolCalls: ToolCall[] = [];
+
+    let lastContent = '';
+    let rounds = 0;
+
+    for (let round = 0; round < maxRounds; round++) {
+      rounds = round + 1;
+
+      const apiResult = await this.callApi(conversation, opts);
+      if (!apiResult.ok) return apiResult;
+
+      const { content, toolCalls } = apiResult.value;
+      lastContent = content;
+
+      if (toolCalls.length === 0) {
+        // 模型不再请求工具：完成
+        return ok({ content, toolCalls: allToolCalls, rounds });
+      }
+
+      // 记录 + 把 assistant(toolCalls) 追加到对话历史
+      allToolCalls.push(...toolCalls);
+      conversation.push({
+        role: 'assistant',
+        content,
+        tool_calls: toolCalls.map((tc) => ({
+          id: tc.id,
+          type: 'function',
+          function: { name: tc.name, arguments: tc.argumentsRaw },
+        })),
+      });
+
+      // 串行执行 tool（避免 BitableClient QPS 风暴），错误隔离到单条 ToolResult
+      for (const call of toolCalls) {
+        let result: ToolResult;
+        const callStartMs = Date.now();
+        try {
+          result = await opts.executor(call);
+        } catch (e) {
+          result = {
+            toolCallId: call.id,
+            name: call.name,
+            content: JSON.stringify({
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          };
+        }
+        console.log(
+          `[LLMClient] tool=${call.name} call_id=${call.id} duration=${Date.now() - callStartMs}ms`,
+        );
+        conversation.push({
+          role: 'tool',
+          tool_call_id: result.toolCallId,
+          name: result.name,
+          content: result.content,
+        });
+      }
+      // 进入下一轮：把 tool 结果回灌给模型
+    }
+
+    // 达到 maxRounds 仍有 tool_calls 未处理完 → 返回最后一次 content + 历史
+    console.warn(
+      `[LLMClient] chatWithTools hit maxRounds=${maxRounds}, returning last content`,
+    );
+    return ok({ content: lastContent, toolCalls: allToolCalls, rounds });
   }
 
   async askStructured<T>(

--- a/packages/bot/src/llm-client.ts
+++ b/packages/bot/src/llm-client.ts
@@ -47,7 +47,8 @@ interface ArkToolCallWire {
 
 interface ArkMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
-  content: string;
+  /** assistant + tool_calls 时可省略，让严格 provider 接受 null/缺失语义 */
+  content?: string;
   tool_calls?: ArkToolCallWire[];
   tool_call_id?: string;
   name?: string;
@@ -94,9 +95,19 @@ function stripCodeFence(raw: string): string {
 }
 
 function toArkMessage(m: ChatMessage): ArkMessage {
-  const base: ArkMessage = { role: m.role, content: m.content };
-  if (m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0) {
-    base.tool_calls = m.toolCalls.map((tc) => ({
+  // H1/L2: 当 assistant 消息只调工具不说话时，content === ''。
+  // OpenAI / Claude 等严格 provider 期望 content === null（Ark 容忍空串）。
+  // 这里对 assistant 做特殊处理：有 toolCalls + content 为空 → 省略 content；
+  // 其他场景保持 content 字段，避免破坏现有调用。
+  const hasToolCalls = m.role === 'assistant' && !!m.toolCalls && m.toolCalls.length > 0;
+  const omitContent = hasToolCalls && m.content === '';
+
+  const base: ArkMessage = omitContent
+    ? ({ role: m.role } as ArkMessage)
+    : { role: m.role, content: m.content };
+
+  if (hasToolCalls) {
+    base.tool_calls = m.toolCalls!.map((tc) => ({
       id: tc.id,
       type: 'function',
       function: { name: tc.name, arguments: tc.argumentsRaw },
@@ -165,6 +176,9 @@ export class VolcanoLLMClient implements LLMClient {
     });
 
     let lastErr: unknown;
+    // H2: 跨 attempt 跟踪是否出现过 AbortError，否则最后一次非 timeout 错误会
+    // 把"前面其实是 timeout"的信息掩盖成 LLM_INVALID_RESPONSE，影响调用方降级策略
+    let sawTimeout = false;
 
     for (let attempt = 0; attempt < 3; attempt++) {
       const startMs = Date.now();
@@ -212,16 +226,16 @@ export class VolcanoLLMClient implements LLMClient {
       } catch (e) {
         clearTimeout(timer);
         lastErr = e;
+        if (e instanceof Error && e.name === 'AbortError') sawTimeout = true;
         if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
       }
     }
 
-    const isTimeout = lastErr instanceof Error && lastErr.name === 'AbortError';
     return err(
       makeError(
-        isTimeout ? ErrorCode.LLM_TIMEOUT : ErrorCode.LLM_INVALID_RESPONSE,
-        isTimeout
-          ? 'LLM request timed out after 3 attempts'
+        sawTimeout ? ErrorCode.LLM_TIMEOUT : ErrorCode.LLM_INVALID_RESPONSE,
+        sawTimeout
+          ? 'LLM request timed out (at least once) across 3 attempts'
           : 'LLM request failed after 3 attempts',
         lastErr,
       ),
@@ -281,16 +295,19 @@ export class VolcanoLLMClient implements LLMClient {
       }
 
       // 记录 + 把 assistant(toolCalls) 追加到对话历史
+      // H1: 同时返回 content + tool_calls 的情况（"我先查一下天气" + tool_call），
+      // 仅在 content 非空时回填，避免空串混入对话历史
       allToolCalls.push(...toolCalls);
-      conversation.push({
+      const assistantMsg: ArkMessage = {
         role: 'assistant',
-        content,
+        ...(content && { content }),
         tool_calls: toolCalls.map((tc) => ({
           id: tc.id,
           type: 'function',
           function: { name: tc.name, arguments: tc.argumentsRaw },
         })),
-      });
+      };
+      conversation.push(assistantMsg);
 
       // 串行执行 tool（避免 BitableClient QPS 风暴），错误隔离到单条 ToolResult
       for (const call of toolCalls) {

--- a/packages/bot/src/llm-client.ts
+++ b/packages/bot/src/llm-client.ts
@@ -75,6 +75,8 @@ interface ArkRawResult {
   completionTokens: number;
 }
 
+type ArkToolChoice = 'auto' | 'none' | { type: 'function'; function: { name: string } };
+
 // ---------- Constants ----------
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -131,6 +133,12 @@ function logCall(params: {
   );
 }
 
+function toArkToolChoice(toolChoice: AskOptions['toolChoice']): ArkToolChoice {
+  if (toolChoice === undefined || toolChoice === 'auto') return 'auto';
+  if (toolChoice === 'none') return 'none';
+  return { type: 'function', function: { name: toolChoice } };
+}
+
 // ---------- Implementation ----------
 
 export class VolcanoLLMClient implements LLMClient {
@@ -162,17 +170,18 @@ export class VolcanoLLMClient implements LLMClient {
       messages,
       ...(opts.maxTokens !== undefined && { max_tokens: opts.maxTokens }),
       ...(opts.temperature !== undefined && { temperature: opts.temperature }),
-      ...(opts.tools && opts.tools.length > 0 && {
-        tools: opts.tools.map((t) => ({
-          type: 'function',
-          function: {
-            name: t.name,
-            description: t.description,
-            parameters: t.parameters,
-          },
-        })),
-        tool_choice: opts.toolChoice ?? 'auto',
-      }),
+      ...(opts.tools &&
+        opts.tools.length > 0 && {
+          tools: opts.tools.map((t) => ({
+            type: 'function',
+            function: {
+              name: t.name,
+              description: t.description,
+              parameters: t.parameters,
+            },
+          })),
+          tool_choice: toArkToolChoice(opts.toolChoice),
+        }),
     });
 
     let lastErr: unknown;
@@ -267,10 +276,7 @@ export class VolcanoLLMClient implements LLMClient {
   ): Promise<Result<ChatWithToolsResult>> {
     if (!opts.tools || opts.tools.length === 0) {
       return err(
-        makeError(
-          ErrorCode.INVALID_INPUT,
-          'chatWithTools requires opts.tools to be non-empty',
-        ),
+        makeError(ErrorCode.INVALID_INPUT, 'chatWithTools requires opts.tools to be non-empty'),
       );
     }
     const maxRounds = Math.max(1, opts.maxToolCallRounds ?? DEFAULT_MAX_TOOL_CALL_ROUNDS);
@@ -338,9 +344,7 @@ export class VolcanoLLMClient implements LLMClient {
     }
 
     // 达到 maxRounds 仍有 tool_calls 未处理完 → 返回最后一次 content + 历史
-    console.warn(
-      `[LLMClient] chatWithTools hit maxRounds=${maxRounds}, returning last content`,
-    );
+    console.warn(`[LLMClient] chatWithTools hit maxRounds=${maxRounds}, returning last content`);
     return ok({ content: lastContent, toolCalls: allToolCalls, rounds });
   }
 

--- a/packages/bot/src/scripts/smoke-tool-call.ts
+++ b/packages/bot/src/scripts/smoke-tool-call.ts
@@ -1,38 +1,61 @@
 /**
- * smoke-tool-call.ts — 真实调用豆包验证 Function Calling 兼容性
+ * smoke-tool-call.ts — 真实调用豆包验证 chatWithTools（M1）
  *
  * 运行：pnpm --filter @seedhac/bot dev:smoke-tool-call
  *
- * 目标：把 M1（chatWithTools）拿到火山方舟真实环境跑一遍，
- *      确认豆包对 OpenAI tool-call 协议的兼容性。
+ * 设计原则：模拟 M5 真实链路 —— 一条群消息进来，模型需要先用工具去
+ * 检索"项目说明书 / skill 列表"，再决定怎么回。这是 lark-loom Harness
+ * 架构的核心 use case，不用通用 weather demo 糊弄。
  *
- * 验证场景：
- *   1. 单工具调用：模型识别需要调工具 → 我们执行 → 回灌 → 模型给出最终答复
- *   2. 不必要的工具调用：问候类问题，模型应直接回答（无 tool_calls）
- *   3. maxToolCallRounds 上限：人工构造死循环，验证守卫生效
+ * ───────────── 场景 1：完整 Harness 链路 ─────────────
+ *   群消息（用户问技术红线 + 求 ppt）
+ *   → 极简 systemprompt 告诉模型「memory 在哪、skill.md 在哪」
+ *   → 模型自主决定调用 lookup_project_memory + list_skills（最少 2 个工具）
+ *   → 我们回灌真实数据
+ *   → 模型给出最终回复，里面应同时引用「红线」+「下一步建议哪个 skill」
+ *
+ * ───────────── 场景 2：闲聊不调工具 ─────────────
+ *   "1+1 等于几"  → 模型直接回答，不应触发工具
+ *
+ * ───────────── 场景 3：maxToolCallRounds 守卫 ─────────────
+ *   prompt 让模型逐主题查询，maxRounds=2 强制截断
+ *
+ * ───────────── 场景 4：工具执行抛错隔离 ─────────────
+ *   故意让 executor 抛错，验证错误被包成 ToolResult 回灌后
+ *   模型能给出"查询失败"的合理降级回答
  */
 
 import { createLLMClient } from '../llm-client.js';
-import type { LLMTool, ToolCall, ToolResult } from '@seedhac/contracts';
+import type { LLMTool, ToolCall, ToolResult, ChatMessage } from '@seedhac/contracts';
 
 const llm = createLLMClient();
 
 function section(title: string): void {
-  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`\n${'═'.repeat(70)}`);
   console.log(`▶ ${title}`);
-  console.log('─'.repeat(60));
+  console.log('═'.repeat(70));
 }
+
+function divider(): void {
+  console.log('─'.repeat(70));
+}
+
+// ────────────────────────────────────────────────────────────────────
+// 工具定义：模拟 M3 将要实现的 4 个工具中的两个（最关键的两个）
+// ────────────────────────────────────────────────────────────────────
 
 const TOOLS: LLMTool[] = [
   {
     name: 'lookup_project_memory',
-    description: '查询 lark-loom 项目的常驻记忆。比如项目的目标、技术栈、红线。',
+    description:
+      '查询 lark-loom 项目的常驻记忆（项目目标、技术栈、产品红线、术语定义等）。' +
+      '当用户问到项目相关的事实性问题时调用。',
     parameters: {
       type: 'object',
       properties: {
         topic: {
           type: 'string',
-          description: '要查询的主题，例如 "技术栈" / "产品红线" / "项目目标"',
+          description: '主题关键词，例如 "技术栈" / "产品红线" / "项目目标" / "术语"',
         },
       },
       required: ['topic'],
@@ -40,7 +63,8 @@ const TOOLS: LLMTool[] = [
   },
   {
     name: 'list_skills',
-    description: '列出当前机器人可用的所有 skill 及其一句话描述。',
+    description:
+      '列出当前机器人可用的所有 skill 及其触发条件。当需要决定"用户这条消息该走哪个 skill 处理"时调用。',
     parameters: {
       type: 'object',
       properties: {},
@@ -48,37 +72,83 @@ const TOOLS: LLMTool[] = [
   },
 ];
 
-function makeMockExecutor(): (call: ToolCall) => Promise<ToolResult> {
+// ────────────────────────────────────────────────────────────────────
+// 极简 systemprompt（M3 OVERVIEW.md 思路的预演 — 控制在 ~1KB 以内）
+// ────────────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `你是 lark-loom 飞书群聊助手的内部路由 LLM。
+
+【你的工作】
+- 看到群消息后，判断是否需要调用工具检索项目记忆 / skill 列表
+- 闲聊或常识问题 → 直接回答，**不要**乱调工具
+- 涉及项目特定知识（技术栈/红线/术语）→ 调 lookup_project_memory
+- 用户提出明确请求（写文档、做 ppt、归档项目）→ 调 list_skills 看可用 skill
+
+【可用工具】
+- lookup_project_memory(topic): 查项目常驻记忆
+- list_skills(): 列出 skill 及触发方式
+
+【输出格式】
+完成查询后用一段话回复用户：先回答事实，再用一句话推荐下一步（如"建议 @我 触发 slides skill"）。
+不要复述工具返回的原始 JSON。`;
+
+// ────────────────────────────────────────────────────────────────────
+// 真实 executor：返回 lark-loom 项目里有据可查的数据
+// ────────────────────────────────────────────────────────────────────
+
+const PROJECT_MEMORY: Record<string, string> = {
+  技术栈:
+    'Node 20+ / TypeScript 5 / pnpm monorepo / @larksuiteoapi/node-sdk v1.62 / 火山方舟豆包（Lite + Pro）/ 飞书多维表格（结构化记忆）/ ChromaDB（向量检索）',
+  产品红线:
+    '不监听 1v1 私聊；只在群聊响应；不存敏感信息（手机号/密码等）；所有 Lark API 调用必须走 BotRuntime 限流（100 req/min + 5 req/sec）',
+  项目目标:
+    '飞书生态原生的群知识助手 —— 把群聊对话沉淀成结构化项目记忆（多维表格 + 知识图谱），并在合适时机主动召回缺失的上下文',
+  术语:
+    'Skill = 业务能力（qa/recall/summary/slides/archive/weekly）；GapDetector = 信息缺口检测（规则+LLM 两层）；MessageBuffer = 消息批处理（30s 或 10 条触发）',
+};
+
+const PROJECT_SKILLS = [
+  { name: 'qa', description: '群聊问答，需要 @bot，回答群相关问题', trigger: '@bot + 问题' },
+  {
+    name: 'recall',
+    description: '检测信息缺口主动召回历史上下文（产品差异化）',
+    trigger: '出现"那个东西/上次说的"等模糊指代',
+  },
+  { name: 'summary', description: '会议纪要 / 进度更新自动整理', trigger: '群里出现"会议纪要"等关键词' },
+  { name: 'slides', description: 'IM 对话 → 演示文稿（飞书 docx）', trigger: '"做ppt"等关键词' },
+  { name: 'archive', description: '项目全链路归档', trigger: '决赛阶段手动 @触发' },
+  { name: 'weekly', description: '周报自动生成', trigger: 'cron 周一 09:00' },
+];
+
+function makeRealExecutor(opts: { failOn?: string } = {}): (call: ToolCall) => Promise<ToolResult> {
   return async (call) => {
-    console.log(`  [executor] 收到 tool 调用: ${call.name}(${call.argumentsRaw})`);
+    console.log(`  ↳ tool=${call.name} args=${call.argumentsRaw}`);
+
+    if (opts.failOn && call.name === opts.failOn) {
+      throw new Error(`模拟故障：${opts.failOn} 后端不可用`);
+    }
+
     if (call.name === 'lookup_project_memory') {
       const args = JSON.parse(call.argumentsRaw) as { topic: string };
-      const fake: Record<string, string> = {
-        技术栈: 'Node 20 + TypeScript + 飞书 SDK + 火山方舟豆包 + 多维表格 + Chroma',
-        产品红线: '不窃听 1v1、不存敏感信息、所有 API 调用走 BotRuntime 限流',
-        项目目标: '飞书生态原生的群知识助手，把对话沉淀成可检索的项目记忆',
-      };
+      const matchedKey = Object.keys(PROJECT_MEMORY).find(
+        (k) => args.topic.includes(k) || k.includes(args.topic),
+      );
+      const answer = matchedKey ? PROJECT_MEMORY[matchedKey] : '（未找到此主题的记忆）';
       return {
         toolCallId: call.id,
         name: call.name,
-        content: JSON.stringify({
-          topic: args.topic,
-          answer: fake[args.topic] ?? '（未找到此主题的记忆）',
-        }),
+        content: JSON.stringify({ topic: args.topic, matched: matchedKey ?? null, answer }),
       };
     }
+
     if (call.name === 'list_skills') {
       return {
         toolCallId: call.id,
         name: call.name,
-        content: JSON.stringify([
-          { name: 'qa', description: '群聊问答，需要 @bot 触发' },
-          { name: 'recall', description: '检测信息缺口主动召回历史上下文' },
-          { name: 'summary', description: '会议纪要 / 进度更新摘要' },
-          { name: 'slides', description: '把 IM 对话转成演示文稿' },
-        ]),
+        content: JSON.stringify(PROJECT_SKILLS),
       };
     }
+
     return {
       toolCallId: call.id,
       name: call.name,
@@ -87,92 +157,165 @@ function makeMockExecutor(): (call: ToolCall) => Promise<ToolResult> {
   };
 }
 
-// ---------- 场景 1：单工具调用 ----------
+// ────────────────────────────────────────────────────────────────────
+// 场景 1：完整 Harness 链路（最重要的一个验证）
+// ────────────────────────────────────────────────────────────────────
 
-section('场景 1 · 单工具调用 — 模型应该调 lookup_project_memory');
+section('场景 1 · 完整 Harness 链路：群消息触发多工具协作');
+console.log('用户消息：「lark-loom 项目的产品红线是什么？另外我想把今天的讨论做成 ppt，怎么搞？」');
+divider();
 
-const r1 = await llm.chatWithTools(
-  [
-    {
-      role: 'user',
-      content: 'lark-loom 这个项目的产品红线是什么？请用工具查一下再回答。',
-    },
-  ],
+const messages1: ChatMessage[] = [
   {
-    model: 'pro',
-    tools: TOOLS,
-    executor: makeMockExecutor(),
+    role: 'user',
+    content:
+      'lark-loom 项目的产品红线是什么？另外我想把今天的讨论做成 ppt，怎么搞？',
   },
-);
+];
 
-if (r1.ok) {
-  console.log('✅ 成功');
-  console.log(`轮数: ${r1.value.rounds}, 工具调用次数: ${r1.value.toolCalls.length}`);
-  for (const tc of r1.value.toolCalls) {
-    console.log(`  · ${tc.name}(${tc.argumentsRaw})`);
-  }
-  console.log('最终回答:', r1.value.content);
-} else {
+const t1 = Date.now();
+const r1 = await llm.chatWithTools(messages1, {
+  model: 'pro',
+  systemPrompt: SYSTEM_PROMPT,
+  tools: TOOLS,
+  executor: makeRealExecutor(),
+});
+const dur1 = Date.now() - t1;
+
+if (!r1.ok) {
   console.error('❌ 失败:', r1.error);
   process.exit(1);
 }
+console.log(`\n✅ 成功（耗时 ${dur1}ms，${r1.value.rounds} 轮，${r1.value.toolCalls.length} 次 tool 调用）`);
+console.log('工具调用序列:');
+for (const tc of r1.value.toolCalls) {
+  console.log(`  · ${tc.name}(${tc.argumentsRaw})`);
+}
+console.log('\n模型最终回复:');
+console.log(r1.value.content);
 
-// ---------- 场景 2：不必要的工具调用 ----------
+const mentionsRedLine =
+  r1.value.content.includes('1v1') ||
+  r1.value.content.includes('私聊') ||
+  r1.value.content.includes('限流') ||
+  r1.value.content.includes('敏感');
+const mentionsSlides = r1.value.content.includes('slides') || r1.value.content.includes('ppt');
+const usedBothTools =
+  r1.value.toolCalls.some((c) => c.name === 'lookup_project_memory') &&
+  r1.value.toolCalls.some((c) => c.name === 'list_skills');
 
-section('场景 2 · 闲聊 — 模型应该直接回答，不调工具');
+console.log('\n验收:');
+console.log(`  · 调用了两个工具（memory + skills）: ${usedBothTools ? '✅' : '❌'}`);
+console.log(`  · 回复包含产品红线信息: ${mentionsRedLine ? '✅' : '❌'}`);
+console.log(`  · 回复推荐了 slides skill: ${mentionsSlides ? '✅' : '❌'}`);
+if (!usedBothTools || !mentionsRedLine || !mentionsSlides) {
+  console.warn('⚠️  场景 1 验收未全部通过，可能需要调整 systemprompt 或工具描述');
+}
 
+// ────────────────────────────────────────────────────────────────────
+// 场景 2：闲聊不调工具
+// ────────────────────────────────────────────────────────────────────
+
+section('场景 2 · 闲聊：不应触发工具');
+console.log('用户消息：「你好，1+1 等于几？」');
+divider();
+
+const t2 = Date.now();
 const r2 = await llm.chatWithTools(
   [{ role: 'user', content: '你好，1+1 等于几？' }],
   {
     model: 'pro',
+    systemPrompt: SYSTEM_PROMPT,
     tools: TOOLS,
-    executor: makeMockExecutor(),
+    executor: makeRealExecutor(),
   },
 );
+const dur2 = Date.now() - t2;
 
-if (r2.ok) {
-  console.log('✅ 成功');
-  console.log(`轮数: ${r2.value.rounds}, 工具调用次数: ${r2.value.toolCalls.length}`);
-  console.log('最终回答:', r2.value.content);
-  if (r2.value.toolCalls.length > 0) {
-    console.warn('⚠️  注意：模型对闲聊也调了工具，prompt 设计需要优化');
-  }
-} else {
+if (!r2.ok) {
   console.error('❌ 失败:', r2.error);
   process.exit(1);
 }
+console.log(`✅ 成功（耗时 ${dur2}ms，${r2.value.rounds} 轮，${r2.value.toolCalls.length} 次 tool 调用）`);
+console.log('模型回复:', r2.value.content);
+console.log(
+  `\n验收 · 闲聊未调工具: ${r2.value.toolCalls.length === 0 ? '✅' : '⚠️  调了 ' + r2.value.toolCalls.length + ' 次（systemprompt 引导可能过强）'}`,
+);
 
-// ---------- 场景 3：maxToolCallRounds 上限 ----------
+// ────────────────────────────────────────────────────────────────────
+// 场景 3：maxToolCallRounds 守卫
+// ────────────────────────────────────────────────────────────────────
 
-section('场景 3 · maxRounds 守卫 — 让模型多次调工具，验证 3 轮上限');
+section('场景 3 · maxRounds=2 强制截断');
+console.log('用户消息：让模型依次查 4 个主题，但 maxRounds 只给 2');
+divider();
 
+const t3 = Date.now();
 const r3 = await llm.chatWithTools(
   [
     {
       role: 'user',
       content:
-        '请依次查询 项目目标、技术栈、产品红线 三个主题，每次只查一个，每查到一个简短复述一次，全部查完后再总结。',
+        '请依次查询以下 4 个主题的项目记忆，每查到一个简短复述：项目目标、技术栈、产品红线、术语。每次只查一个主题，全部查完再总结。',
     },
   ],
   {
     model: 'pro',
+    systemPrompt: SYSTEM_PROMPT,
     tools: TOOLS,
-    maxToolCallRounds: 3,
-    executor: makeMockExecutor(),
+    maxToolCallRounds: 2,
+    executor: makeRealExecutor(),
   },
 );
+const dur3 = Date.now() - t3;
 
-if (r3.ok) {
-  console.log('✅ 成功');
-  console.log(`轮数: ${r3.value.rounds}（上限 3）, 工具调用次数: ${r3.value.toolCalls.length}`);
-  console.log('最终回答:', r3.value.content.slice(0, 200));
-} else {
+if (!r3.ok) {
   console.error('❌ 失败:', r3.error);
   process.exit(1);
 }
+console.log(`✅ 成功（耗时 ${dur3}ms，${r3.value.rounds} 轮，${r3.value.toolCalls.length} 次 tool 调用）`);
+console.log('模型回复（截断守卫触发后）:', r3.value.content.slice(0, 300));
+console.log(`\n验收 · 轮数 ≤ 2: ${r3.value.rounds <= 2 ? '✅' : '❌'}`);
 
-// ---------- 完成 ----------
+// ────────────────────────────────────────────────────────────────────
+// 场景 4：工具抛错隔离
+// ────────────────────────────────────────────────────────────────────
 
-console.log(`\n${'─'.repeat(60)}`);
+section('场景 4 · 工具 executor 抛错被隔离');
+console.log('用户消息：「项目的术语怎么定义？」（lookup_project_memory 故意抛错）');
+divider();
+
+const t4 = Date.now();
+const r4 = await llm.chatWithTools(
+  [{ role: 'user', content: '项目的术语怎么定义？' }],
+  {
+    model: 'pro',
+    systemPrompt: SYSTEM_PROMPT,
+    tools: TOOLS,
+    executor: makeRealExecutor({ failOn: 'lookup_project_memory' }),
+  },
+);
+const dur4 = Date.now() - t4;
+
+if (!r4.ok) {
+  console.error('❌ 失败:', r4.error);
+  process.exit(1);
+}
+console.log(`✅ 成功（耗时 ${dur4}ms，${r4.value.rounds} 轮，${r4.value.toolCalls.length} 次 tool 调用）`);
+console.log('模型回复:', r4.value.content);
+const handledError =
+  r4.value.content.includes('失败') ||
+  r4.value.content.includes('错误') ||
+  r4.value.content.includes('暂时') ||
+  r4.value.content.includes('不可用') ||
+  r4.value.content.includes('无法');
+console.log(`\n验收 · 模型在错误下给出合理降级回复: ${handledError ? '✅' : '⚠️  未明确说明失败'}`);
+
+// ────────────────────────────────────────────────────────────────────
+// 总结
+// ────────────────────────────────────────────────────────────────────
+
+console.log(`\n${'═'.repeat(70)}`);
 console.log('🎉 chatWithTools 真实 API 验证完成');
-console.log('─'.repeat(60));
+console.log(`总耗时: ${dur1 + dur2 + dur3 + dur4}ms`);
+console.log('═'.repeat(70));

--- a/packages/bot/src/scripts/smoke-tool-call.ts
+++ b/packages/bot/src/scripts/smoke-tool-call.ts
@@ -1,0 +1,178 @@
+/**
+ * smoke-tool-call.ts — 真实调用豆包验证 Function Calling 兼容性
+ *
+ * 运行：pnpm --filter @seedhac/bot dev:smoke-tool-call
+ *
+ * 目标：把 M1（chatWithTools）拿到火山方舟真实环境跑一遍，
+ *      确认豆包对 OpenAI tool-call 协议的兼容性。
+ *
+ * 验证场景：
+ *   1. 单工具调用：模型识别需要调工具 → 我们执行 → 回灌 → 模型给出最终答复
+ *   2. 不必要的工具调用：问候类问题，模型应直接回答（无 tool_calls）
+ *   3. maxToolCallRounds 上限：人工构造死循环，验证守卫生效
+ */
+
+import { createLLMClient } from '../llm-client.js';
+import type { LLMTool, ToolCall, ToolResult } from '@seedhac/contracts';
+
+const llm = createLLMClient();
+
+function section(title: string): void {
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`▶ ${title}`);
+  console.log('─'.repeat(60));
+}
+
+const TOOLS: LLMTool[] = [
+  {
+    name: 'lookup_project_memory',
+    description: '查询 lark-loom 项目的常驻记忆。比如项目的目标、技术栈、红线。',
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: {
+          type: 'string',
+          description: '要查询的主题，例如 "技术栈" / "产品红线" / "项目目标"',
+        },
+      },
+      required: ['topic'],
+    },
+  },
+  {
+    name: 'list_skills',
+    description: '列出当前机器人可用的所有 skill 及其一句话描述。',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  },
+];
+
+function makeMockExecutor(): (call: ToolCall) => Promise<ToolResult> {
+  return async (call) => {
+    console.log(`  [executor] 收到 tool 调用: ${call.name}(${call.argumentsRaw})`);
+    if (call.name === 'lookup_project_memory') {
+      const args = JSON.parse(call.argumentsRaw) as { topic: string };
+      const fake: Record<string, string> = {
+        技术栈: 'Node 20 + TypeScript + 飞书 SDK + 火山方舟豆包 + 多维表格 + Chroma',
+        产品红线: '不窃听 1v1、不存敏感信息、所有 API 调用走 BotRuntime 限流',
+        项目目标: '飞书生态原生的群知识助手，把对话沉淀成可检索的项目记忆',
+      };
+      return {
+        toolCallId: call.id,
+        name: call.name,
+        content: JSON.stringify({
+          topic: args.topic,
+          answer: fake[args.topic] ?? '（未找到此主题的记忆）',
+        }),
+      };
+    }
+    if (call.name === 'list_skills') {
+      return {
+        toolCallId: call.id,
+        name: call.name,
+        content: JSON.stringify([
+          { name: 'qa', description: '群聊问答，需要 @bot 触发' },
+          { name: 'recall', description: '检测信息缺口主动召回历史上下文' },
+          { name: 'summary', description: '会议纪要 / 进度更新摘要' },
+          { name: 'slides', description: '把 IM 对话转成演示文稿' },
+        ]),
+      };
+    }
+    return {
+      toolCallId: call.id,
+      name: call.name,
+      content: JSON.stringify({ error: 'unknown tool' }),
+    };
+  };
+}
+
+// ---------- 场景 1：单工具调用 ----------
+
+section('场景 1 · 单工具调用 — 模型应该调 lookup_project_memory');
+
+const r1 = await llm.chatWithTools(
+  [
+    {
+      role: 'user',
+      content: 'lark-loom 这个项目的产品红线是什么？请用工具查一下再回答。',
+    },
+  ],
+  {
+    model: 'pro',
+    tools: TOOLS,
+    executor: makeMockExecutor(),
+  },
+);
+
+if (r1.ok) {
+  console.log('✅ 成功');
+  console.log(`轮数: ${r1.value.rounds}, 工具调用次数: ${r1.value.toolCalls.length}`);
+  for (const tc of r1.value.toolCalls) {
+    console.log(`  · ${tc.name}(${tc.argumentsRaw})`);
+  }
+  console.log('最终回答:', r1.value.content);
+} else {
+  console.error('❌ 失败:', r1.error);
+  process.exit(1);
+}
+
+// ---------- 场景 2：不必要的工具调用 ----------
+
+section('场景 2 · 闲聊 — 模型应该直接回答，不调工具');
+
+const r2 = await llm.chatWithTools(
+  [{ role: 'user', content: '你好，1+1 等于几？' }],
+  {
+    model: 'pro',
+    tools: TOOLS,
+    executor: makeMockExecutor(),
+  },
+);
+
+if (r2.ok) {
+  console.log('✅ 成功');
+  console.log(`轮数: ${r2.value.rounds}, 工具调用次数: ${r2.value.toolCalls.length}`);
+  console.log('最终回答:', r2.value.content);
+  if (r2.value.toolCalls.length > 0) {
+    console.warn('⚠️  注意：模型对闲聊也调了工具，prompt 设计需要优化');
+  }
+} else {
+  console.error('❌ 失败:', r2.error);
+  process.exit(1);
+}
+
+// ---------- 场景 3：maxToolCallRounds 上限 ----------
+
+section('场景 3 · maxRounds 守卫 — 让模型多次调工具，验证 3 轮上限');
+
+const r3 = await llm.chatWithTools(
+  [
+    {
+      role: 'user',
+      content:
+        '请依次查询 项目目标、技术栈、产品红线 三个主题，每次只查一个，每查到一个简短复述一次，全部查完后再总结。',
+    },
+  ],
+  {
+    model: 'pro',
+    tools: TOOLS,
+    maxToolCallRounds: 3,
+    executor: makeMockExecutor(),
+  },
+);
+
+if (r3.ok) {
+  console.log('✅ 成功');
+  console.log(`轮数: ${r3.value.rounds}（上限 3）, 工具调用次数: ${r3.value.toolCalls.length}`);
+  console.log('最终回答:', r3.value.content.slice(0, 200));
+} else {
+  console.error('❌ 失败:', r3.error);
+  process.exit(1);
+}
+
+// ---------- 完成 ----------
+
+console.log(`\n${'─'.repeat(60)}`);
+console.log('🎉 chatWithTools 真实 API 验证完成');
+console.log('─'.repeat(60));

--- a/packages/contracts/src/llm.ts
+++ b/packages/contracts/src/llm.ts
@@ -12,7 +12,39 @@ import type { Result } from './result.js';
 export type LLMModel = 'lite' | 'pro';
 
 export interface ChatMessage {
-  readonly role: 'system' | 'user' | 'assistant';
+  readonly role: 'system' | 'user' | 'assistant' | 'tool';
+  readonly content: string;
+  /** 仅当 role === 'assistant' 时可能存在：模型本轮发起的 tool 调用 */
+  readonly toolCalls?: readonly ToolCall[];
+  /** 仅当 role === 'tool' 时存在：对应的 ToolCall.id */
+  readonly toolCallId?: string;
+  /** 仅当 role === 'tool' 时存在：被调用的工具名（便于日志/审计） */
+  readonly name?: string;
+}
+
+/**
+ * OpenAI / 火山方舟兼容的工具描述。
+ * parameters 用 JSON Schema（最常见子集即可：type/properties/required）。
+ */
+export interface LLMTool {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: Record<string, unknown>;
+}
+
+/** 模型一次工具调用请求 */
+export interface ToolCall {
+  readonly id: string;
+  readonly name: string;
+  /** 模型给出的原始参数字符串（通常是 JSON），调用方负责 parse + 校验 */
+  readonly argumentsRaw: string;
+}
+
+/** 调用方执行 tool 后回传给模型的结果 */
+export interface ToolResult {
+  readonly toolCallId: string;
+  readonly name: string;
+  /** 工具执行结果（字符串）。失败也返回字符串说明，让模型自行处理 */
   readonly content: string;
 }
 
@@ -22,6 +54,32 @@ export interface AskOptions {
   readonly temperature?: number;
   readonly systemPrompt?: string;
   readonly timeoutMs?: number;
+  /** 可选：声明模型可调用的工具列表（function calling） */
+  readonly tools?: readonly LLMTool[];
+  /** 可选：'auto'（默认）/ 'none' / 具体工具名 */
+  readonly toolChoice?: 'auto' | 'none' | string;
+}
+
+/** chatWithTools 的最终输出 */
+export interface ChatWithToolsResult {
+  /** 模型最终给用户的文本（可能为空：模型只调工具不说话的极端情况） */
+  readonly content: string;
+  /** 中途所有 tool 调用记录（顺序），便于日志与审计 */
+  readonly toolCalls: readonly ToolCall[];
+  /** 实际经过的轮数（含初始 + 每次 tool 回灌） */
+  readonly rounds: number;
+}
+
+/** chatWithTools 的运行参数 */
+export interface ChatWithToolsOptions extends AskOptions {
+  /** 单次调用允许的最大 tool-call 轮数。默认 5 */
+  readonly maxToolCallRounds?: number;
+  /**
+   * 工具执行器：把 ToolCall 转成 ToolResult。
+   * 抛错或拒绝时也应返回带 content 的 ToolResult（建议格式：JSON.stringify({ error: '...' })），
+   * 由模型决定是否重试或换工具。
+   */
+  readonly executor: (call: ToolCall) => Promise<ToolResult>;
 }
 
 /**
@@ -50,4 +108,17 @@ export interface LLMClient {
    *   4. 失败重试 N 次后返回 LLM_INVALID_RESPONSE
    */
   askStructured<T>(prompt: string, schema: SchemaLike<T>, opts?: AskOptions): Promise<Result<T>>;
+
+  /**
+   * 多轮对话 + Function Calling（OpenAI 兼容协议）。
+   * 模型若返回 tool_calls：
+   *   1. 调用方通过 opts.executor 逐个执行 → ToolResult
+   *   2. 把 assistant(toolCalls) + tool(results) 追加到消息历史回灌模型
+   *   3. 重复直到模型不再请求工具，或达到 maxToolCallRounds（默认 5）
+   * 达到上限仍未收敛时返回最后一次 content + 所有 toolCalls，调用方决定如何处理。
+   */
+  chatWithTools(
+    messages: readonly ChatMessage[],
+    opts: ChatWithToolsOptions,
+  ): Promise<Result<ChatWithToolsResult>>;
 }

--- a/packages/contracts/src/llm.ts
+++ b/packages/contracts/src/llm.ts
@@ -56,7 +56,11 @@ export interface AskOptions {
   readonly timeoutMs?: number;
   /** 可选：声明模型可调用的工具列表（function calling） */
   readonly tools?: readonly LLMTool[];
-  /** 可选：'auto'（默认）/ 'none' / 具体工具名 */
+  /**
+   * 可选：'auto'（默认，模型自决）/ 'none'（强制不调工具）/ 具体工具名（强制调指定工具）。
+   * 注：联合中的 string 表达"具体工具名"，类型层面无法收窄字面量；
+   * 实现按 OpenAI 协议透传，string 视为工具名。
+   */
   readonly toolChoice?: 'auto' | 'none' | string;
 }
 


### PR DESCRIPTION
## 背景

Harness 风格 memory 系统的 **blocker** —— 模型按需用 tool 检索记忆/skill 说明书，前提是 LLMClient 支持 OpenAI 兼容的 Function Calling。当前 `VolcanoLLMClient` 只有纯文本 chat，本 PR 把这道门打开。

跟 epic #72 + issue #66 对齐。

## 改了什么

### contracts
- `LLMTool` / `ToolCall` / `ToolResult` / `ChatWithToolsOptions` / `ChatWithToolsResult` 类型
- `ChatMessage` 扩展 tool/assistant 字段（toolCalls / toolCallId / name）
- `LLMClient` 接口新增 `chatWithTools(messages, opts)`

### bot/llm-client
- `VolcanoLLMClient.chatWithTools` 实现：
  - tools + tool_choice 字段透传给 Ark API
  - 模型返回 tool_calls → executor 串行执行 → 结果回灌为 tool message → 继续直到收敛
  - **maxToolCallRounds 守卫**（默认 5）防死循环
  - **executor 抛错隔离**：异常包成 ToolResult 喂给模型，调用不崩
- `chat()` 改用统一的 `toArkMessage` helper，新字段不丢

### 测试
- 6 个新单测覆盖：空 tools 拒绝 / 单工具往返 / tool_choice 透传 / maxRounds 守卫 / executor 错误隔离 / 并行 tool_calls
- 真豆包 smoke `pnpm dev:smoke-tool-call`：4 个 lark-loom 实战场景 4/4 通过

## 真 API 验收（已跑）

| 场景 | 结果 |
|---|---|
| 完整 Harness 链路：群消息触发 `lookup_project_memory` + `list_skills` 协作 | ✅ 模型自主调对工具 + 回复同时引用红线和推荐 slides skill |
| 闲聊（"1+1=?"）不应调工具 | ✅ 0 次工具调用，直接回答 |
| maxRounds=2 强制截断 | ✅ 守卫触发，rounds=2 |
| executor 抛错隔离 | ✅ 模型回"后端暂时不可用，稍后再试" |

总耗时 ~48 秒，token 消耗约 5K。**结论：豆包 Pro 完全兼容 OpenAI Function Calling 协议**，M3-M5 可以放心基于这套机制设计。

## 测试范围

- `vitest run llm-client` 18/18 通过
- 全包 `vitest run`：147/148 通过（1 个 wiring.test.ts 的 qaSkill 失败是 main 上 PR #65 合并带来的 pre-existing issue，与本 PR 无关）

## 不做的事

- 具体 memory/skill tool handler → M3 (#68)
- 业务接入主循环 → M5 (#70)

## Test plan

- [x] 单元测试（mock fetch）全过
- [x] 真豆包 smoke 4 场景全通过
- [ ] reviewer 复跑 `pnpm --filter @seedhac/bot dev:smoke-tool-call`（可选）

🤖 Generated with [Claude Code](https://claude.com/claude-code)