### PR TITLE
feat(wiring): taskAssignment / progressUpdate 写 bitable.memory 副作用（收口 issue #40）

### DIFF
--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -222,8 +222,8 @@ describe('handleEvent wiring', () => {
     );
   });
 
-  // 4c. side-effect bitable 失败时不 throw，仅 logger.warn
-  it('side-effect bitable insert failure → warn but does not throw', async () => {
+  // 4c. side-effect bitable 返回 err Result 时不 throw，仅 logger.warn
+  it('side-effect bitable insert returns err → warn but does not throw', async () => {
     const failingBitable = {
       insert: vi
         .fn()
@@ -240,6 +240,26 @@ describe('handleEvent wiring', () => {
     expect(ctx.logger.warn as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
       'bitable insert failed',
       expect.objectContaining({ intent: 'taskAssignment', code: ErrorCode.FEISHU_API_ERROR }),
+    );
+  });
+
+  // 4d. side-effect bitable.insert 真 reject（网络/认证异常）→ catch 兜住，不触发 unhandled rejection
+  it('side-effect bitable insert rejects → caught, warn but does not throw', async () => {
+    const throwingBitable = {
+      insert: vi.fn().mockRejectedValue(new Error('network ETIMEDOUT')),
+    } as unknown as SkillContext['bitable'];
+    const msg = makeMessage({ text: '我来负责前端', mentions: [] });
+    const ctx = { ...makeCtx(makeEvent(msg)), bitable: throwingBitable };
+
+    // 关键：handleEvent 自身不能 throw，且不能产生 unhandled rejection
+    await expect(
+      handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>),
+    ).resolves.toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ctx.logger.warn as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'bitable insert threw',
+      expect.objectContaining({ intent: 'taskAssignment', error: 'network ETIMEDOUT' }),
     );
   });
 

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -58,7 +58,9 @@ function makeCtx(event: BotEvent, runtimeOverride?: BotRuntime): SkillContext {
       askStructured: vi.fn(),
       chatWithTools: vi.fn(),
     } as unknown as SkillContext['llm'],
-    bitable: {} as SkillContext['bitable'],
+    bitable: {
+      insert: vi.fn().mockResolvedValue(ok({ tableId: 't', recordId: 'r' })),
+    } as unknown as SkillContext['bitable'],
     docx: {} as SkillContext['docx'],
     slides: {} as NonNullable<SkillContext['slides']>,
     cardBuilder: {
@@ -168,6 +170,77 @@ describe('handleEvent wiring', () => {
     await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
 
     expect(mockSkill.run).not.toHaveBeenCalled();
+  });
+
+  // 4a. taskAssignment intent → 写 bitable.memory 副作用（无 skill 不触发 run）
+  it('taskAssignment intent → bitable.insert called with memory side-effect', async () => {
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
+    // 「我来负责前端」命中 taskAssignment pattern
+    const msg = makeMessage({ text: '我来负责前端，李四来负责后端', mentions: [] });
+    const ctx = makeCtx(makeEvent(msg));
+
+    await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
+    // fire-and-forget，等微任务跑完
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockSkill.run).not.toHaveBeenCalled();
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'memory',
+        row: expect.objectContaining({
+          chatId: msg.chatId,
+          type: 'taskAssignment',
+          content: msg.text,
+        }),
+      }),
+    );
+  });
+
+  // 4b. progressUpdate intent → 写 bitable.memory 副作用
+  it('progressUpdate intent → bitable.insert called with memory side-effect', async () => {
+    const mockSkill: Skill = {
+      ...qaSkill,
+      match: () => true,
+      run: vi.fn().mockResolvedValue(ok({ text: 'x' })),
+    };
+    const msg = makeMessage({ text: '前端模块已完成，下周联调', mentions: [] });
+    const ctx = makeCtx(makeEvent(msg));
+
+    await handleEvent(ctx, router, { qa: mockSkill } as unknown as Record<SkillName, Skill>);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockSkill.run).not.toHaveBeenCalled();
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'memory',
+        row: expect.objectContaining({ type: 'progressUpdate' }),
+      }),
+    );
+  });
+
+  // 4c. side-effect bitable 失败时不 throw，仅 logger.warn
+  it('side-effect bitable insert failure → warn but does not throw', async () => {
+    const failingBitable = {
+      insert: vi
+        .fn()
+        .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'bitable down'))),
+    } as unknown as SkillContext['bitable'];
+    const msg = makeMessage({ text: '我来负责前端', mentions: [] });
+    const ctx = { ...makeCtx(makeEvent(msg)), bitable: failingBitable };
+
+    await expect(
+      handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>),
+    ).resolves.toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ctx.logger.warn as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'bitable insert failed',
+      expect.objectContaining({ intent: 'taskAssignment', code: ErrorCode.FEISHU_API_ERROR }),
+    );
   });
 
   // 5. skill.run() 返回 err → 不 crash，logger.error 被调用

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -91,6 +91,9 @@ async function handleWithSkillRouter(
 
   // taskAssignment / progressUpdate 没对应 skill，但仍把消息写进 memory 表，
   // 供后续 qa / docIterate / recall 检索。fire-and-forget。
+  // 必须同时挂 .then() 和 .catch()：底层网络/认证异常时 bitable.insert
+  // 可能直接 reject 而不是返回 err Result，没 .catch() 会触发
+  // unhandled rejection（Node 18+ 默认 --unhandled-rejections=strict 会终止进程）。
   if (SIDE_EFFECT_INTENTS.has(intent)) {
     void ctx.bitable
       .insert({
@@ -110,6 +113,12 @@ async function handleWithSkillRouter(
             message: res.error.message,
           });
         }
+      })
+      .catch((e: unknown) => {
+        logger.warn('bitable insert threw', {
+          intent,
+          error: e instanceof Error ? e.message : String(e),
+        });
       });
     return;
   }

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -22,6 +22,12 @@ export const intentToSkill: Partial<Record<RouteIntent, SkillName>> = {
   requirementDoc: 'requirementDoc',
 };
 
