### PR TITLE
fix(slides): bot-owned slides + per-member permission grant

### DIFF
--- a/packages/bot/src/__tests__/bot-runtime.test.ts
+++ b/packages/bot/src/__tests__/bot-runtime.test.ts
@@ -8,6 +8,7 @@ const mockMessageCreate = vi.fn();
 const mockMessageReply = vi.fn();
 const mockMessagePatch = vi.fn();
 const mockMessageList = vi.fn();
+const mockChatMembersGet = vi.fn();
 const mockWsStart = vi.fn();
 const mockWsClose = vi.fn();
 const mockRegister = vi.fn();
@@ -25,6 +26,11 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
             reply: mockMessageReply,
             patch: mockMessagePatch,
             list: mockMessageList,
+          },
+          v1: {
+            chatMembers: {
+              get: mockChatMembersGet,
+            },
           },
         },
       };
@@ -160,6 +166,35 @@ describe('LarkBotRuntime', () => {
       expect(result.value.messages[0]!.text).toBe('历史消息');
       expect(result.value.hasMore).toBe(false);
     }
+  });
+
+  it('fetchMembers returns mapped chat members', async () => {
+    mockChatMembersGet.mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          { member_id: 'ou_1', name: '张三' },
+          { member_id: 'ou_2', name: '李四' },
+        ],
+      },
+    });
+
+    const runtime = makeRuntime();
+    const result = await runtime.fetchMembers({ chatId: 'oc_chat1' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.members).toEqual([
+        { userId: 'ou_1', name: '张三' },
+        { userId: 'ou_2', name: '李四' },
+      ]);
+    }
+    expect(mockChatMembersGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { chat_id: 'oc_chat1' },
+        params: expect.objectContaining({ member_id_type: 'open_id' }),
+      }),
+    );
   });
 
   // 5. SDK 报错 → sendText 返回 err，不抛异常

--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -148,6 +148,19 @@ describe('slides card', () => {
     expect(j).toContain('市场机会');
     expect(j).toContain('打开演示文稿');
   });
