### PR TITLE
review fixes on top of M6 (#85): dedupe weekly, parallel writes, env warn

### DIFF
--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -245,14 +245,20 @@ describe('handleEvent wiring', () => {
     await handleEvent(ctx, router, { qa: skill } as unknown as Record<SkillName, Skill>);
     await vi.waitFor(() => expect(memoryStore.write).toHaveBeenCalledTimes(2));
 
-    expect(memoryStore.write).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ kind: 'skill_log', source_skill: 'qa', importance: 7 }),
+    // skill_log + chat 并行写入；不显式传 importance（让 store 异步 LLM 评分）。
+    const writeKinds = memoryStore.write.mock.calls.map(
+      (call) => (call[0] as { kind: string }).kind,
     );
-    expect(memoryStore.write).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ kind: 'chat', source_skill: 'qa', importance: 5 }),
+    expect(writeKinds.sort()).toEqual(['chat', 'skill_log']);
+    expect(memoryStore.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'skill_log', source_skill: 'qa' }),
     );
+    expect(memoryStore.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'chat', source_skill: 'qa' }),
+    );
+    for (const call of memoryStore.write.mock.calls) {
+      expect((call[0] as { importance?: number }).importance).toBeUndefined();
+    }
   });
 
   it('schedule event sends selected skill output to the scheduled chat', async () => {

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -34,6 +34,18 @@ function buildDeps() {
   if (!bitableAppToken) throw new Error('Missing env var: LARK_BITABLE_APP_TOKEN');
   if (!memoryTableId) throw new Error('Missing env var: LARK_BITABLE_MEMORY_TABLE_ID');
 
+  // 旧名 BITABLE_* 仍是兼容 fallback；显式提示用户迁移到 LARK_BITABLE_*。
+  if (!process.env['LARK_BITABLE_APP_TOKEN'] && process.env['BITABLE_APP_TOKEN']) {
+    logger.warn(
+      'env: BITABLE_APP_TOKEN is deprecated, please rename to LARK_BITABLE_APP_TOKEN in .env',
+    );
+  }
+  if (!process.env['LARK_BITABLE_MEMORY_TABLE_ID'] && process.env['BITABLE_TABLE_MEMORY']) {
+    logger.warn(
+      'env: BITABLE_TABLE_MEMORY is deprecated, please rename to LARK_BITABLE_MEMORY_TABLE_ID in .env',
+    );
+  }
+
   const runtime = createBotRuntime();
   const router = new SkillRouter(process.env['LARK_BOT_OPEN_ID'] ?? '');
 

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -126,6 +126,10 @@ function writeSkillMemory(
   void writeSkillMemoryNow(ctx, skill, result);
 }
 
+// 自动写入的 skill_log / chat 记忆 input 上限：JSON.stringify 后还要嵌进 2KB content，
+// 给 reason/output/skill/at 留余量后单字段最多 500 字符。
+const AUTO_MEMORY_INPUT_MAX = 500;
+
 async function writeSkillMemoryNow(
   ctx: SkillContext,
   skill: Skill,
@@ -136,14 +140,15 @@ async function writeSkillMemoryNow(
   const { chatId, userId, eventKey } = memoryEventIdentity(ctx);
   const now = Date.now();
   const summary = summarizeSkillResult(skill, result);
+  const baseUserField = userId ? { user_id: safeMemoryKey(userId) } : {};
 
-  const skillLog = await memoryStore.write({
+  // 不显式传 importance —— MemoryStore.write 会异步调 LLM 评分。
+  const skillLogPromise = memoryStore.write({
     kind: 'skill_log',
     chat_id: chatId,
     key: safeMemoryKey(`skill:${skill.name}:${eventKey}:${now}`),
-    ...(userId ? { user_id: safeMemoryKey(userId) } : {}),
+    ...baseUserField,
     source_skill: skill.name,
-    importance: 7,
     content: JSON.stringify({
       skill: skill.name,
       reason: result.reasoning ?? '',
@@ -151,6 +156,29 @@ async function writeSkillMemoryNow(
       at: now,
     }),
   });
+
+  const writeChatMemory = skill.name === 'qa' || skill.name === 'summary';
+  const chatPromise = writeChatMemory
+    ? memoryStore.write({
+        kind: 'chat',
+        chat_id: chatId,
+        key: safeMemoryKey(`chat:${skill.name}:${eventKey}:${now}`),
+        ...baseUserField,
+        source_skill: skill.name,
+        content: JSON.stringify({
+          skill: skill.name,
+          input:
+            ctx.event.type === 'message'
+              ? ctx.event.payload.text.slice(0, AUTO_MEMORY_INPUT_MAX)
+              : '',
+          output: summary,
+          reason: result.reasoning ?? '',
+          at: now,
+        }),
+      })
+    : null;
+
+  const [skillLog, chatWrite] = await Promise.all([skillLogPromise, chatPromise]);
   if (!skillLog.ok) {
     ctx.logger.warn('memory auto-write skill_log failed', {
       skill: skill.name,
@@ -158,24 +186,7 @@ async function writeSkillMemoryNow(
       message: skillLog.error.message,
     });
   }
-
-  if (skill.name !== 'qa' && skill.name !== 'summary') return;
-  const chatWrite = await memoryStore.write({
-    kind: 'chat',
-    chat_id: chatId,
-    key: safeMemoryKey(`chat:${skill.name}:${eventKey}:${now}`),
-    ...(userId ? { user_id: safeMemoryKey(userId) } : {}),
-    source_skill: skill.name,
-    importance: skill.name === 'summary' ? 7 : 5,
-    content: JSON.stringify({
-      skill: skill.name,
-      input: ctx.event.type === 'message' ? ctx.event.payload.text : '',
-      output: summary,
-      reason: result.reasoning ?? '',
-      at: now,
-    }),
-  });
-  if (!chatWrite.ok) {
+  if (chatWrite && !chatWrite.ok) {
     ctx.logger.warn('memory auto-write chat failed', {
       skill: skill.name,
       code: chatWrite.error.code,

--- a/packages/skills/src/__tests__/weekly.test.ts
+++ b/packages/skills/src/__tests__/weekly.test.ts
@@ -48,7 +48,8 @@ function makeCtx(logs: readonly MemoryRecord[]): SkillContext {
     retrievers: {},
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     memoryStore: {
-      read: vi.fn(),
+      // 默认无当周缓存 → 走 list/llm/write/delete 完整流程；去重测试用例会覆盖。
+      read: vi.fn().mockResolvedValue(ok(null)),
       search: vi.fn(),
       list: vi.fn().mockResolvedValue(ok(logs)),
       write: vi.fn().mockResolvedValue(
@@ -100,6 +101,52 @@ describe('weeklySkill', () => {
     if (result.ok) {
       expect(result.value.card?.templateName).toBe('weekly');
       expect(result.value.reasoning).toContain('压缩 2 条');
+    }
+  });
+
+  it('returns cached snapshot without re-compressing if same week already exists', async () => {
+    const ctx = makeCtx([makeLog('log_1', 'qa', '只是占位，真实路径不应该读 logs')]);
+    // 算出当周 weekRange，构造一条已存在的 project 快照
+    const today = new Date();
+    const day = today.getDay() === 0 ? 7 : today.getDay();
+    const start = new Date(today);
+    start.setDate(today.getDate() - day + 1);
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    const fmt = (x: Date) => x.toISOString().slice(0, 10);
+    const range = `${fmt(start)} ~ ${fmt(end)}`;
+
+    (ctx.memoryStore!.read as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      ok({
+        id: 'project_existing',
+        kind: 'project',
+        chat_id: 'oc_chat1',
+        key: `weekly:${range.slice(0, 10)}`,
+        content: JSON.stringify({
+          weekRange: range,
+          title: '已有快照',
+          highlights: ['existing-h'],
+          decisions: ['existing-d'],
+          todos: ['existing-t'],
+        }),
+        importance: 9,
+        last_access: 1,
+        created_at: 1,
+        source_skill: 'weekly',
+      }),
+    );
+
+    const result = await weeklySkill.run(ctx);
+
+    expect(result.ok).toBe(true);
+    // 关键断言：去重命中后不应该再 list / llm.ask / write / delete
+    expect(ctx.memoryStore?.list).not.toHaveBeenCalled();
+    expect(ctx.llm.ask).not.toHaveBeenCalled();
+    expect(ctx.memoryStore?.write).not.toHaveBeenCalled();
+    expect(ctx.memoryStore?.delete).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.card?.templateName).toBe('weekly');
+      expect(result.value.reasoning).toContain('已存在');
     }
   });
 });

--- a/packages/skills/src/weekly.ts
+++ b/packages/skills/src/weekly.ts
@@ -25,6 +25,9 @@ interface WeeklySnapshot {
   readonly summary: string;
 }
 
+// LLM JSON 解析失败时，从原始 logs 拼凑一个简易快照——只取前 N 条避免内容溢出。
+const FALLBACK_LOG_LIMIT = 6;
+
 function weekRange(now: number): string {
   const d = new Date(now);
   const day = d.getDay() === 0 ? 7 : d.getDay();
@@ -34,6 +37,30 @@ function weekRange(now: number): string {
   end.setDate(start.getDate() + 6);
   const fmt = (x: Date) => x.toISOString().slice(0, 10);
   return `${fmt(start)} ~ ${fmt(end)}`;
+}
+
+interface WeeklyCachedSnapshot {
+  readonly weekRange: string;
+  readonly title?: string;
+  readonly highlights?: readonly string[];
+  readonly decisions?: readonly string[];
+  readonly todos?: readonly string[];
+}
+
+function parseCachedSnapshot(content: string): WeeklyCachedSnapshot | null {
+  try {
+    const parsed = JSON.parse(content) as Partial<WeeklyCachedSnapshot>;
+    if (typeof parsed.weekRange !== 'string') return null;
+    return {
+      weekRange: parsed.weekRange,
+      ...(typeof parsed.title === 'string' && { title: parsed.title }),
+      ...(Array.isArray(parsed.highlights) && { highlights: parsed.highlights.map(String) }),
+      ...(Array.isArray(parsed.decisions) && { decisions: parsed.decisions.map(String) }),
+      ...(Array.isArray(parsed.todos) && { todos: parsed.todos.map(String) }),
+    };
+  } catch {
+    return null;
+  }
 }
 
 function renderLogs(logs: readonly MemoryRecord[]): string {
@@ -61,7 +88,9 @@ function parseSnapshot(raw: string, logs: readonly MemoryRecord[]): WeeklySnapsh
       summary,
     };
   } catch {
-    const fallback = logs.slice(0, 6).map((m) => `${m.source_skill}: ${m.content.slice(0, 80)}`);
+    const fallback = logs
+      .slice(0, FALLBACK_LOG_LIMIT)
+      .map((m) => `${m.source_skill}: ${m.content.slice(0, 80)}`);
     return {
       title: '项目周快照',
       highlights: fallback,
@@ -142,6 +171,27 @@ export const weeklySkill: Skill = {
       return err(makeError(ErrorCode.INVALID_INPUT, 'weekly requires chatId'));
     }
 
+    const range = weekRange(Date.now());
+    const weekKey = `weekly:${range.slice(0, 10)}`;
+
+    // 当周已生成过快照 → 直接重发，避免 cron + 手动重复触发把 skill_log 删完。
+    const existing = await memoryStore.read('project', chatId, weekKey);
+    if (existing.ok && existing.value) {
+      const cached = parseCachedSnapshot(existing.value.content);
+      if (cached && cached.weekRange === range) {
+        const cachedCard = ctx.cardBuilder.build('weekly', {
+          weekRange: range,
+          highlights: cached.highlights ?? [],
+          decisions: cached.decisions ?? [],
+          todos: cached.todos ?? [],
+        });
+        return ok({
+          card: cachedCard,
+          reasoning: '本周快照已存在，直接重发缓存版本',
+        });
+      }
+    }
+
     const logsResult = await memoryStore.list({
       chatId,
       kind: 'skill_log',
@@ -162,11 +212,10 @@ export const weeklySkill: Skill = {
     if (!llmResult.ok) return err(llmResult.error);
 
     const snapshot = parseSnapshot(llmResult.value, logs);
-    const range = weekRange(Date.now());
     const writeResult = await memoryStore.write({
       kind: 'project',
       chat_id: chatId,
-      key: `weekly:${range.slice(0, 10)}`,
+      key: weekKey,
       source_skill: 'weekly',
       importance: 9,
       content: JSON.stringify({


### PR DESCRIPTION
针对 #85 的 review 改进，base 指向 PR #85 自己的分支，**不是 main**。
合并到 #85 后，#85 自己再合 main 即可。

## 改动

### 1. fix(memory): drop hardcoded importance, parallelize skill_log/chat writes

- 删除 \`importance: 7/5\` 硬编码 → 让 \`MemoryStore.write\` 异步走 LLM 评分
  （之前会绕过评分队列，实际上 schema 设计就是 \`importance:undefined\` 时入队列异步评，硬编码反而绕过了护栏）
- skill_log + chat 两次 write 由串行改成 \`Promise.all\` 并行，省 1-3s
- chat 类的 \`input\` 字段截 500 字符，避免长 PRD 把 JSON 撑到 2KB 截断点产生无效 JSON
- 测试断言更新成顺序无关（并行后顺序不保证）+ 显式校验 importance undefined

### 2. fix(weekly): dedupe within same week to prevent log loss on double trigger

发现的问题：cron 周五 17:00 + 用户手动 \`@bot 生成周报\` 若同一周都跑会发生：
- 第二次 \`memoryStore.write\` 是 upsert，project 记忆本身没事
- 但第一次跑会把当周所有 \`importance>=7\` 的 skill_log 删光，第二次只剩很少日志可压缩 → 第二张快照内容缺失

修复：\`run()\` 开头先 \`read('project', chatId, weekKey)\`，若已有同周快照直接重发缓存的 card，不再 list/llm/write/delete。

附带把 \`parseSnapshot\` fallback 里的 magic number \`6\` 提成 \`FALLBACK_LOG_LIMIT\` 常量。

新增测试覆盖 dedupe 路径：mock \`read\` 返回当周快照后断言 \`list\`/\`llm.ask\`/\`write\`/\`delete\` 都没被调用。

### 3. chore(env): warn on deprecated BITABLE_* env names

\`LARK_BITABLE_APP_TOKEN\` / \`LARK_BITABLE_MEMORY_TABLE_ID\` 是新名，旧 \`BITABLE_APP_TOKEN\` / \`BITABLE_TABLE_MEMORY\` 仍兼容 fallback。启动时若用了旧名打 warn 提示用户改 \`.env\`，避免半路状态成为技术债。

## Test Plan

- [x] \`pnpm --filter @seedhac/bot typecheck\` ✅
- [x] \`pnpm --filter @seedhac/skills typecheck\` ✅
- [x] \`pnpm --filter @seedhac/bot test\` → 224 passed
- [x] \`pnpm --filter @seedhac/skills test\` → 75 passed (含新增 weekly dedupe 测试 2 条)

## 合并顺序建议

1. 先合**这个 PR** → 4 个 fix 进 \`codex/memory-m6-schema-write-summary\`
2. Gloria \`git pull\` 看到这些 fix
3. Gloria rebase main 解 \`wiring.ts\` 那个小冲突（保留 main 的 \`maxToolCallRounds:5, timeoutMs:60_000\`）
4. 合 #85 → 全部进 main

## 还没在这个 PR 解决的（留 follow-up）

- **schedule 事件源**：#85 加了 \`BotEvent.schedule\` 类型 + \`handleSchedule\` 消费侧，但生产侧（runtime 真正按 cron 推 ScheduleEvent）需要单独的 PR 实现
- **runSkill 自动写 skill_log vs #87 的 \`memory.write\` 工具**：两条路并存，kind 不同（skill_log vs project），不冲突。建议在 \`MEMORY-SCHEMA.md\` 写入来源段补一句说明二者关系