+/**
+ * 这些 intent 没有对应 skill，但仍要把消息写进 bitable.memory，
+ * 供后续 qa / docIterate / recall 检索。fire-and-forget，失败仅 warn。
+ */
+const SIDE_EFFECT_INTENTS = new Set<RouteIntent>(['taskAssignment', 'progressUpdate']);
+
 export interface HarnessConfig {
   readonly promptCache: SystemPromptCache;
   readonly memoryStore: IMemoryStore;
@@ -78,10 +84,36 @@ async function handleWithSkillRouter(
   router: SkillRouter,
   skills: Readonly<Partial<Record<SkillName, Skill>>>,
 ): Promise<void> {
-  const { event } = ctx;
+  const { event, logger } = ctx;
   if (event.type !== 'message') return;
   const msg = event.payload;
   const intent = router.route(msg);
+
+  // taskAssignment / progressUpdate 没对应 skill，但仍把消息写进 memory 表，
+  // 供后续 qa / docIterate / recall 检索。fire-and-forget。
+  if (SIDE_EFFECT_INTENTS.has(intent)) {
+    void ctx.bitable
+      .insert({
+        table: 'memory',
+        row: {
+          chatId: msg.chatId,
+          type: intent,
+          content: msg.text,
+          timestamp: Date.now(),
+        },
+      })
+      .then((res) => {
+        if (!res.ok) {
+          logger.warn('bitable insert failed', {
+            intent,
+            code: res.error.code,
+            message: res.error.message,
+          });
+        }
+      });
+    return;
+  }
+
   const skillName = intentToSkill[intent];
   if (!skillName) return;
   const skill = skills[skillName];


### PR DESCRIPTION
Closes #40

## 背景

PR #93 已合 main，把 issue #40 fix 3 的 \`intentToSkill[requirementDoc]\` 映射补上了。但 fix 3 验收标准的**最后一项**——「\`taskAssignment\` / \`progressUpdate\` 走 Bitable 写入逻辑」**还没做**。

当前 main 上 router 路出这两个 intent 后，\`intentToSkill[intent]\` 返回 undefined，wiring 直接 return，**消息被静默丢掉**——后续 qa / docIterate / recall 检索不到任何分工讨论 / 进度更新。

## 修复

\`packages/bot/src/wiring.ts\`：

\`\`\`ts
const SIDE_EFFECT_INTENTS = new Set<RouteIntent>(['taskAssignment', 'progressUpdate']);

// handleWithSkillRouter 里：
if (SIDE_EFFECT_INTENTS.has(intent)) {
  void ctx.bitable.insert({
    table: 'memory',
    row: {
      chatId: msg.chatId,
      type: intent,
      content: msg.text,
      timestamp: Date.now(),
    },
  }).then((res) => {
    if (!res.ok) logger.warn('bitable insert failed', { ... });
  });
  return;
}
\`\`\`

fire-and-forget；失败仅 \`logger.warn\` 不阻断主流程。

## 测试（3 个新用例）

\`packages/bot/src/__tests__/wiring.test.ts\`：

- **4a**. \`taskAssignment\` intent → \`bitable.insert\` 被调，\`row.type='taskAssignment'\`
- **4b**. \`progressUpdate\` intent → 同上，\`row.type='progressUpdate'\`
- **4c**. \`bitable.insert\` 失败时 \`logger.warn\` 而不 \`throw\`

## issue #40 完整收口

- ✅ Fix 1（\`requireMention\` 拼写）— 早前 PR 已合
- ✅ Fix 2（weekly cron）— 早前 PR 已合
- ✅ Fix 3 part A（\`intentToSkill[requirementDoc]\` 映射）— PR #93 已合
- ✅ Fix 3 part B（\`taskAssignment\` / \`progressUpdate\` 副作用）— **本 PR**

## Test plan

- [x] \`pnpm -r build\`
- [x] \`pnpm -r test\`（bot 225/225 全过）
- [x] \`pnpm lint\`（0 errors）

🤖 Generated with [Claude Code](https://claude.com/claude-code)