### PR TITLE
fix(memory): lite-model decision, 600s timeout, force stdout flush

### DIFF
--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -16,6 +16,14 @@ import { handleEvent } from './wiring.js';
 
 const DEFAULT_DOCS_ROOT = resolve(fileURLToPath(import.meta.url), '../../../../docs/bot-memory');
 
+// 后台运行时 stdout 默认 block-buffered (4KB)，每条日志几十字节就会滞留好几分钟才刷盘。
+// 强制 stdout/stderr 同步写，保证 nohup/script 重定向到文件时实时可读。
+// 代价：每次 console.* 都同步落盘，但 bot 日志 QPS 很低，可以接受。
+// 参考：https://nodejs.org/api/process.html#a-note-on-process-io
+type WritableWithBlocking = NodeJS.WriteStream & { _handle?: { setBlocking?: (b: boolean) => void } };
+(process.stdout as WritableWithBlocking)._handle?.setBlocking?.(true);
+(process.stderr as WritableWithBlocking)._handle?.setBlocking?.(true);
+
 const logger: Logger = {
   debug: (msg, meta) => console.debug(`[bot] ${msg}`, meta ?? ''),
   info: (msg, meta) => console.info(`[bot] ${msg}`, meta ?? ''),

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -145,7 +145,9 @@ async function handleWithHarness(
 
   const skillChoices = [...registeredSkillNames(skills), 'silent'].join('|');
   const decisionInstruction =
-    '请按需调用 skill.list / skill.read / memory.search，然后只输出 JSON：' +
+    '可调用工具：skill.list / skill.read / memory.search 用于检索，' +
+    'memory.write 用于把消息中的可记忆事实（项目目标/用户群体/截止日期/分工/关键决策/文档链接）写入记忆。' +
+    '工具调用完成后只输出 JSON：' +
     `{"skill":"${skillChoices}","reason":"一句话原因","args":{}}。` +
     '如果不应处理，skill 必须是 "silent"。不要输出 JSON 以外的文字。';
 
@@ -158,7 +160,8 @@ async function handleWithHarness(
     tools: getLLMTools(),
     executor,
     maxToolCallRounds: 5,
-    timeoutMs: 60_000,
+    model: 'lite', // 决策走 lite — pro 在长输出下经常 30s+，lite 通常 5-10s
+    timeoutMs: 600_000, // 10 分钟：留够长任务（PPT 生成等）的余地，LLM 自己也会写完结束
   });
 
   if (!result.ok) {
@@ -383,7 +386,7 @@ async function handlePassiveObserve(
     messages,
     [writeTool],
     executor,
-    30_000, // 被动观察用更短超时，30s 还回不来就放弃
+    600_000, // 10 分钟：与主动路径对齐，避免 LLM 写记忆中途被切
   );
 
   if (!result.ok) {


### PR DESCRIPTION
## Summary

Three follow-ups discovered while end-to-end testing the harness path merged in #87. All three were causing user-visible flakiness:

1. **Decision LLM moved to lite.** \`pro\` was hitting 28-41s on long-output prompts; with wiki links the third attempt also timed out, so 3 × 60s = 180s of dead air before the bot did anything. \`lite\` finishes the same decision in 7-9s end-to-end.

2. **\`chatWithTools\` timeoutMs 60s → 600s** for both harness + passive paths. Long-running skills (slides generation, requirementDoc with linked-doc fetches, upcoming PPT generation) need this. Failure mode is the LLM finishing on its own, not the timer.

3. **\`memory.write\` mentioned in the decision instruction.** Without it, the decision LLM only knew about read/search and would silently skip writes — the model knew the tool existed (system prompt lists it) but the inline instruction told it to consider read/search only.

4. **\`process.stdout/stderr.setBlocking(true)\`** at boot. macOS Node defaults to a 4KB block buffer when stdout is redirected to a file under nohup. Bot logs are short, so they'd sit in memory for minutes — bot looked frozen while it was actually working. Calling \`setBlocking(true)\` (Node's official API for CLI tools, used by yarn/pnpm) forces sync writes; cost is microseconds per log line.

## Verified end-to-end

- Passive observe (no @mention): wrote a Bitable record with \`source_skill='passive_observe'\` 18s after the message landed. lite model 9s decision + 3s write + 6s wrap-up.
- Active harness (@mention): wrote \`source_skill='harness'\` ~50s end-to-end with auto-rated importance=8.

## Test plan

- [ ] Group chat (no @): \`项目背景：...\` → bot stays silent, Bitable gets a row with \`source_skill='passive_observe'\`
- [ ] Group chat: \`@bot 记一下：项目代号 X\` → Bitable gets a row with \`source_skill='harness'\`
- [ ] \`pnpm --filter @seedhac/bot dev:check-memory\` shows the rows
- [ ] Tail \`/tmp/bot-boot.log\` while bot runs — log lines appear immediately, not after multi-minute delays