+
+  it('renders loading state', () => {
+    const card = larkCardBuilder.build('slides', {
+      title: '文件生成中…',
+      presentationUrl: '',
+      pageCount: 0,
+      isLoading: true,
+    });
+    const j = json(card);
+    expect(noPlaceholders(j)).toBe(true);
+    expect(j).toContain('演示文稿生成中');
+    expect(j).toContain('正在生成演示文稿和汇报分工文稿');
+  });
 });
 
 describe('archive card', () => {

--- a/packages/bot/src/__tests__/skill-router.test.ts
+++ b/packages/bot/src/__tests__/skill-router.test.ts
@@ -181,16 +181,16 @@ describe('slides', () => {
     expect(router.route(plain('下周要做PPT汇报'))).toBe('slides');
   });
 
-  it('pos: "幻灯片" → slides', () => {
-    expect(router.route(plain('幻灯片初稿出来了'))).toBe('slides');
+  it('pos: "帮忙整理幻灯片" → slides', () => {
+    expect(router.route(plain('帮忙整理一下幻灯片初稿'))).toBe('slides');
   });
 
   it('pos: "向上级汇报" → slides', () => {
     expect(router.route(plain('我们需要向上级汇报项目进展'))).toBe('slides');
   });
 
-  it('pos: "演示文稿" → slides', () => {
-    expect(router.route(plain('演示文稿风格参考上次的'))).toBe('slides');
+  it('pos: "生成演示文稿" → slides', () => {
+    expect(router.route(plain('根据项目进展生成演示文稿'))).toBe('slides');
   });
 
   it('neg: 含需求关键词 → requirementDoc 优先级低，slides 先命中 → slides', () => {
@@ -199,6 +199,13 @@ describe('slides', () => {
 
   it('neg: 普通消息 → silent', () => {
     expect(router.route(plain('今天下午有时间吗'))).toBe('silent');
+  });
+
+  it('neg: merely discussing ppt does not trigger slides', () => {
+    expect(router.route(plain('这个ppt怎么样'))).toBe('silent');
+    expect(router.route(plain('这个 ppt 风格太丑了'))).toBe('silent');
+    expect(router.route(plain('上次 PPT 放哪了'))).toBe('silent');
+    expect(router.route(plain('我们先别做 ppt'))).toBe('silent');
   });
 });
 

--- a/packages/bot/src/__tests__/slides-client.test.ts
+++ b/packages/bot/src/__tests__/slides-client.test.ts
@@ -4,9 +4,17 @@ import { LarkSlidesClient } from '../slides-client.js';
 
 const OUTLINE = {
   title: '项目进展汇报',
+  subtitle: '基于 IM 的办公协同智能助手',
   slides: [
-    { heading: '项目背景', bullets: ['提升协作效率', '覆盖核心流程'] },
-    { heading: '下一步计划', bullets: ['上线演示', '收集反馈'] },
+    { type: 'cover' as const, title: '项目进展汇报', subtitle: '基于 IM 的办公协同智能助手' },
+    {
+      type: 'overview' as const,
+      title: '项目进展',
+      cards: [
+        { title: '协作效率', value: '提升', detail: '覆盖核心流程' },
+        { title: '上线演示', value: '下一步', detail: '收集反馈' },
+      ],
+    },
   ],
 };
 
@@ -53,7 +61,11 @@ describe('LarkSlidesClient', () => {
     expect(slidesJson).toBeDefined();
     if (!slidesJson) throw new Error('missing --slides argument');
     expect(JSON.parse(slidesJson)).toHaveLength(2);
-    expect(slidesJson).toContain('项目背景');
+    expect(slidesJson).toContain('type=\\"text\\"');
+    expect(slidesJson).toContain('项目进展汇报');
+    expect(slidesJson).toContain('协作效率');
+    expect(slidesJson).not.toContain('type=\\"image\\"');
+    expect(slidesJson).not.toContain('<img');
     expect(slidesJson).toContain('height=\\"540\\"');
     expect(slidesJson).not.toContain('height=\\"720\\"');
   });
@@ -103,7 +115,10 @@ describe('LarkSlidesClient', () => {
   it('returns INVALID_INPUT when the outline has no slides', async () => {
     const execFile = vi.fn();
     const slidesClient = new LarkSlidesClient({ execFile });
-    const result = await slidesClient.createFromOutline('空演示文稿', { title: '空演示文稿', slides: [] });
+    const result = await slidesClient.createFromOutline('空演示文稿', {
+      title: '空演示文稿',
+      slides: [],
+    });
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.INVALID_INPUT);
@@ -120,5 +135,64 @@ describe('LarkSlidesClient', () => {
       expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
       expect(result.error.message).toContain('keychain not initialized');
     }
+  });
+
+  it('grants slides edit permission to each member via lark-cli user identity', async () => {
+    const execFile = vi
+      .fn()
+      .mockResolvedValue({ stdout: JSON.stringify({ ok: true }), stderr: '' });
+    const slidesClient = new LarkSlidesClient({ bin: 'lark-cli', as: 'user', execFile });
+
+    const result = await slidesClient.grantMembersEdit('sldcn123', ['ou_user_001', 'ou_user_002']);
+
+    expect(result.ok).toBe(true);
+    expect(execFile).toHaveBeenCalledTimes(2);
+    expect(execFile).toHaveBeenNthCalledWith(
+      1,
+      'lark-cli',
+      [
+        'drive',
+        'permission.members',
+        'create',
+        '--as',
+        'user',
+        '--params',
+        JSON.stringify({ token: 'sldcn123', type: 'slides', need_notification: false }),
+        '--data',
+        JSON.stringify({
+          member_type: 'openid',
+          member_id: 'ou_user_001',
+          perm: 'edit',
+        }),
+        '--yes',
+      ],
+      expect.objectContaining({ maxBuffer: expect.any(Number) }),
+    );
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      'lark-cli',
+      expect.arrayContaining(['--data', expect.stringContaining('ou_user_002')]),
+      expect.objectContaining({ maxBuffer: expect.any(Number) }),
+    );
+  });
+
+  it('returns FEISHU_API_ERROR when lark-cli reports ok=false on grant', async () => {
+    const execFile = vi
+      .fn()
+      .mockResolvedValue({ stdout: JSON.stringify({ ok: false, error: 'denied' }), stderr: '' });
+    const slidesClient = new LarkSlidesClient({ bin: 'lark-cli', as: 'user', execFile });
+
+    const result = await slidesClient.grantMembersEdit('sldcn123', ['ou_user_001']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
+  });
+
+  it('skips lark-cli call when userIds is empty', async () => {
+    const execFile = vi.fn();
+    const slidesClient = new LarkSlidesClient({ execFile });
+    const result = await slidesClient.grantMembersEdit('sldcn123', []);
+    expect(result.ok).toBe(true);
+    expect(execFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -10,6 +10,8 @@ import {
   type PatchCardParams,
   type FetchHistoryParams,
   type FetchHistoryResult,
+  type FetchMembersParams,
+  type FetchMembersResult,
   type Message,
   type Mention,
   type UserRef,
@@ -425,6 +427,30 @@ export class LarkBotRuntime implements BotRuntime {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchHistory error: ${msg}`, e));
+    }
+  }
+
+  async fetchMembers(params: FetchMembersParams): Promise<Result<FetchMembersResult>> {
+    await this.limiter.acquire();
+    try {
+      const res = await this.client.im.v1.chatMembers.get({
+        path: { chat_id: params.chatId },
+        params: { member_id_type: 'open_id', page_size: 100 },
+      });
+
+      if (res.code !== 0) {
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchMembers failed: ${res.msg}`));
+      }
+
+      return ok({
+        members: (res.data?.items ?? []).map((item) => ({
+          userId: item.member_id ?? '',
+          name: item.name ?? item.member_id ?? '未知成员',
+        })),
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchMembers error: ${msg}`, e));
     }
   }
 }

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -442,8 +442,17 @@ export class LarkBotRuntime implements BotRuntime {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchMembers failed: ${res.msg}`));
       }
 
+      // 当前实现不分页：>100 人的群只返回前 100 个，下游授权/分工会静默截断。
+      // 这里至少把信号暴露出来，调用方按需决定是否提示用户。后续 follow-up：分页循环。
+      const items = res.data?.items ?? [];
+      if (res.data?.has_more) {
+        console.warn(
+          `[bot-runtime] fetchMembers: chat ${params.chatId} has more than 100 members, only the first ${items.length} are returned`,
+        );
+      }
+
       return ok({
-        members: (res.data?.items ?? []).map((item) => ({
+        members: items.map((item) => ({
           userId: item.member_id ?? '',
           name: item.name ?? item.member_id ?? '未知成员',
         })),

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -269,6 +269,28 @@ function buildSummary(input: SummaryCardInput): Card {
  * UI：页数 + 每页标题 + bullet 预览，唯一主按钮
  */
 function buildSlides(input: SlidesCardInput): Card {
+  if (input.isLoading) {
+    return card('slides', {
+      schema: '2.0',
+      header: { title: pt('演示文稿生成中'), template: 'orange' },
+      body: {
+        elements: [
+          md(`**${input.title}**\n正在生成演示文稿和汇报分工文稿，请稍等片刻。`),
+        ],
+      },
+    });
+  }
+
+  if (input.errorMessage) {
+    return card('slides', {
+      schema: '2.0',
+      header: { title: pt('演示文稿生成失败'), template: 'red' },
+      body: {
+        elements: [md(`**${input.title}**\n${input.errorMessage}`)],
+      },
+    });
+  }
+
   const elements: BodyElement[] = [md(`**${input.title}**\n共 ${input.pageCount} 页`), hr()];
   if (input.preview?.length) {
     const previewMd = input.preview

--- a/packages/bot/src/docx-client.ts
+++ b/packages/bot/src/docx-client.ts
@@ -103,6 +103,25 @@ export class LarkDocxClient implements DocxClient {
     }
   }
 
+  async grantMembersEdit(token: string, type: 'docx' | 'slides', userIds: readonly string[]): Promise<Result<void>> {
+    for (const memberId of userIds) {
+      try {
+        const res = await (this.client.drive.v1.permissionMember as any).create({
+          path: { token },
+          params: { type, need_notification: false },
+          data: { member_type: 'openid', member_id: memberId, perm: 'edit' },
+        });
+        if (res.code !== 0) {
+          return err(makeError(ErrorCode.FEISHU_API_ERROR, `grantMembersEdit failed for ${memberId}: ${res.msg}`));
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return err(makeError(ErrorCode.FEISHU_API_ERROR, `grantMembersEdit error: ${msg}`, e));
+      }
+    }
+    return ok(undefined);
+  }
+
   private async readDocxRawContent(token: string): Promise<Result<string>> {
     try {
       const res = await (

--- a/packages/bot/src/scripts/smoke-bot-runtime.ts
+++ b/packages/bot/src/scripts/smoke-bot-runtime.ts
@@ -14,7 +14,8 @@
  */
 
 import { createBotRuntime } from '../bot-runtime.js';
-import type { Message, Card } from '@seedhac/contracts';
+import { larkCardBuilder } from '../card-builder.js';
+import type { Message } from '@seedhac/contracts';
 
 const runtime = createBotRuntime();
 
@@ -91,23 +92,29 @@ if (!historyResult.ok) {
   console.log('hasMore:', historyResult.value.hasMore);
 }
 
-// ─── 场景 5：sendCard ─────────────────────────────────────────────────────────
+// ─── 场景 5：fetchMembers ─────────────────────────────────────────────────────
 
-section('场景 5 · sendCard — 发送卡片消息');
+section('场景 5 · fetchMembers — 拉取群成员列表');
 
-const card = {
-  config: { wide_screen_mode: true },
-  header: {
-    title: { tag: 'plain_text', content: 'smoke test · BotRuntime' },
-    template: 'green',
-  },
-  elements: [
-    {
-      tag: 'div',
-      text: { tag: 'lark_md', content: '**BotRuntime.sendCard()** 验证通过 ✅\n\n所有场景均已完成。' },
-    },
-  ],
-} as unknown as Card;
+const membersResult = await runtime.fetchMembers({ chatId: firstMessage.chatId });
+
+if (!membersResult.ok) {
+  console.error('❌ fetchMembers 失败:', membersResult.error);
+  console.error('   可能缺少权限: im:chat:readonly 或 im:chat.member:read');
+} else {
+  console.log('✅ 成功，共', membersResult.value.members.length, '位成员:');
+  for (const m of membersResult.value.members) {
+    console.log(`  userId=${m.userId}  name=${m.name}`);
+  }
+}
+
+// ─── 场景 6：sendCard ─────────────────────────────────────────────────────────
+
+section('场景 6 · sendCard — 发送卡片消息');
+
+const card = larkCardBuilder.build('activation', {
+  chatName: 'smoke test · BotRuntime.sendCard() 验证通过 ✅',
+});
 
 const cardResult = await runtime.sendCard({
   chatId: firstMessage.chatId,

--- a/packages/bot/src/scripts/smoke-cards.ts
+++ b/packages/bot/src/scripts/smoke-cards.ts
@@ -113,7 +113,18 @@ async function main(): Promise<void> {
   await sleep(800);
 
   await send(
-    '6/10 slides — 演示文稿',
+    '6a/10 slides — loading 状态',
+    larkCardBuilder.build('slides', {
+      title: '文件生成中…',
+      presentationUrl: '',
+      pageCount: 0,
+      isLoading: true,
+    }).content,
+  );
+  await sleep(800);
+
+  await send(
+    '6b/10 slides — 演示文稿（最终）',
     larkCardBuilder.build('slides', {
       title: '业务探索方向汇报',
       presentationUrl: 'https://example.feishu.cn/slides/demo',
@@ -124,6 +135,17 @@ async function main(): Promise<void> {
         { title: '技术实现', bullets: ['飞书 Card 2.0', '7 条 Skill 主线'] },
         { title: '下一步', bullets: ['MVP 上线', '用户反馈'] },
       ],
+    }).content,
+  );
+  await sleep(800);
+
+  await send(
+    '6c/10 slides — 错误状态',
+    larkCardBuilder.build('slides', {
+      title: '业务探索方向汇报 — 汇报分工',
+      presentationUrl: '',
+      pageCount: 0,
+      errorMessage: '文件生成失败：飞书 API 返回 403',
     }).content,
   );
   await sleep(800);

--- a/packages/bot/src/skill-router.ts
+++ b/packages/bot/src/skill-router.ts
@@ -29,7 +29,19 @@ interface RouteRule {
   /** 与 contracts/Skill.trigger.requireMention 同名，语义一致：是否要求 @bot */
   readonly requireMention: boolean;
   readonly patterns: readonly RegExp[];
+  readonly excludePatterns?: readonly RegExp[];
 }
+
+const SLIDES_NEGATION_PATTERNS: readonly RegExp[] = [
+  /(?:先别|别|不要|不用|无需|不需要|暂时不).{0,12}(?:ppt|幻灯片|演示文稿|演示|汇报)/i,
+];
+
+const SLIDES_REQUEST_PATTERNS: readonly RegExp[] = [
+  /向上级汇报|给老板汇报|做.{0,10}汇报|准备.{0,10}汇报|整理.{0,10}汇报/,
+  /给老板做.{0,4}演示|做.{0,4}演示/,
+  /(?:帮|请|需要|要|得|麻烦|可以|能不能|生成|创建|做|准备|整理|产出|写|弄|交).{0,12}(?:ppt|幻灯片|演示文稿)/i,
+  /(?:ppt|幻灯片|演示文稿).{0,12}(?:生成|创建|做|准备|整理|产出|写|弄|交|汇报|给老板|给.*看)/i,
+];
 
 /** 规则表，按优先级从高到低排列 */
 const RULES: readonly RouteRule[] = [
@@ -100,7 +112,8 @@ const RULES: readonly RouteRule[] = [
   {
     intent: 'slides',
     requireMention: false,
-    patterns: [/ppt/i, /幻灯片/, /演示文稿/, /向上级汇报/, /给老板汇报/, /做个演示/],
+    patterns: SLIDES_REQUEST_PATTERNS,
+    excludePatterns: SLIDES_NEGATION_PATTERNS,
   },
 
   // ── requirementDoc：项目需求/资料（被动，最宽泛放最后）──────────
@@ -147,6 +160,7 @@ export class SkillRouter {
 
     for (const rule of RULES) {
       if (rule.requireMention && !mentioned) continue;
+      if (rule.excludePatterns?.some((p) => p.test(text))) continue;
       if (rule.patterns.some((p) => p.test(text))) {
         return rule.intent;
       }

--- a/packages/bot/src/slides-client.ts
+++ b/packages/bot/src/slides-client.ts
@@ -6,6 +6,7 @@ import {
   makeError,
   ok,
   type Result,
+  type SlideCard,
   type SlidesClient,
   type SlidesOutline,
   type SlidesRef,
@@ -15,7 +16,7 @@ type ExecFileResult = { stdout: string; stderr: string };
 type ExecFile = (
   file: string,
   args: readonly string[],
-  options?: { maxBuffer?: number },
+  options?: { cwd?: string; maxBuffer?: number },
 ) => Promise<ExecFileResult>;
 
 const execFile = promisify(execFileCallback) as ExecFile;
@@ -35,7 +36,10 @@ export class LarkSlidesClient implements SlidesClient {
 
   constructor(options: LarkSlidesClientOptions = {}) {
     this.bin = options.bin ?? 'lark-cli';
-    this.as = options.as ?? 'user';
+    // 默认用 bot 身份：bot 创建 = bot owns，可直接给团队成员授权，
+    // 无需任何人登录 lark-cli 也无需补 user OAuth scope。lark-cli 在
+    // bot 模式下还会自动把当前 cli 登录用户加为 full_access。
+    this.as = options.as ?? 'bot';
     this.baseUrl = options.baseUrl ?? 'https://feishu.cn';
     this.execFile = options.execFile ?? execFile;
   }
@@ -43,7 +47,9 @@ export class LarkSlidesClient implements SlidesClient {
   async createFromOutline(title: string, outline: SlidesOutline): Promise<Result<SlidesRef>> {
     const slides = outline.slides.map((slide, index) => renderSlideXml(slide, index));
     if (!slides.length) {
-      return err(makeError(ErrorCode.INVALID_INPUT, 'slides outline must contain at least one page'));
+      return err(
+        makeError(ErrorCode.INVALID_INPUT, 'slides outline must contain at least one page'),
+      );
     }
 
     try {
@@ -77,35 +83,251 @@ export class LarkSlidesClient implements SlidesClient {
       return ok(ref);
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      return err(makeError(ErrorCode.FEISHU_API_ERROR, `lark-cli slides +create failed: ${message}`));
+      return err(
+        makeError(ErrorCode.FEISHU_API_ERROR, `lark-cli slides +create failed: ${message}`),
+      );
     }
+  }
+
+  async grantMembersEdit(slidesToken: string, userIds: readonly string[]): Promise<Result<void>> {
+    if (userIds.length === 0) return ok(undefined);
+
+    for (const userId of userIds) {
+      try {
+        const { stdout, stderr } = await this.execFile(
+          this.bin,
+          [
+            'drive',
+            'permission.members',
+            'create',
+            '--as',
+            this.as,
+            '--params',
+            JSON.stringify({
+              token: slidesToken,
+              type: 'slides',
+              need_notification: false,
+            }),
+            '--data',
+            JSON.stringify({
+              member_type: 'openid',
+              member_id: userId,
+              perm: 'edit',
+            }),
+            '--yes',
+          ],
+          { maxBuffer: 1024 * 1024 },
+        );
+
+        const parsed = parseJsonOutput(stdout);
+        if (parsed && typeof parsed === 'object') {
+          const record = parsed as Record<string, unknown>;
+          if (record['ok'] === false || (typeof record['code'] === 'number' && record['code'] !== 0)) {
+            return err(
+              makeError(
+                ErrorCode.FEISHU_API_ERROR,
+                `lark-cli drive permission.members create failed for ${userId}`,
+                undefined,
+                { stdout, stderr },
+              ),
+            );
+          }
+        }
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        return err(
+          makeError(
+            ErrorCode.FEISHU_API_ERROR,
+            `grant slides member permission failed for ${userId}: ${message}`,
+          ),
+        );
+      }
+    }
+
+    return ok(undefined);
   }
 }
 
-function renderSlideXml(slide: SlidesOutline['slides'][number], index: number): string {
-  const bgColor = index % 2 === 0 ? 'rgb(246,248,250)' : 'rgb(255,250,240)';
-  const accentColor = index % 2 === 0 ? 'rgb(37,99,235)' : 'rgb(217,119,6)';
-  const bullets = slide.bullets
-    .slice(0, 5)
-    .map((bullet) => `<li><p>${escapeXml(bullet)}</p></li>`)
-    .join('');
-  const notes = slide.notes
-    ? `<shape type="text" topLeftX="80" topLeftY="465" width="820" height="44"><content textType="caption"><p>${escapeXml(slide.notes)}</p></content></shape>`
-    : '';
+const THEME = {
+  ink: 'rgb(17,24,39)',
+  slate: 'rgb(71,85,105)',
+  muted: 'rgb(100,116,139)',
+  line: 'rgb(215,222,232)',
+  paper: 'rgb(251,252,255)',
+  blue: 'rgb(36,91,255)',
+  green: 'rgb(22,163,74)',
+  amber: 'rgb(217,119,6)',
+  red: 'rgb(220,38,38)',
+  softBlue: 'rgb(238,244,255)',
+  softGreen: 'rgb(236,253,245)',
+  softAmber: 'rgb(255,247,237)',
+  softRed: 'rgb(255,241,242)',
+  white: 'rgb(255,255,255)',
+} as const;
 
+function renderSlideXml(slide: SlidesOutline['slides'][number], index: number): string {
   return [
     '<slide xmlns="http://www.larkoffice.com/sml/2.0">',
-    '<style>',
-    `<fill><fillColor color="${bgColor}"/></fill>`,
-    '</style>',
+    `<style><fill><fillColor color="${THEME.paper}"/></fill></style>`,
     '<data>',
-    `<shape type="rect" topLeftX="0" topLeftY="0" width="18" height="540"><style><fill><fillColor color="${accentColor}"/></fill></style></shape>`,
-    `<shape type="text" topLeftX="80" topLeftY="52" width="820" height="86"><content textType="title"><p>${escapeXml(slide.heading)}</p></content></shape>`,
-    `<shape type="text" topLeftX="86" topLeftY="170" width="800" height="260"><content textType="body"><ul>${bullets}</ul></content></shape>`,
-    notes,
+    ...renderNativeShapes(slide, index),
     '</data>',
     '</slide>',
   ].join('');
+}
+
+function renderNativeShapes(slide: SlidesOutline['slides'][number], index: number): string[] {
+  const accent = accentForSlide(slide.type);
+  const shapes = [
+    rect(0, 0, 960, 540, THEME.paper),
+    rect(0, 0, 18, 540, accent),
+    rect(72, 52, 96, 8, accent),
+    text(slide.title, 72, 78, 760, 76, 'title'),
+    text(`第 ${index + 1} 页`, 836, 56, 72, 30, 'caption'),
+  ];
+
+  if (slide.type === 'cover') {
+    return [
+      ...shapes,
+      text(slide.subtitle ?? slide.bullets?.[0] ?? '项目阶段性进展汇报', 76, 190, 720, 58, 'body'),
+      rect(72, 308, 760, 2, THEME.line),
+      text('Agent-Pilot Office Copilot', 76, 350, 520, 38, 'caption'),
+    ];
+  }
+
+  if (slide.type === 'timeline') {
+    const milestones = (
+      slide.milestones?.length
+        ? slide.milestones
+        : normalizeCards(slide).map((card) => ({
+            label: card.title,
+            ...(card.value && { date: card.value }),
+            ...(card.detail && { status: card.detail }),
+          }))
+    ).slice(0, 5);
+    return [
+      ...shapes,
+      ...milestones.flatMap((item, i) => [
+        rect(92, 156 + i * 70, 18, 18, accent),
+        text(item.date ?? `阶段 ${i + 1}`, 132, 150 + i * 70, 120, 34, 'caption'),
+        text(item.label, 268, 148 + i * 70, 360, 38, 'body'),
+        text(item.status ?? '', 650, 150 + i * 70, 190, 34, 'caption'),
+      ]),
+    ];
+  }
+
+  if (slide.type === 'risks') {
+    const risks = (
+      slide.risks?.length
+        ? slide.risks
+        : normalizeCards(slide).map((card) => ({
+            risk: card.title,
+            impact: card.value ?? '影响待评估',
+            mitigation: card.detail ?? '持续跟进',
+          }))
+    ).slice(0, 3);
+    return [
+      ...shapes,
+      rect(72, 142, 800, 42, THEME.softRed),
+      text('风险', 96, 151, 160, 26, 'caption'),
+      text('影响', 360, 151, 160, 26, 'caption'),
+      text('应对', 620, 151, 160, 26, 'caption'),
+      ...risks.flatMap((item, i) => [
+        rect(72, 210 + i * 88, 800, 58, i % 2 === 0 ? THEME.white : THEME.softRed),
+        rect(72, 210 + i * 88, 8, 58, accent),
+        text(item.risk, 96, 222 + i * 88, 230, 34, 'body'),
+        text(item.impact, 360, 222 + i * 88, 220, 34, 'body'),
+        text(item.mitigation, 620, 222 + i * 88, 230, 34, 'body'),
+      ]),
+    ];
+  }
+
+  if (slide.type === 'nextSteps') {
+    const tasks = (
+      slide.tasks?.length
+        ? slide.tasks
+        : normalizeCards(slide).map((card) => ({
+            owner: card.value ?? slide.presenterName ?? '待定',
+            task: card.title,
+            ...(card.detail && { due: card.detail }),
+          }))
+    ).slice(0, 5);
+    return [
+      ...shapes,
+      rect(72, 142, 800, 42, THEME.softAmber),
+      text('负责人', 96, 151, 160, 26, 'caption'),
+      text('行动项', 260, 151, 440, 26, 'caption'),
+      text('截止', 735, 151, 120, 26, 'caption'),
+      ...tasks.flatMap((item, i) => [
+        rect(72, 204 + i * 62, 800, 44, i % 2 === 0 ? THEME.white : THEME.softAmber),
+        rect(72, 204 + i * 62, 8, 44, accent),
+        text(item.owner, 96, 214 + i * 62, 132, 28, 'caption'),
+        text(item.task, 260, 212 + i * 62, 420, 30, 'body'),
+        text(item.due ?? '待定', 735, 214 + i * 62, 120, 28, 'caption'),
+      ]),
+    ];
+  }
+
+  const cards = normalizeCards(slide).slice(0, 5);
+  const bullets = slide.type === 'closing' && slide.bullets?.length ? slide.bullets : undefined;
+  return [
+    ...shapes,
+    ...(bullets
+      ? bullets.slice(0, 4).flatMap((item, i) => bullet(item, 86, 176 + i * 62, accent))
+      : cards.flatMap((card, i) => cardShape(card, 76 + (i % 2) * 402, 154 + Math.floor(i / 2) * 118, accent))),
+    ...(slide.presenterName ? [text(`汇报人：${slide.presenterName}`, 72, 480, 300, 28, 'caption')] : []),
+  ];
+}
+
+function accentForSlide(type: SlidesOutline['slides'][number]['type']): string {
+  switch (type) {
+    case 'timeline':
+      return THEME.green;
+    case 'risks':
+      return THEME.red;
+    case 'nextSteps':
+      return THEME.amber;
+    default:
+      return THEME.blue;
+  }
+}
+
+function cardShape(card: SlideCard, x: number, y: number, accent: string): string[] {
+  return [
+    rect(x, y, 360, 82, THEME.white),
+    rect(x, y, 8, 82, accent),
+    text(card.value ?? '', x + 28, y + 14, 90, 26, 'caption'),
+    text(card.title, x + 126, y + 12, 190, 30, 'body'),
+    text(card.detail ?? '', x + 126, y + 48, 200, 24, 'caption'),
+  ];
+}
+
+function bullet(value: string, x: number, y: number, accent: string): string[] {
+  return [rect(x, y + 8, 10, 10, accent), text(value, x + 28, y, 700, 34, 'body')];
+}
+
+function rect(x: number, y: number, width: number, height: number, fill: string): string {
+  return `<shape type="rect" topLeftX="${x}" topLeftY="${y}" width="${width}" height="${height}"><style><fill><fillColor color="${fill}"/></fill></style></shape>`;
+}
+
+function text(
+  value: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  textType: 'title' | 'body' | 'caption',
+): string {
+  if (!value.trim()) return '';
+  return `<shape type="text" topLeftX="${x}" topLeftY="${y}" width="${width}" height="${height}"><content textType="${textType}"><p>${escapeXml(value)}</p></content></shape>`;
+}
+
+function normalizeCards(slide: SlidesOutline['slides'][number]): SlideCard[] {
+  if (slide.cards?.length) return [...slide.cards];
+  const bullets = slide.bullets?.length ? slide.bullets : [];
+  return bullets.length
+    ? bullets.map((bulletText, index) => ({ title: bulletText, value: `0${index + 1}` }))
+    : [{ title: slide.subtitle ?? slide.title, value: '01' }];
 }
 
 function escapeXml(value: string): string {
@@ -119,7 +341,9 @@ function escapeXml(value: string): string {
 
 function parseSlidesRef(output: string, baseUrl: string): SlidesRef | undefined {
   const parsed = parseJsonOutput(output);
-  const url = parsed ? findString(parsed, (value) => /https?:\/\/\S+\/slides\//.test(value)) : undefined;
+  const url = parsed
+    ? findString(parsed, (value) => /https?:\/\/\S+\/slides\//.test(value))
+    : undefined;
   const xmlPresentationId = parsed ? findStringByKey(parsed, 'xml_presentation_id') : undefined;
   const tokenFromJson = parsed
     ? findString(parsed, (value) => /^[A-Za-z0-9_-]{8,}$/.test(value) && !value.startsWith('http'))

--- a/packages/contracts/src/bot-runtime.ts
+++ b/packages/contracts/src/bot-runtime.ts
@@ -46,6 +46,19 @@ export interface FetchHistoryResult {
   readonly nextPageToken?: string;
 }
 
+export interface FetchMembersParams {
+  readonly chatId: string;
+}
+
+export interface ChatMember {
+  readonly userId: string;
+  readonly name: string;
+}
+
+export interface FetchMembersResult {
+  readonly members: readonly ChatMember[];
+}
+
 export interface PatchCardParams {
   readonly messageId: string;
   readonly card: Card;
@@ -65,6 +78,9 @@ export interface BotRuntime {
 
   /** 拉取群历史消息（机器人必须是群成员）*/
   fetchHistory(params: FetchHistoryParams): Promise<Result<FetchHistoryResult>>;
+
+  /** 拉取群成员列表（机器人必须是群成员）*/
+  fetchMembers(params: FetchMembersParams): Promise<Result<FetchMembersResult>>;
 
   /** 注册事件回调；返回 unregister 函数 */
   on(handler: EventHandler): () => void;

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -93,6 +93,8 @@ export interface SlidesCardInput {
   readonly presentationUrl: string;
   readonly pageCount: number;
   readonly preview?: readonly { title: string; bullets: readonly string[] }[];
+  readonly isLoading?: boolean;
+  readonly errorMessage?: string;
 }
 
 export interface ArchiveCardInput {

--- a/packages/contracts/src/docx.ts
+++ b/packages/contracts/src/docx.ts
@@ -19,4 +19,6 @@ export interface DocxClient {
   createFromMarkdown(title: string, markdown: string): Promise<Result<DocRef>>;
   /** 读取文档 / wiki / 幻灯片的纯文本内容 */
   readContent(token: string, kind?: 'doc' | 'wiki' | 'slides'): Promise<Result<string>>;
+  /** 将指定用户加为 Drive 文件的编辑协作者 */
+  grantMembersEdit(token: string, type: 'docx' | 'slides', userIds: readonly string[]): Promise<Result<void>>;
 }

--- a/packages/contracts/src/slides.ts
+++ b/packages/contracts/src/slides.ts
@@ -1,8 +1,41 @@
 import type { Result } from './result.js';
 
+export type SlideType = 'cover' | 'overview' | 'timeline' | 'risks' | 'nextSteps' | 'closing';
+
+export interface SlideCard {
+  readonly title: string;
+  readonly value?: string;
+  readonly detail?: string;
+}
+
+export interface SlideMilestone {
+  readonly label: string;
+  readonly date?: string;
+  readonly status?: string;
+}
+
+export interface SlideRisk {
+  readonly risk: string;
+  readonly impact: string;
+  readonly mitigation: string;
+}
+
+export interface SlideTask {
+  readonly owner: string;
+  readonly task: string;
+  readonly due?: string;
+}
+
 export interface SlideDraft {
-  readonly heading: string;
-  readonly bullets: readonly string[];
+  readonly type: SlideType;
+  readonly title: string;
+  readonly presenterName?: string;
+  readonly subtitle?: string;
+  readonly bullets?: readonly string[];
+  readonly cards?: readonly SlideCard[];
+  readonly milestones?: readonly SlideMilestone[];
+  readonly risks?: readonly SlideRisk[];
+  readonly tasks?: readonly SlideTask[];
   readonly notes?: string;
 }
 
@@ -19,4 +52,11 @@ export interface SlidesRef {
 export interface SlidesClient {
   /** 创建原生飞书演示文稿，返回可直接打开的 slides URL。 */
   createFromOutline(title: string, outline: SlidesOutline): Promise<Result<SlidesRef>>;
+
+  /**
+   * 把演示文稿按成员粒度授权（每个 user 一个 openid）。
+   * 实现方需用与创建者一致的身份调用（默认 lark-cli `--as bot`，bot 即 owner）；
+   * 否则会因为没有管理权限而失败。
+   */
+  grantMembersEdit(slidesToken: string, userIds: readonly string[]): Promise<Result<void>>;
 }

--- a/packages/skills/src/__tests__/slides-assignment.test.ts
+++ b/packages/skills/src/__tests__/slides-assignment.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { ASSIGNMENT_PROMPT, AssignmentSchema } from '../prompts/slides-assignment.js';
+
+const OUTLINE = {
+  title: '项目进展汇报',
+  slides: [
+    { type: 'overview' as const, title: '项目背景', bullets: ['说明目标', '讲清痛点'] },
+    { type: 'nextSteps' as const, title: '下一步计划', bullets: ['安排上线', '收集反馈'] },
+  ],
+};
+
+describe('slides assignment prompt/schema', () => {
+  it('includes outline and member names in prompt', () => {
+    const prompt = ASSIGNMENT_PROMPT(OUTLINE, [
+      { userId: 'ou_1', name: '张三' },
+      { userId: 'ou_2', name: '李四' },
+    ]);
+
+    expect(prompt).toContain('项目进展汇报');
+    expect(prompt).toContain('张三、李四');
+  });
+
+  it('uses fallback member text when member list is empty', () => {
+    const prompt = ASSIGNMENT_PROMPT(OUTLINE, []);
+
+    expect(prompt).toContain('待定成员');
+  });
+
+  it('parses a valid assignment', () => {
+    const assignment = AssignmentSchema.parse({
+      assignments: [
+        {
+          memberName: '张三',
+          pages: [{ pageIndex: 0, heading: '项目背景', talkingPoints: ['先讲背景'] }],
+        },
+      ],
+    });
+
+    expect(assignment.assignments[0]?.memberName).toBe('张三');
+    expect(assignment.assignments[0]?.pages[0]?.pageIndex).toBe(0);
+  });
+
+  it('rejects missing assignments array', () => {
+    expect(() => AssignmentSchema.parse({})).toThrow(/assignments/);
+  });
+
+  it('exports a JSON schema for structured LLM calls', () => {
+    const schema = AssignmentSchema.jsonSchema?.();
+
+    expect(schema?.required).toEqual(['assignments']);
+    expect(JSON.stringify(schema)).toContain('talkingPoints');
+  });
+});

--- a/packages/skills/src/__tests__/slides-prompt.test.ts
+++ b/packages/skills/src/__tests__/slides-prompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { OutlineSchema, SLIDES_PROMPT } from '../prompts/slides.js';
+
+describe('slides prompt/schema', () => {
+  it('asks for templated slide types', () => {
+    const prompt = SLIDES_PROMPT([], [], [{ userId: 'ou_1', name: '张三' }]);
+
+    expect(prompt).toContain('cover、overview、timeline、risks、nextSteps、closing');
+    expect(prompt).toContain('overview 使用 cards 字段');
+    expect(prompt).toContain('presenterName');
+    expect(prompt).toContain('张三');
+  });
+
+  it('parses a templated outline', () => {
+    const outline = OutlineSchema.parse({
+      title: '项目进展汇报',
+      subtitle: '基于 IM 的办公协同智能助手',
+      slides: [
+        { type: 'cover', title: '项目进展汇报', subtitle: '挑战赛 Demo' },
+        {
+          type: 'overview',
+          title: '核心进展',
+          presenterName: '张三',
+          cards: [{ title: 'MVP', value: '已完成', detail: '主链路可演示' }],
+        },
+        {
+          type: 'nextSteps',
+          title: '下一步计划',
+          tasks: [{ owner: '张三', task: '手机端联调', due: '明天' }],
+        },
+      ],
+    });
+
+    expect(outline.slides[0]?.type).toBe('cover');
+    expect(outline.slides[1]?.presenterName).toBe('张三');
+    expect(outline.slides[1]?.cards?.[0]?.title).toBe('MVP');
+    expect(outline.slides[2]?.tasks?.[0]?.owner).toBe('张三');
+  });
+
+  it('rejects legacy slides without type', () => {
+    expect(() =>
+      OutlineSchema.parse({
+        title: '旧版大纲',
+        slides: [{ heading: '背景', bullets: ['一句话'] }],
+      }),
+    ).toThrow(/slide.type/);
+  });
+
+  it('exports schema fields for all templates', () => {
+    const schema = OutlineSchema.jsonSchema?.();
+    const asText = JSON.stringify(schema);
+
+    expect(asText).toContain('milestones');
+    expect(asText).toContain('risks');
+    expect(asText).toContain('tasks');
+    expect(asText).toContain('presenterName');
+  });
+});

--- a/packages/skills/src/__tests__/slides.test.ts
+++ b/packages/skills/src/__tests__/slides.test.ts
@@ -34,10 +34,27 @@ function makeEvent(text: string, overrides?: Partial<Message>): BotEvent {
 
 const MOCK_OUTLINE = {
   title: '项目进展汇报',
+  subtitle: '基于 IM 的办公协同智能助手',
   slides: [
-    { heading: '项目背景', bullets: ['解决团队协作问题', '提升效率 30%'] },
-    { heading: '核心进展', bullets: ['完成 MVP 开发', '完成测试覆盖'] },
-    { heading: '下一步计划', bullets: ['上线演示', '收集反馈'] },
+    { type: 'cover' as const, title: '项目进展汇报', subtitle: '基于 IM 的办公协同智能助手' },
+    {
+      type: 'overview' as const,
+      title: '核心进展',
+      presenterName: '张三',
+      cards: [
+        { title: 'MVP 开发', value: '已完成', detail: '核心链路可演示' },
+        { title: '测试覆盖', value: '进行中', detail: '补齐关键场景' },
+      ],
+    },
+    {
+      type: 'nextSteps' as const,
+      title: '下一步计划',
+      presenterName: '李四',
+      tasks: [
+        { owner: '张三', task: '上线演示', due: '明天' },
+        { owner: '李四', task: '收集反馈' },
+      ],
+    },
   ],
 };
 
@@ -45,19 +62,40 @@ const MOCK_SLIDES_REF = {
   slidesToken: 'sldcnABCDEF',
   url: 'https://example.feishu.cn/slides/abc',
 };
-const MOCK_CARD: Card = { templateName: 'slides', content: { mock: true } };
+const MOCK_ASSIGNMENT = {
+  assignments: [
+    {
+      memberName: '张三',
+      pages: [
+        { pageIndex: 0, heading: '项目背景', talkingPoints: ['先讲问题背景', '说明目标收益'] },
+      ],
+    },
+  ],
+};
+const MOCK_DOC_REF = { docToken: 'doxcnABCDEF', url: 'https://example.feishu.cn/docx/abc' };
+const MOCK_SLIDES_CARD: Card = { templateName: 'slides', content: { slides: true } };
+const MOCK_DOC_PUSH_CARD: Card = { templateName: 'docPush', content: { docPush: true } };
 
 function makeRuntime(): BotRuntime {
   return {
     on: vi.fn(),
     start: vi.fn().mockResolvedValue(ok(undefined)),
     stop: vi.fn().mockResolvedValue(undefined),
-    sendText: vi.fn().mockResolvedValue(ok({ messageId: 'r1', chatId: 'oc_chat_001', timestamp: 0 })),
-    sendCard: vi.fn().mockResolvedValue(ok({ messageId: 'r2', chatId: 'oc_chat_001', timestamp: 0 })),
+    sendText: vi
+      .fn()
+      .mockResolvedValue(ok({ messageId: 'r1', chatId: 'oc_chat_001', timestamp: 0 })),
+    sendCard: vi
+      .fn()
+      .mockResolvedValue(ok({ messageId: 'r2', chatId: 'oc_chat_001', timestamp: 0 })),
     patchCard: vi.fn().mockResolvedValue(ok(undefined)),
-    fetchHistory: vi.fn().mockResolvedValue(
-      ok({ messages: [makeMessage('我们做个ppt汇报一下进展')], hasMore: false }),
-    ),
+    fetchHistory: vi
+      .fn()
+      .mockResolvedValue(
+        ok({ messages: [makeMessage('我们做个ppt汇报一下进展')], hasMore: false }),
+      ),
+    fetchMembers: vi
+      .fn()
+      .mockResolvedValue(ok({ members: [{ userId: 'ou_user_001', name: '张三' }] })),
   } as unknown as BotRuntime;
 }
 
@@ -65,18 +103,24 @@ function makeLLM(outline = MOCK_OUTLINE): LLMClient {
   return {
     ask: vi.fn(),
     chat: vi.fn(),
-    askStructured: vi.fn().mockResolvedValue(ok(outline)),
+    askStructured: vi
+      .fn()
+      .mockResolvedValueOnce(ok(outline))
+      .mockResolvedValue(ok(MOCK_ASSIGNMENT)),
   } as unknown as LLMClient;
 }
 
 function makeCardBuilder(): CardBuilder {
-  return { build: vi.fn().mockReturnValue(MOCK_CARD) };
+  return {
+    build: vi
+      .fn()
+      .mockImplementation((template) =>
+        template === 'docPush' ? MOCK_DOC_PUSH_CARD : MOCK_SLIDES_CARD,
+      ),
+  };
 }
 
-function makeCtx(
-  event: BotEvent,
-  overrides: Partial<SkillContext> = {},
-): SkillContext {
+function makeCtx(event: BotEvent, overrides: Partial<SkillContext> = {}): SkillContext {
   return {
     event,
     runtime: makeRuntime(),
@@ -93,10 +137,12 @@ function makeCtx(
       create: vi.fn(),
       appendBlocks: vi.fn(),
       getShareLink: vi.fn(),
-      createFromMarkdown: vi.fn(),
+      createFromMarkdown: vi.fn().mockResolvedValue(ok(MOCK_DOC_REF)),
+      grantMembersEdit: vi.fn().mockResolvedValue(ok(undefined)),
     } as unknown as SkillContext['docx'],
     slides: {
       createFromOutline: vi.fn().mockResolvedValue(ok(MOCK_SLIDES_REF)),
+      grantMembersEdit: vi.fn().mockResolvedValue(ok(undefined)),
     } as unknown as NonNullable<SkillContext['slides']>,
     cardBuilder: makeCardBuilder(),
     retrievers: {},
@@ -116,12 +162,12 @@ describe('slidesSkill.match()', () => {
     expect(slidesSkill.match(makeCtx(makeEvent('下周要交PPT')))).toBe(true);
   });
 
-  it('returns true for "幻灯片"', () => {
-    expect(slidesSkill.match(makeCtx(makeEvent('幻灯片初稿出来了')))).toBe(true);
+  it('returns true for a request to organize slides', () => {
+    expect(slidesSkill.match(makeCtx(makeEvent('帮忙整理一下幻灯片初稿')))).toBe(true);
   });
 
-  it('returns true for "演示文稿"', () => {
-    expect(slidesSkill.match(makeCtx(makeEvent('演示文稿风格参考上次的')))).toBe(true);
+  it('returns true for a request to generate a presentation', () => {
+    expect(slidesSkill.match(makeCtx(makeEvent('根据项目进展生成演示文稿')))).toBe(true);
   });
 
   it('returns true for "向上级汇报"', () => {
@@ -136,8 +182,18 @@ describe('slidesSkill.match()', () => {
     expect(slidesSkill.match(makeCtx(makeEvent('今天天气不错')))).toBe(false);
   });
 
+  it('returns false when the group is merely discussing ppt', () => {
+    expect(slidesSkill.match(makeCtx(makeEvent('这个ppt怎么样')))).toBe(false);
+    expect(slidesSkill.match(makeCtx(makeEvent('这个 ppt 风格太丑了')))).toBe(false);
+    expect(slidesSkill.match(makeCtx(makeEvent('上次 PPT 放哪了')))).toBe(false);
+    expect(slidesSkill.match(makeCtx(makeEvent('我们先别做 ppt')))).toBe(false);
+  });
+
   it('returns false for non-message event', () => {
-    const ctx = makeCtx({ type: 'botJoinedChat', payload: { chatId: 'c1', inviter: { userId: 'u1' }, timestamp: 0 } });
+    const ctx = makeCtx({
+      type: 'botJoinedChat',
+      payload: { chatId: 'c1', inviter: { userId: 'u1' }, timestamp: 0 },
+    });
     expect(slidesSkill.match(ctx)).toBe(false);
   });
 });
@@ -151,28 +207,91 @@ describe('slidesSkill.run() — happy path', () => {
     ctx = makeCtx(makeEvent('下周要做PPT汇报'));
   });
 
-  it('returns ok with a slides card', async () => {
+  it('returns ok with an assignment docPush card', async () => {
     const result = await slidesSkill.run(ctx);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.card?.templateName).toBe('slides');
+      expect(result.value.card?.templateName).toBe('docPush');
     }
   });
 
-  it('calls cardBuilder.build with slides template and correct data', async () => {
+  it('sends loading card, patches final slides card, and returns assignment card', async () => {
     await slidesSkill.run(ctx);
-    expect(ctx.cardBuilder.build).toHaveBeenCalledWith('slides', expect.objectContaining({
-      title: MOCK_OUTLINE.title,
-      presentationUrl: MOCK_SLIDES_REF.url,
-      pageCount: MOCK_OUTLINE.slides.length,
-    }));
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        title: '文件生成中…',
+        isLoading: true,
+      }),
+    );
+    expect(ctx.runtime.sendCard).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'oc_chat_001', card: MOCK_SLIDES_CARD }),
+    );
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        title: MOCK_OUTLINE.title,
+        presentationUrl: MOCK_SLIDES_REF.url,
+        pageCount: MOCK_OUTLINE.slides.length,
+      }),
+    );
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'r2', card: MOCK_SLIDES_CARD }),
+    );
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'docPush',
+      expect.objectContaining({
+        docTitle: `${MOCK_OUTLINE.title} — 汇报分工`,
+        docUrl: MOCK_DOC_REF.url,
+        docType: 'report',
+      }),
+    );
   });
 
   it('calls slides.createFromOutline with outline title', async () => {
     await slidesSkill.run(ctx);
-    expect(ctx.slides?.createFromOutline).toHaveBeenCalledWith(
-      MOCK_OUTLINE.title,
-      MOCK_OUTLINE,
+    expect(ctx.slides?.createFromOutline).toHaveBeenCalledWith(MOCK_OUTLINE.title, MOCK_OUTLINE);
+  });
+
+  it('only calls LLM once and builds assignment locally', async () => {
+    await slidesSkill.run(ctx);
+    expect(ctx.llm.askStructured).toHaveBeenCalledTimes(1);
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'slides: building assignment locally',
+      expect.objectContaining({ memberCount: 1 }),
+    );
+  });
+
+  it('uses LLM-provided presenterName when building assignment doc', async () => {
+    const ctx = makeCtx(makeEvent('下周要做PPT汇报'), {
+      runtime: {
+        ...makeRuntime(),
+        fetchMembers: vi.fn().mockResolvedValue(
+          ok({
+            members: [
+              { userId: 'ou_user_001', name: '张三' },
+              { userId: 'ou_user_002', name: '李四' },
+            ],
+          }),
+        ),
+      } as unknown as BotRuntime,
+    });
+
+    await slidesSkill.run(ctx);
+
+    expect(ctx.docx.createFromMarkdown).toHaveBeenCalledWith(
+      `${MOCK_OUTLINE.title} — 汇报分工`,
+      expect.stringMatching(
+        /## 张三[\s\S]*第 2 页：核心进展[\s\S]*## 李四[\s\S]*第 3 页：下一步计划/,
+      ),
+    );
+  });
+
+  it('grants slides access to team members via lark-cli user identity', async () => {
+    await slidesSkill.run(ctx);
+    expect(ctx.slides?.grantMembersEdit).toHaveBeenCalledWith(
+      MOCK_SLIDES_REF.slidesToken,
+      ['ou_user_001'],
     );
   });
 
@@ -183,14 +302,16 @@ describe('slidesSkill.run() — happy path', () => {
     );
   });
 
-  it('sends an immediate progress acknowledgement', async () => {
+  it('sends loading card before creating files', async () => {
     await slidesSkill.run(ctx);
-    expect(ctx.runtime.sendText).toHaveBeenCalledWith(
-      expect.objectContaining({
-        chatId: 'oc_chat_001',
-        text: expect.stringContaining('正在生成演示文稿'),
-      }),
-    );
+    const sendOrder = (ctx.runtime.sendCard as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const createOrder = (ctx.slides!.createFromOutline as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    expect(sendOrder).toBeDefined();
+    expect(createOrder).toBeDefined();
+    if (sendOrder === undefined || createOrder === undefined) throw new Error('missing call order');
+    expect(sendOrder).toBeLessThan(createOrder);
   });
 
   it('includes reasoning in the result', async () => {
@@ -208,9 +329,9 @@ describe('slidesSkill.run() — error paths', () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       runtime: {
         ...makeRuntime(),
-        fetchHistory: vi.fn().mockResolvedValue(
-          err(makeError(ErrorCode.FEISHU_API_ERROR, 'history fetch failed')),
-        ),
+        fetchHistory: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'history fetch failed'))),
       } as unknown as BotRuntime,
     });
     const result = await slidesSkill.run(ctx);
@@ -231,9 +352,9 @@ describe('slidesSkill.run() — error paths', () => {
       llm: {
         ask: vi.fn(),
         chat: vi.fn(),
-        askStructured: vi.fn().mockResolvedValue(
-          err(makeError(ErrorCode.LLM_TIMEOUT, 'llm timed out')),
-        ),
+        askStructured: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.LLM_TIMEOUT, 'llm timed out'))),
       } as unknown as LLMClient,
     });
     const result = await slidesSkill.run(ctx);
@@ -244,9 +365,9 @@ describe('slidesSkill.run() — error paths', () => {
   it('returns err when slides.createFromOutline fails', async () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       slides: {
-        createFromOutline: vi.fn().mockResolvedValue(
-          err(makeError(ErrorCode.FEISHU_API_ERROR, 'slides create failed')),
-        ),
+        createFromOutline: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'slides create failed'))),
       } as unknown as NonNullable<SkillContext['slides']>,
     });
     const result = await slidesSkill.run(ctx);
@@ -254,18 +375,88 @@ describe('slidesSkill.run() — error paths', () => {
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
   });
 
-  it('does not call cardBuilder.build when slides creation fails', async () => {
+  it('proceeds when fetchMembers fails and still creates assignment doc', async () => {
+    const ctx = makeCtx(makeEvent('做个ppt'), {
+      runtime: {
+        ...makeRuntime(),
+        fetchMembers: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'members failed'))),
+      } as unknown as BotRuntime,
+    });
+
+    const result = await slidesSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.docx.createFromMarkdown).toHaveBeenCalledWith(
+      `${MOCK_OUTLINE.title} — 汇报分工`,
+      expect.stringContaining('张三'),
+    );
+  });
+
+  it('returns err and patches error card when assignment doc creation fails', async () => {
+    const ctx = makeCtx(makeEvent('做个ppt'), {
+      docx: {
+        create: vi.fn(),
+        appendBlocks: vi.fn(),
+        getShareLink: vi.fn(),
+        createFromMarkdown: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'assignment doc failed'))),
+        grantMembersEdit: vi.fn().mockResolvedValue(ok(undefined)),
+      } as unknown as SkillContext['docx'],
+    });
+
+    const result = await slidesSkill.run(ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        errorMessage: expect.stringContaining('assignment doc failed'),
+      }),
+    );
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'r2', card: MOCK_SLIDES_CARD }),
+    );
+  });
+
+  it('does not fail the flow when final patchCard fails', async () => {
+    const ctx = makeCtx(makeEvent('做个ppt'), {
+      runtime: {
+        ...makeRuntime(),
+        patchCard: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'patch failed'))),
+      } as unknown as BotRuntime,
+    });
+
+    const result = await slidesSkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      'slides: patch loading card failed',
+      expect.objectContaining({ message: 'patch failed' }),
+    );
+  });
+
+  it('does not build final cards when slides creation fails', async () => {
     const cardBuilder = makeCardBuilder();
     const ctx = makeCtx(makeEvent('做个ppt'), {
       slides: {
-        createFromOutline: vi.fn().mockResolvedValue(
-          err(makeError(ErrorCode.FEISHU_API_ERROR, 'slides create failed')),
-        ),
+        createFromOutline: vi
+          .fn()
+          .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'slides create failed'))),
       } as unknown as NonNullable<SkillContext['slides']>,
       cardBuilder,
     });
     await slidesSkill.run(ctx);
-    expect(cardBuilder.build).not.toHaveBeenCalled();
+    expect(cardBuilder.build).toHaveBeenCalledTimes(1);
+    expect(cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({ isLoading: true }),
+    );
   });
 });
 
@@ -275,9 +466,7 @@ describe('slidesSkill.run() — bitable snapshot degradation', () => {
   it('proceeds without snapshots when bitable.find fails', async () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       bitable: {
-        find: vi.fn().mockResolvedValue(
-          err(makeError(ErrorCode.BITABLE_QPS, 'qps exceeded')),
-        ),
+        find: vi.fn().mockResolvedValue(err(makeError(ErrorCode.BITABLE_QPS, 'qps exceeded'))),
         insert: vi.fn(),
         batchInsert: vi.fn(),
         update: vi.fn(),

--- a/packages/skills/src/__tests__/slides.test.ts
+++ b/packages/skills/src/__tests__/slides.test.ts
@@ -325,7 +325,7 @@ describe('slidesSkill.run() — happy path', () => {
 // ─── run() — error paths ──────────────────────────────────────────────────────
 
 describe('slidesSkill.run() — error paths', () => {
-  it('returns err when fetchHistory fails', async () => {
+  it('returns err and patches loading card when fetchHistory fails', async () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       runtime: {
         ...makeRuntime(),
@@ -337,6 +337,15 @@ describe('slidesSkill.run() — error paths', () => {
     const result = await slidesSkill.run(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        errorMessage: expect.stringContaining('history fetch failed'),
+      }),
+    );
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'r2' }),
+    );
   });
 
   it('returns err when slides client is missing', async () => {
@@ -347,7 +356,7 @@ describe('slidesSkill.run() — error paths', () => {
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.CONFIG_MISSING);
   });
 
-  it('returns err when LLM times out', async () => {
+  it('returns err and patches loading card when LLM times out', async () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       llm: {
         ask: vi.fn(),
@@ -360,9 +369,18 @@ describe('slidesSkill.run() — error paths', () => {
     const result = await slidesSkill.run(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.LLM_TIMEOUT);
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        errorMessage: expect.stringContaining('llm timed out'),
+      }),
+    );
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'r2' }),
+    );
   });
 
-  it('returns err when slides.createFromOutline fails', async () => {
+  it('returns err and patches loading card when slides.createFromOutline fails', async () => {
     const ctx = makeCtx(makeEvent('做个ppt'), {
       slides: {
         createFromOutline: vi
@@ -373,6 +391,15 @@ describe('slidesSkill.run() — error paths', () => {
     const result = await slidesSkill.run(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe(ErrorCode.FEISHU_API_ERROR);
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'slides',
+      expect.objectContaining({
+        errorMessage: expect.stringContaining('slides create failed'),
+      }),
+    );
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'r2' }),
+    );
   });
 
   it('proceeds when fetchMembers fails and still creates assignment doc', async () => {
@@ -441,7 +468,7 @@ describe('slidesSkill.run() — error paths', () => {
     );
   });
 
-  it('does not build final cards when slides creation fails', async () => {
+  it('does not build final/docPush cards when slides creation fails', async () => {
     const cardBuilder = makeCardBuilder();
     const ctx = makeCtx(makeEvent('做个ppt'), {
       slides: {
@@ -452,11 +479,20 @@ describe('slidesSkill.run() — error paths', () => {
       cardBuilder,
     });
     await slidesSkill.run(ctx);
-    expect(cardBuilder.build).toHaveBeenCalledTimes(1);
-    expect(cardBuilder.build).toHaveBeenCalledWith(
+
+    // build 调用：1) loading card 2) error patch card；不应再 build 成功态卡或 docPush 卡
+    expect(cardBuilder.build).toHaveBeenCalledTimes(2);
+    expect(cardBuilder.build).toHaveBeenNthCalledWith(
+      1,
       'slides',
       expect.objectContaining({ isLoading: true }),
     );
+    expect(cardBuilder.build).toHaveBeenNthCalledWith(
+      2,
+      'slides',
+      expect.objectContaining({ errorMessage: expect.stringContaining('slides create failed') }),
+    );
+    expect(cardBuilder.build).not.toHaveBeenCalledWith('docPush', expect.anything());
   });
 });
 

--- a/packages/skills/src/prompts/slides-assignment.ts
+++ b/packages/skills/src/prompts/slides-assignment.ts
@@ -1,0 +1,110 @@
+import type { ChatMember, SchemaLike } from '@seedhac/contracts';
+import type { Outline } from './slides.js';
+
+export interface AssignmentPage {
+  readonly pageIndex: number;
+  readonly heading: string;
+  readonly talkingPoints: readonly string[];
+}
+
+export interface AssignmentItem {
+  readonly memberName: string;
+  readonly pages: readonly AssignmentPage[];
+}
+
+export interface Assignment {
+  readonly assignments: readonly AssignmentItem[];
+}
+
+export const ASSIGNMENT_PROMPT = (
+  outline: Outline,
+  members: readonly ChatMember[],
+): string => {
+  const memberCount = members.length || 1;
+  const memberList = members.length > 0 ? members.map((m) => m.name).join('、') : '待定成员';
+  return `
+根据以下演示文稿大纲和汇报成员列表，为每位成员分配负责讲解的页面，并给出每页的发言要点。
+
+成员列表（共 ${memberCount} 人）：${memberList}
+
+要求：
+- 必须为上方列出的每一位成员都生成一条 assignment，输出的 assignments 数组长度必须等于 ${memberCount}
+- 每位成员分配 1-3 页，尽量均衡分配，不要让某一位承担过多页面
+- 发言要点 2-3 句，简洁口语化
+- pageIndex 对应 outline.slides 的 0-based 下标
+- 输出严格遵循 JSON schema，不要有额外文字
+
+大纲：
+${JSON.stringify(outline, null, 2)}
+`.trim();
+};
+
+function parseAssignmentPage(raw: unknown): AssignmentPage {
+  if (typeof raw !== 'object' || raw === null) throw new Error('invalid assignment page');
+  const p = raw as Record<string, unknown>;
+  if (typeof p['pageIndex'] !== 'number') throw new Error('assignment.pageIndex must be number');
+  if (typeof p['heading'] !== 'string') throw new Error('assignment.heading must be string');
+  if (!Array.isArray(p['talkingPoints'])) {
+    throw new Error('assignment.talkingPoints must be array');
+  }
+  return {
+    pageIndex: p['pageIndex'],
+    heading: p['heading'],
+    talkingPoints: p['talkingPoints'].map((point) => {
+      if (typeof point !== 'string') throw new Error('talking point must be string');
+      return point;
+    }),
+  };
+}
+
+function parseAssignmentItem(raw: unknown): AssignmentItem {
+  if (typeof raw !== 'object' || raw === null) throw new Error('invalid assignment item');
+  const a = raw as Record<string, unknown>;
+  if (typeof a['memberName'] !== 'string') throw new Error('assignment.memberName must be string');
+  if (!Array.isArray(a['pages'])) throw new Error('assignment.pages must be array');
+  return {
+    memberName: a['memberName'],
+    pages: a['pages'].map(parseAssignmentPage),
+  };
+}
+
+export const AssignmentSchema: SchemaLike<Assignment> = {
+  parse(value: unknown): Assignment {
+    if (typeof value !== 'object' || value === null) throw new Error('assignment must be object');
+    const a = value as Record<string, unknown>;
+    if (!Array.isArray(a['assignments'])) throw new Error('assignment.assignments must be array');
+    return {
+      assignments: a['assignments'].map(parseAssignmentItem),
+    };
+  },
+  jsonSchema(): Record<string, unknown> {
+    return {
+      type: 'object',
+      required: ['assignments'],
+      properties: {
+        assignments: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['memberName', 'pages'],
+            properties: {
+              memberName: { type: 'string' },
+              pages: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['pageIndex', 'heading', 'talkingPoints'],
+                  properties: {
+                    pageIndex: { type: 'number' },
+                    heading: { type: 'string' },
+                    talkingPoints: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+  },
+};

--- a/packages/skills/src/prompts/slides.ts
+++ b/packages/skills/src/prompts/slides.ts
@@ -1,26 +1,50 @@
-import type { BitableRow, Message, SchemaLike } from '@seedhac/contracts';
+import type {
+  BitableRow,
+  ChatMember,
+  Message,
+  SchemaLike,
+  SlideCard,
+  SlideDraft,
+  SlideMilestone,
+  SlideRisk,
+  SlideTask,
+  SlideType,
+} from '@seedhac/contracts';
 
-export interface SlideItem {
-  heading: string;
-  bullets: string[];
-  notes?: string;
-}
+const SLIDE_TYPES: readonly SlideType[] = [
+  'cover',
+  'overview',
+  'timeline',
+  'risks',
+  'nextSteps',
+  'closing',
+] as const;
 
 export interface Outline {
   title: string;
-  slides: SlideItem[];
+  subtitle?: string;
+  slides: SlideDraft[];
 }
 
 export const SLIDES_PROMPT = (
   history: readonly Message[],
   snapshots: readonly BitableRow[],
-): string => `
-你是一个项目协作助手。根据以下群聊记录和项目背景，生成一份演示文稿大纲。
+  members: readonly ChatMember[] = [],
+): string =>
+  `
+你是一个项目协作助手。根据以下群聊记录和项目背景，生成一份可直接渲染为飞书原生 Slides 的结构化演示文稿方案。
 要求：
 - 标题简洁，体现项目核心价值
-- 4-6 页幻灯片，最后一页为"下一步计划"
-- 每页 2-4 个要点，语言简练
+- 生成 5-6 页幻灯片，优先使用这些页面类型：cover、overview、timeline、risks、nextSteps、closing
+- 第一页必须是 cover，最后一页必须是 closing，倒数第二页优先是 nextSteps
+- 每页内容必须短，适合投屏汇报，不要把文档段落塞进 PPT
+- overview 使用 cards 字段，timeline 使用 milestones 字段，risks 使用 risks 字段，nextSteps 使用 tasks 字段
+- 除 cover 和 closing 外，每页都要给出 presenterName。请根据群聊中每个人参与/负责的内容来分配；如果无法判断，再均衡分配给群成员
+- 如果信息不足，可以合理概括，但不要编造具体数据
 输出严格遵循 JSON schema，不要有额外文字。
+
+群成员列表：
+${members.length > 0 ? members.map((m) => m.name).join('、') : '待定成员'}
 
 群聊记录（最近）：
 ${history.map((m) => `${m.sender.name ?? m.sender.userId}: ${m.text}`).join('\n')}
@@ -29,17 +53,97 @@ ${history.map((m) => `${m.sender.name ?? m.sender.userId}: ${m.text}`).join('\n'
 ${snapshots.map((s) => String(s['content'] ?? '')).join('\n')}
 `.trim();
 
-function parseSlideItem(raw: unknown): SlideItem {
+function parseStringArray(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error(`${field} must be array`);
+  return value.map((item) => {
+    if (typeof item !== 'string') throw new Error(`${field} item must be string`);
+    return item;
+  });
+}
+
+function parseCards(value: unknown): SlideCard[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error('slide.cards must be array');
+  return value.map((raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('slide card must be object');
+    const c = raw as Record<string, unknown>;
+    if (typeof c['title'] !== 'string') throw new Error('slide.card.title must be string');
+    return {
+      title: c['title'],
+      ...(typeof c['value'] === 'string' && { value: c['value'] }),
+      ...(typeof c['detail'] === 'string' && { detail: c['detail'] }),
+    };
+  });
+}
+
+function parseMilestones(value: unknown): SlideMilestone[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error('slide.milestones must be array');
+  return value.map((raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('slide milestone must be object');
+    const m = raw as Record<string, unknown>;
+    if (typeof m['label'] !== 'string') throw new Error('slide.milestone.label must be string');
+    return {
+      label: m['label'],
+      ...(typeof m['date'] === 'string' && { date: m['date'] }),
+      ...(typeof m['status'] === 'string' && { status: m['status'] }),
+    };
+  });
+}
+
+function parseRisks(value: unknown): SlideRisk[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error('slide.risks must be array');
+  return value.map((raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('slide risk must be object');
+    const r = raw as Record<string, unknown>;
+    if (typeof r['risk'] !== 'string') throw new Error('slide.risk.risk must be string');
+    if (typeof r['impact'] !== 'string') throw new Error('slide.risk.impact must be string');
+    if (typeof r['mitigation'] !== 'string')
+      throw new Error('slide.risk.mitigation must be string');
+    return { risk: r['risk'], impact: r['impact'], mitigation: r['mitigation'] };
+  });
+}
+
+function parseTasks(value: unknown): SlideTask[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error('slide.tasks must be array');
+  return value.map((raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('slide task must be object');
+    const t = raw as Record<string, unknown>;
+    if (typeof t['owner'] !== 'string') throw new Error('slide.task.owner must be string');
+    if (typeof t['task'] !== 'string') throw new Error('slide.task.task must be string');
+    return {
+      owner: t['owner'],
+      task: t['task'],
+      ...(typeof t['due'] === 'string' && { due: t['due'] }),
+    };
+  });
+}
+
+function parseSlideItem(raw: unknown): SlideDraft {
   if (typeof raw !== 'object' || raw === null) throw new Error('invalid slide item');
   const s = raw as Record<string, unknown>;
-  if (typeof s['heading'] !== 'string') throw new Error('slide.heading must be string');
-  if (!Array.isArray(s['bullets'])) throw new Error('slide.bullets must be array');
+  if (typeof s['type'] !== 'string' || !SLIDE_TYPES.includes(s['type'] as SlideType)) {
+    throw new Error('slide.type must be a supported slide type');
+  }
+  if (typeof s['title'] !== 'string') throw new Error('slide.title must be string');
+  const bullets = parseStringArray(s['bullets'], 'slide.bullets');
+  const cards = parseCards(s['cards']);
+  const milestones = parseMilestones(s['milestones']);
+  const risks = parseRisks(s['risks']);
+  const tasks = parseTasks(s['tasks']);
   return {
-    heading: s['heading'],
-    bullets: s['bullets'].map((b) => {
-      if (typeof b !== 'string') throw new Error('bullet must be string');
-      return b;
-    }),
+    type: s['type'] as SlideType,
+    title: s['title'],
+    ...(typeof s['presenterName'] === 'string' && { presenterName: s['presenterName'] }),
+    ...(typeof s['subtitle'] === 'string' && { subtitle: s['subtitle'] }),
+    ...(bullets !== undefined && { bullets }),
+    ...(cards !== undefined && { cards }),
+    ...(milestones !== undefined && { milestones }),
+    ...(risks !== undefined && { risks }),
+    ...(tasks !== undefined && { tasks }),
     ...(typeof s['notes'] === 'string' && { notes: s['notes'] }),
   };
 }
@@ -52,6 +156,7 @@ export const OutlineSchema: SchemaLike<Outline> = {
     if (!Array.isArray(o['slides'])) throw new Error('outline.slides must be array');
     return {
       title: o['title'],
+      ...(typeof o['subtitle'] === 'string' && { subtitle: o['subtitle'] }),
       slides: (o['slides'] as unknown[]).map(parseSlideItem),
     };
   },
@@ -61,14 +166,66 @@ export const OutlineSchema: SchemaLike<Outline> = {
       required: ['title', 'slides'],
       properties: {
         title: { type: 'string' },
+        subtitle: { type: 'string' },
         slides: {
           type: 'array',
           items: {
             type: 'object',
-            required: ['heading', 'bullets'],
+            required: ['type', 'title'],
             properties: {
-              heading: { type: 'string' },
+              type: { type: 'string', enum: SLIDE_TYPES },
+              title: { type: 'string' },
+              presenterName: { type: 'string' },
+              subtitle: { type: 'string' },
               bullets: { type: 'array', items: { type: 'string' } },
+              cards: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['title'],
+                  properties: {
+                    title: { type: 'string' },
+                    value: { type: 'string' },
+                    detail: { type: 'string' },
+                  },
+                },
+              },
+              milestones: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['label'],
+                  properties: {
+                    label: { type: 'string' },
+                    date: { type: 'string' },
+                    status: { type: 'string' },
+                  },
+                },
+              },
+              risks: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['risk', 'impact', 'mitigation'],
+                  properties: {
+                    risk: { type: 'string' },
+                    impact: { type: 'string' },
+                    mitigation: { type: 'string' },
+                  },
+                },
+              },
+              tasks: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['owner', 'task'],
+                  properties: {
+                    owner: { type: 'string' },
+                    task: { type: 'string' },
+                    due: { type: 'string' },
+                  },
+                },
+              },
               notes: { type: 'string' },
             },
           },

--- a/packages/skills/src/slides.ts
+++ b/packages/skills/src/slides.ts
@@ -110,7 +110,10 @@ async function runSlides(ctx: Parameters<Skill['run']>[0], msg: Message): Return
   ]);
 
   // a. process fetchHistory
-  if (!historyResult.ok) return err(historyResult.error);
+  if (!historyResult.ok) {
+    await patchErrorCard(ctx, loadingMessageId, '幻灯片生成', historyResult.error.message);
+    return err(historyResult.error);
+  }
   const history = historyResult.value.messages;
 
   // d. process fetchMembers
@@ -141,7 +144,10 @@ async function runSlides(ctx: Parameters<Skill['run']>[0], msg: Message): Return
     OutlineSchema,
     { model: 'pro', timeoutMs: 90_000, maxTokens: 2600, temperature: 0.2 },
   );
-  if (!outlineResult.ok) return err(outlineResult.error);
+  if (!outlineResult.ok) {
+    await patchErrorCard(ctx, loadingMessageId, '幻灯片生成', outlineResult.error.message);
+    return err(outlineResult.error);
+  }
   const outline = outlineResult.value;
 
   // e. 汇报分工从 outline.presenterName 生成；LLM 在一次大纲调用里已根据聊天贡献分配负责人。
@@ -163,7 +169,10 @@ async function runSlides(ctx: Parameters<Skill['run']>[0], msg: Message): Return
   ]);
 
   // f. handle slides creation result
-  if (!slidesResult.ok) return err(slidesResult.error);
+  if (!slidesResult.ok) {
+    await patchErrorCard(ctx, loadingMessageId, outline.title, slidesResult.error.message);
+    return err(slidesResult.error);
+  }
 
   // g. handle assignment doc creation result
   if (!assignmentDocResult.ok) {

--- a/packages/skills/src/slides.ts
+++ b/packages/skills/src/slides.ts
@@ -5,9 +5,48 @@
  * 数据流：群聊上下文 + Bitable 快照 → LLM 生成大纲 → 飞书演示文稿 → slides 卡片
  */
 
-import type { Message, Skill } from '@seedhac/contracts';
+import type { ChatMember, Message, Skill } from '@seedhac/contracts';
+import type { SlideDraft } from '@seedhac/contracts';
 import { ErrorCode, err, makeError, ok } from '@seedhac/contracts';
 import { OutlineSchema, SLIDES_PROMPT } from './prompts/slides.js';
+
+/** chatId 正在生成中的锁，防止同一群短时间内重复触发 */
+const generating = new Set<string>();
+
+const SLIDES_NEGATION_PATTERNS: readonly RegExp[] = [
+  /(?:先别|别|不要|不用|无需|不需要|暂时不).{0,12}(?:ppt|幻灯片|演示文稿|演示|汇报)/i,
+];
+
+const SLIDES_REQUEST_PATTERNS: readonly RegExp[] = [
+  /向上级汇报|给老板汇报|做.{0,10}汇报|准备.{0,10}汇报|整理.{0,10}汇报/,
+  /给老板做.{0,4}演示|做.{0,4}演示/,
+  /(?:帮|请|需要|要|得|麻烦|可以|能不能|生成|创建|做|准备|整理|产出|写|弄|交).{0,12}(?:ppt|幻灯片|演示文稿)/i,
+  /(?:ppt|幻灯片|演示文稿).{0,12}(?:生成|创建|做|准备|整理|产出|写|弄|交|汇报|给老板|给.*看)/i,
+];
+
+const ASSIGNMENT_FALLBACK = {
+  assignments: [
+    {
+      memberName: '待定成员',
+      pages: [] as Array<{ pageIndex: number; heading: string; talkingPoints: string[] }>,
+    },
+  ],
+};
+
+interface AssignmentPage {
+  readonly pageIndex: number;
+  readonly heading: string;
+  readonly talkingPoints: readonly string[];
+}
+
+interface AssignmentItem {
+  readonly memberName: string;
+  readonly pages: readonly AssignmentPage[];
+}
+
+interface Assignment {
+  readonly assignments: readonly AssignmentItem[];
+}
 
 export const slidesSkill: Skill = {
   name: 'slides',
@@ -20,7 +59,8 @@ export const slidesSkill: Skill = {
   match: (ctx) => {
     if (ctx.event.type !== 'message') return false;
     const text = (ctx.event.payload as Message).text;
-    return /ppt|幻灯片|演示文稿|向上级汇报|给老板汇报|做个演示|做.{0,10}汇报/i.test(text);
+    if (SLIDES_NEGATION_PATTERNS.some((pattern) => pattern.test(text))) return false;
+    return SLIDES_REQUEST_PATTERNS.some((pattern) => pattern.test(text));
   },
   run: async (ctx) => {
     const msg = ctx.event.payload as Message;
@@ -30,75 +70,282 @@ export const slidesSkill: Skill = {
       return err(makeError(ErrorCode.CONFIG_MISSING, 'slides client is not configured'));
     }
 
-    ctx.logger.info('slides: received request', { chatId, messageId: msg.messageId });
-    const ackResult = await ctx.runtime.sendText({
-      chatId,
-      text: '收到，正在生成演示文稿。这个过程可能需要 30 秒左右，我生成好后会把卡片发到群里。',
-    });
-    if (!ackResult.ok) {
-      ctx.logger.warn('slides: progress acknowledgement failed', {
-        code: ackResult.error.code,
-        message: ackResult.error.message,
-      });
+    if (generating.has(chatId)) {
+      ctx.logger.info('slides: generation already in progress, skipping', { chatId });
+      return ok({ text: '' });
     }
-
-    // a. 拉取群历史消息
-    ctx.logger.info('slides: fetching chat history', { chatId });
-    const historyResult = await ctx.runtime.fetchHistory({ chatId, pageSize: 30 });
-    if (!historyResult.ok) return err(historyResult.error);
-    const history = historyResult.value.messages;
-
-    // b. 查 Bitable 项目快照
-    ctx.logger.info('slides: fetching bitable snapshots', { chatId });
-    const snapshotResult = await ctx.bitable.find({
-      table: 'memory',
-      where: { chatId },
-      pageSize: 3,
-    });
-    const snapshots = snapshotResult.ok ? snapshotResult.value.records : [];
-    if (!snapshotResult.ok) {
-      ctx.logger.warn('slides: bitable snapshots skipped', {
-        code: snapshotResult.error.code,
-        message: snapshotResult.error.message,
-      });
+    generating.add(chatId);
+    try {
+      return await runSlides(ctx, msg);
+    } finally {
+      generating.delete(chatId);
     }
-
-    // c. LLM 生成大纲
-    ctx.logger.info('slides: asking LLM for outline', {
-      historyCount: history.length,
-      snapshotCount: snapshots.length,
-    });
-    const outlineResult = await ctx.llm.askStructured(
-      SLIDES_PROMPT(history, snapshots),
-      OutlineSchema,
-      { model: 'pro' },
-    );
-    if (!outlineResult.ok) return err(outlineResult.error);
-    const outline = outlineResult.value;
-
-    // d. 创建飞书演示文稿
-    ctx.logger.info('slides: creating native presentation', {
-      title: outline.title,
-      pageCount: outline.slides.length,
-    });
-    const slidesResult = await ctx.slides.createFromOutline(outline.title, outline);
-    if (!slidesResult.ok) return err(slidesResult.error);
-
-    // e. 构建 slides 卡片
-    ctx.logger.info('slides: presentation created', { url: slidesResult.value.url });
-    const card = ctx.cardBuilder.build('slides', {
-      title: outline.title,
-      presentationUrl: slidesResult.value.url,
-      pageCount: outline.slides.length,
-      preview: outline.slides.slice(0, 2).map((s) => ({
-        title: s.heading,
-        bullets: s.bullets,
-      })),
-    });
-
-    return ok({
-      card,
-      reasoning: `检测到 PPT 需求，基于 ${history.length} 条群聊记录生成 ${outline.slides.length} 页大纲`,
-    });
   },
 };
+
+async function runSlides(ctx: Parameters<Skill['run']>[0], msg: Message): ReturnType<Skill['run']> {
+  const chatId = msg.chatId;
+  // slides client is guaranteed by the caller (checked before generating.add)
+  const slidesClient = ctx.slides!;
+
+  const loadingCard = ctx.cardBuilder.build('slides', {
+    title: '文件生成中…',
+    presentationUrl: '',
+    pageCount: 0,
+    isLoading: true,
+  });
+  const sentResult = await ctx.runtime.sendCard({ chatId, card: loadingCard });
+  if (!sentResult.ok) return err(sentResult.error);
+  const loadingMessageId = sentResult.value.messageId;
+
+  // ── Parallel batch 1: fetchHistory + fetchMembers + fetchBitable ─────────────
+  ctx.logger.info('slides: fetching history, members, and bitable snapshots in parallel', {
+    chatId,
+  });
+
+  const [historyResult, membersResult, snapshotResult] = await Promise.all([
+    ctx.runtime.fetchHistory({ chatId, pageSize: 20 }),
+    ctx.runtime.fetchMembers({ chatId }),
+    ctx.bitable.find({ table: 'memory', where: { chatId }, pageSize: 2 }),
+  ]);
+
+  // a. process fetchHistory
+  if (!historyResult.ok) return err(historyResult.error);
+  const history = historyResult.value.messages;
+
+  // d. process fetchMembers
+  const members = membersResult.ok ? membersResult.value.members : [];
+  if (!membersResult.ok) {
+    ctx.logger.warn('slides: members skipped', {
+      code: membersResult.error.code,
+      message: membersResult.error.message,
+    });
+  }
+
+  // b. process fetchBitable
+  const snapshots = snapshotResult.ok ? snapshotResult.value.records : [];
+  if (!snapshotResult.ok) {
+    ctx.logger.warn('slides: bitable snapshots skipped', {
+      code: snapshotResult.error.code,
+      message: snapshotResult.error.message,
+    });
+  }
+
+  // c. LLM 生成大纲
+  ctx.logger.info('slides: asking LLM for outline', {
+    historyCount: history.length,
+    snapshotCount: snapshots.length,
+  });
+  const outlineResult = await ctx.llm.askStructured(
+    SLIDES_PROMPT(history, snapshots, members),
+    OutlineSchema,
+    { model: 'pro', timeoutMs: 90_000, maxTokens: 2600, temperature: 0.2 },
+  );
+  if (!outlineResult.ok) return err(outlineResult.error);
+  const outline = outlineResult.value;
+
+  // e. 汇报分工从 outline.presenterName 生成；LLM 在一次大纲调用里已根据聊天贡献分配负责人。
+  ctx.logger.info('slides: building assignment locally', { memberCount: members.length });
+  const assignment = buildAssignment(outline.slides, members);
+
+  // ── Parallel batch 2: createFromOutline + createFromMarkdown ─────────────────
+  ctx.logger.info('slides: creating native presentation and assignment doc in parallel', {
+    title: outline.title,
+    pageCount: outline.slides.length,
+  });
+
+  const assignmentTitle = `${outline.title} — 汇报分工`;
+  const assignmentMd = renderAssignmentMarkdown(assignmentTitle, assignment);
+
+  const [slidesResult, assignmentDocResult] = await Promise.all([
+    slidesClient.createFromOutline(outline.title, outline),
+    ctx.docx.createFromMarkdown(assignmentTitle, assignmentMd),
+  ]);
+
+  // f. handle slides creation result
+  if (!slidesResult.ok) return err(slidesResult.error);
+
+  // g. handle assignment doc creation result
+  if (!assignmentDocResult.ok) {
+    await patchErrorCard(ctx, loadingMessageId, assignmentTitle, assignmentDocResult.error.message);
+    return err(assignmentDocResult.error);
+  }
+
+  // g2. 授予团队成员访问权限。
+  // - slides：lark-cli `--as bot` 创建 → bot 是 owner → bot 自己逐成员 openid 授权。
+  // - 分工文档：bot 用 SDK 创建并 own，可直接 grantMembersEdit。
+  const memberIds = members.map((m) => m.userId);
+  const [slidesMembersEditResult, docEditResult] = await Promise.all([
+    memberIds.length > 0
+      ? slidesClient.grantMembersEdit(slidesResult.value.slidesToken, memberIds)
+      : ok(undefined),
+    memberIds.length > 0
+      ? ctx.docx.grantMembersEdit(assignmentDocResult.value.docToken, 'docx', memberIds)
+      : ok(undefined),
+  ]);
+  if (memberIds.length > 0) {
+    if (!slidesMembersEditResult.ok) {
+      ctx.logger.warn('slides: grant slides members edit failed', {
+        code: slidesMembersEditResult.error.code,
+        message: slidesMembersEditResult.error.message,
+      });
+    } else {
+      ctx.logger.info('slides: granted slides members edit', { memberCount: memberIds.length });
+    }
+    if (!docEditResult.ok) {
+      ctx.logger.warn('slides: grant assignment doc edit failed', {
+        code: docEditResult.error.code,
+        message: docEditResult.error.message,
+      });
+    }
+  } else {
+    ctx.logger.warn('slides: no chat members fetched, skip granting slides permissions', { chatId });
+  }
+
+  // h. patch loading 卡片为最终演示文稿卡片
+  ctx.logger.info('slides: presentation created', { url: slidesResult.value.url });
+  const finalSlidesCard = ctx.cardBuilder.build('slides', {
+    title: outline.title,
+    presentationUrl: slidesResult.value.url,
+    pageCount: outline.slides.length,
+    preview: outline.slides.slice(0, 2).map((s) => ({
+      title: getSlideTitle(s),
+      bullets: getSlideTalkingPoints(s),
+    })),
+  });
+  const patchResult = await ctx.runtime.patchCard({
+    messageId: loadingMessageId,
+    card: finalSlidesCard,
+  });
+  if (!patchResult.ok) {
+    ctx.logger.warn('slides: patch loading card failed', {
+      code: patchResult.error.code,
+      message: patchResult.error.message,
+    });
+  }
+
+  // i. 返回汇报分工文稿卡片，由 wiring 发第二条卡片
+  const assignmentCard = ctx.cardBuilder.build('docPush', {
+    docTitle: assignmentTitle,
+    docUrl: assignmentDocResult.value.url,
+    docType: 'report',
+    summary: `共 ${assignment.assignments.length} 位成员，${outline.slides.length} 页幻灯片`,
+  });
+
+  return ok({
+    card: assignmentCard,
+    reasoning: `检测到 PPT 需求，基于 ${history.length} 条群聊记录生成 ${outline.slides.length} 页大纲与汇报分工`,
+  });
+}
+
+function getSlideTitle(slide: SlideDraft): string {
+  return slide.title;
+}
+
+function getSlideTalkingPoints(slide: SlideDraft): readonly string[] {
+  if (slide.bullets?.length) return slide.bullets;
+  if (slide.cards?.length) {
+    return slide.cards
+      .slice(0, 4)
+      .map((card) => [card.value, card.title, card.detail].filter(Boolean).join(' · '));
+  }
+  if (slide.milestones?.length) {
+    return slide.milestones
+      .slice(0, 4)
+      .map((m) => [m.date, m.label, m.status].filter(Boolean).join(' · '));
+  }
+  if (slide.risks?.length) {
+    return slide.risks.slice(0, 4).map((r) => `${r.risk}：${r.mitigation}`);
+  }
+  if (slide.tasks?.length) {
+    return slide.tasks
+      .slice(0, 4)
+      .map((t) => `${t.owner}：${t.task}${t.due ? `（${t.due}）` : ''}`);
+  }
+  return slide.subtitle ? [slide.subtitle] : [];
+}
+
+function renderAssignmentMarkdown(title: string, assignment: Assignment): string {
+  const effectiveAssignments =
+    assignment.assignments.length > 0 ? assignment.assignments : ASSIGNMENT_FALLBACK.assignments;
+  return `# ${title}\n\n${effectiveAssignments
+    .map(
+      (a) =>
+        `## ${a.memberName}\n${a.pages
+          .map(
+            (p) =>
+              `### 第 ${p.pageIndex + 1} 页：${p.heading}\n${p.talkingPoints
+                .map((point) => `- ${point}`)
+                .join('\n')}`,
+          )
+          .join('\n\n')}`,
+    )
+    .join('\n\n')}`;
+}
+
+function buildAssignment(
+  slides: readonly SlideDraft[],
+  members: readonly ChatMember[],
+): Assignment {
+  const assignees = members.length > 0 ? members : [{ userId: 'pending', name: '待定成员' }];
+  const assignments = assignees.map((member) => ({
+    memberName: member.name,
+    pages: [] as AssignmentPage[],
+  }));
+  const reportSlides = slides
+    .map((slide, pageIndex) => ({ slide, pageIndex }))
+    .filter(({ slide }) => slide.type !== 'cover' && slide.type !== 'closing');
+  const effectiveSlides =
+    reportSlides.length > 0
+      ? reportSlides
+      : slides.map((slide, pageIndex) => ({ slide, pageIndex }));
+
+  effectiveSlides.forEach(({ slide, pageIndex }, index) => {
+    const target =
+      findAssignmentByPresenter(assignments, slide.presenterName) ??
+      assignments[index % assignments.length]!;
+    target.pages.push({
+      pageIndex,
+      heading: getSlideTitle(slide),
+      talkingPoints: getSlideTalkingPoints(slide).slice(0, 3),
+    });
+  });
+
+  return { assignments };
+}
+
+function findAssignmentByPresenter(
+  assignments: readonly { memberName: string; pages: AssignmentPage[] }[],
+  presenterName: string | undefined,
+): { memberName: string; pages: AssignmentPage[] } | undefined {
+  if (!presenterName) return undefined;
+  const normalizedPresenter = normalizeName(presenterName);
+  return assignments.find(
+    (assignment) => normalizeName(assignment.memberName) === normalizedPresenter,
+  );
+}
+
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+async function patchErrorCard(
+  ctx: Parameters<Skill['run']>[0],
+  messageId: string,
+  title: string,
+  message: string,
+): Promise<void> {
+  const errorCard = ctx.cardBuilder.build('slides', {
+    title,
+    presentationUrl: '',
+    pageCount: 0,
+    errorMessage: `文件生成失败：${message}`,
+  });
+  const patchResult = await ctx.runtime.patchCard({ messageId, card: errorCard });
+  if (!patchResult.ok) {
+    ctx.logger.warn('slides: patch error card failed', {
+      code: patchResult.error.code,
+      message: patchResult.error.message,
+    });
+  }
+}

--- a/packages/skills/src/slides.ts
+++ b/packages/skills/src/slides.ts
@@ -77,6 +77,11 @@ export const slidesSkill: Skill = {
     generating.add(chatId);
     try {
       return await runSlides(ctx, msg);
+    } catch (e) {
+      // 守住 Skill.run 契约：失败必须返回 err，不允许向上抛
+      const message = e instanceof Error ? e.message : String(e);
+      ctx.logger.error('slides: runSlides threw unexpectedly', { chatId, message });
+      return err(makeError(ErrorCode.UNKNOWN, `slides crashed: ${message}`, e));
     } finally {
       generating.delete(chatId);
     }


### PR DESCRIPTION
## 背景

群里发 PPT 时，「管理协作者」一直只剩 owner，团队成员从未被加进来；分工文档却完全正常。

## 根因

1. `lark-cli --as user` 创建 slides → owner 是 cli 登录人（个人），bot 对该文件没有管理权限。
2. user 模式还少 OAuth scope `docs:permission.member:create`（lark-cli `--dry-run` 直接报 "insufficient permissions"）。
3. 旧 `grantChatEdit` 走 openchat 授权时还多塞了非法的 `type: 'chat'` 字段，调用就算到了飞书也会被拒。

## 修复

- **`LarkSlidesClient` 默认 `as` 改为 `'bot'`**：bot 创建 = bot owns，bot 自己拿 `tenant_access_token` 就能授权。多人/多团队部署不再依赖任何人登录 lark-cli。
  - lark-cli 在 `--as bot` 模式下还会自动把当前 cli 登录人加为 `full_access`，避免 bot 创建后人类看不见。
- **新增 `grantMembersEdit(slidesToken, userIds[])`**：循环每个 openid 调 `drive.permission.members.create`；识别 lark-cli 两种输出（成功 `{code:0,...}` / 失败 `{ok:false,error:...}`）。
- **skills/slides** 改用 `slidesClient.grantMembersEdit`；分工文档继续走 `ctx.docx.grantMembersEdit`（bot 用 SDK 创建并 own）。
- **SlidesClient 接口** `grantChatEdit` → `grantMembersEdit`；同步更新两个测试文件，新增空 userIds 与失败回包用例。

附带打包了此分支上幻灯片骨架与 Skill 整体改造（cover / timeline / risks / nextSteps 模板、汇报分工文档、negation 关键词、并发抓取等）。

## 实测验证

- ✅ `lark-cli slides +create --as bot --title "..." --slides "..."` 真实创建，bot 是 owner。
- ✅ `lark-cli drive permission.members create --as bot --params '{token,type:slides}' --data '{member_type:openid,...}'` 真实回 `{code:0,msg:"Success"}`，飞书侧已生效。

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r test` (bot: 156/156, skills: 71/71)
- [x] `pnpm lint`（0 errors，仅 scripts 既有 console warning）
- [x] 重启 bot，在群里再触发一次 PPT 生成，确认「管理协作者」出现群所有成员

🤖 Generated with [Claude Code](https://claude.com/claude-code)