### PR TITLE
fix(wiring): close #40 — requirementDoc mapping + taskAssignment/progressUpdate side effects

### DIFF
--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -56,7 +56,9 @@ function makeCtx(event: BotEvent, runtimeOverride?: BotRuntime): SkillContext {
       chat: vi.fn(),
       askStructured: vi.fn(),
     } as unknown as SkillContext['llm'],
-    bitable: {} as SkillContext['bitable'],
+    bitable: {
+      insert: vi.fn().mockResolvedValue(ok({ tableId: 't', recordId: 'r' })),
+    } as unknown as SkillContext['bitable'],
     docx: {} as SkillContext['docx'],
     slides: {} as NonNullable<SkillContext['slides']>,
     cardBuilder: {
@@ -137,19 +139,71 @@ describe('handleEvent wiring', () => {
   });
 
   // 4. intent 无映射（taskAssignment）→ 不触发任何 skill
-  it('intent with no skill mapping → run() not called', async () => {
+  it('taskAssignment intent → writes to bitable memory and no skill runs', async () => {
     const mockSkill: Skill = {
       ...qaSkill,
       match: () => true,
       run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
     };
-    // 分工讨论触发 taskAssignment，intentToSkill 无 taskAssignment 映射
-    const msg = makeMessage({ text: '张三负责前端，李四负责后端', mentions: [] });
+    const msg = makeMessage({ text: '我来负责前端，DDL 下周五', mentions: [] });
     const ctx = makeCtx(makeEvent(msg));
 
     await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
+    // bitable.insert is fire-and-forget; flush microtasks so the promise resolves before assertions
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(mockSkill.run).not.toHaveBeenCalled();
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'memory',
+        row: expect.objectContaining({
+          chatId: msg.chatId,
+          type: 'taskAssignment',
+          content: msg.text,
+        }),
+      }),
+    );
+  });
+
+  it('progressUpdate intent → writes to bitable memory and no skill runs', async () => {
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
+    const msg = makeMessage({ text: '前端模块已完成，下周联调', mentions: [] });
+    const ctx = makeCtx(makeEvent(msg));
+
+    await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockSkill.run).not.toHaveBeenCalled();
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'memory',
+        row: expect.objectContaining({ type: 'progressUpdate' }),
+      }),
+    );
+  });
+
+  it('side-effect bitable insert failure → logs warn but does not throw', async () => {
+    const failingBitable = {
+      insert: vi
+        .fn()
+        .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'bitable down'))),
+    } as unknown as SkillContext['bitable'];
+    const msg = makeMessage({ text: '我来负责前端，DDL 下周五', mentions: [] });
+    const ctx = { ...makeCtx(makeEvent(msg)), bitable: failingBitable };
+
+    await expect(
+      handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>),
+    ).resolves.toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ctx.logger.warn as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'bitable insert failed',
+      expect.objectContaining({ intent: 'taskAssignment', code: ErrorCode.FEISHU_API_ERROR }),
+    );
   });
 
   // 5. skill.run() 返回 err → 不 crash，logger.error 被调用

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -10,7 +10,11 @@ export const intentToSkill: Partial<Record<RouteIntent, SkillName>> = {
   qa: 'qa',
   meetingNotes: 'summary',
   slides: 'slides',
+  requirementDoc: 'requirementDoc',
 };
+
+/** 仅做 Bitable 侧效记录、不触发 skill 的 intent。 */
+const SIDE_EFFECT_INTENTS = new Set<RouteIntent>(['taskAssignment', 'progressUpdate']);
 
 export interface HarnessConfig {
   readonly promptCache: SystemPromptCache;
@@ -44,6 +48,31 @@ export async function handleEvent(
 
   // 非 @mention：保持原有 Skill 路由
   const intent = router.route(msg);
+
+  // taskAssignment / progressUpdate 暂无对应 skill，仅写入 Bitable memory 供后续检索
+  if (SIDE_EFFECT_INTENTS.has(intent)) {
+    void ctx.bitable
+      .insert({
+        table: 'memory',
+        row: {
+          chatId: msg.chatId,
+          type: intent,
+          content: msg.text,
+          timestamp: Date.now(),
+        },
+      })
+      .then((res) => {
+        if (!res.ok) {
+          logger.warn('bitable insert failed', {
+            intent,
+            code: res.error.code,
+            message: res.error.message,
+          });
+        }
+      });
+    return;
+  }
+
   const skillName = intentToSkill[intent];
   if (!skillName) return;
   const skill = skills[skillName];


### PR DESCRIPTION
Closes #40

## 背景

Issue #40 拆三个 fix。前两个先前 PR 已经合并，剩 Fix 3 还差两小项：

- `wiring.ts` 的 `intentToSkill` 缺 `requirementDoc → requirementDoc`，导致需求整理 skill 永远不会被触发。
- `taskAssignment` / `progressUpdate` 两个 intent 路由出来后无人处理，被默默丢弃，没记进 Bitable。

## 修改

- `wiring.ts` 加 `requirementDoc: 'requirementDoc'` 一行映射。
- 新增 `SIDE_EFFECT_INTENTS` 常量；命中后 fire-and-forget 调 `ctx.bitable.insert({ table: 'memory', row: { chatId, type: intent, content, timestamp } })`。
- 插入失败只 `logger.warn`，不抛，主流程继续返回。
- `wiring.test.ts`：
  - `makeCtx` 给 `bitable.insert` 接上 mock（之前是空对象，新代码路径会 throw）。
  - 旧 \"intent with no skill mapping\" 用例改写为 `taskAssignment intent → writes to bitable memory and no skill runs` 的正向断言。
  - 新增 `progressUpdate` 等价用例 + 一个 bitable 返回 err 时不 throw / logger.warn 被调用的回归用例。

## 验收（issue #40 checklist）

- [x] **Fix 1** — `skill-router.ts` 已统一为 `requireMention`（前序 PR 合并，main 上已生效）
- [x] **Fix 2** — `weekly.ts` `events: []` + `cron: '0 17 * * 5'`，`TriggerSpec.cron` 已在 contracts（前序 PR 合并）
- [x] **Fix 3** — `intentToSkill` 包含 `qa`/`meetingNotes`/`slides`/`requirementDoc` 四条；`taskAssignment` / `progressUpdate` 有 Bitable 写入分支（**本 PR**）

> 备注：weekly skill 本体仍是 `SKILL_NOT_IMPLEMENTED`、cron scheduler 也未接，但这是「实现 weekly skill」的范畴，不属 issue #40 三个 bug 的修复。可后续单独开 issue 跟。

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r test`（bot 212/212、skills 71/71）
- [x] `pnpm lint`（0 errors）

🤖 Generated with [Claude Code](https://claude.com/claude-code)