### PR TITLE
fix(memory): skill 写入字段对齐 MemoryRecord schema + env trim 防尾随空格

### DIFF
--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -23,32 +23,39 @@ const logger: Logger = {
   error: (msg, meta) => console.error(`[bot] ${msg}`, meta ?? ''),
 };
 
+// 防御性读 env：trim 掉 trailing space / \r / \t
+// 用户复制粘贴 .env 时常带尾随空白；用 token / table_id 拼到 URL 里会直接挂掉
+// 飞书 API（曾导致 BITABLE 写入静默失败）。
+function envTrim(name: string): string {
+  return (process.env[name] ?? '').trim();
+}
+
 function buildDeps() {
-  const appId = process.env['LARK_APP_ID'];
-  const appSecret = process.env['LARK_APP_SECRET'];
+  const appId = envTrim('LARK_APP_ID');
+  const appSecret = envTrim('LARK_APP_SECRET');
   if (!appId) throw new Error('Missing env var: LARK_APP_ID');
   if (!appSecret) throw new Error('Missing env var: LARK_APP_SECRET');
 
   const runtime = createBotRuntime();
-  const router = new SkillRouter(process.env['LARK_BOT_OPEN_ID'] ?? '');
+  const router = new SkillRouter(envTrim('LARK_BOT_OPEN_ID'));
 
   const llm = new VolcanoLLMClient({
-    apiKey: process.env['ARK_API_KEY'] ?? '',
+    apiKey: envTrim('ARK_API_KEY'),
     modelIds: {
-      lite: process.env['ARK_MODEL_LITE'] ?? '',
-      pro: process.env['ARK_MODEL_PRO'] ?? '',
+      lite: envTrim('ARK_MODEL_LITE'),
+      pro: envTrim('ARK_MODEL_PRO'),
     },
   });
 
   const bitable = new LarkBitableClient({
     appId,
     appSecret,
-    appToken: process.env['BITABLE_APP_TOKEN'] ?? '',
+    appToken: envTrim('BITABLE_APP_TOKEN'),
     tableIds: {
-      memory: process.env['BITABLE_TABLE_MEMORY'] ?? '',
-      decision: process.env['BITABLE_TABLE_DECISION'] ?? '',
-      todo: process.env['BITABLE_TABLE_TODO'] ?? '',
-      knowledge: process.env['BITABLE_TABLE_KNOWLEDGE'] ?? '',
+      memory: envTrim('BITABLE_TABLE_MEMORY'),
+      decision: envTrim('BITABLE_TABLE_DECISION'),
+      todo: envTrim('BITABLE_TABLE_TODO'),
+      knowledge: envTrim('BITABLE_TABLE_KNOWLEDGE'),
     },
   });
 

--- a/packages/skills/src/__tests__/requirement-doc.test.ts
+++ b/packages/skills/src/__tests__/requirement-doc.test.ts
@@ -284,12 +284,19 @@ describe('requirementDocSkill.run() — single message scenario', () => {
     expect(ctx.docx.readContent).not.toHaveBeenCalled();
   });
 
-  it('writes memory with type=requirement and docToken', async () => {
+  it('writes memory with new schema (kind=project, key=req-<docToken>, source_skill)', async () => {
     await requirementDocSkill.run(ctx);
     expect(ctx.bitable.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         table: 'memory',
-        row: expect.objectContaining({ type: 'requirement', docToken: MOCK_DOC_REF.docToken }),
+        row: expect.objectContaining({
+          key: `req-${MOCK_DOC_REF.docToken}`,
+          kind: 'project',
+          chat_id: 'oc_chat_001',
+          source_skill: 'requirementDoc',
+          // content 含 docToken url
+          content: expect.stringContaining(MOCK_DOC_REF.url),
+        }),
       }),
     );
   });

--- a/packages/skills/src/requirement-doc.ts
+++ b/packages/skills/src/requirement-doc.ts
@@ -350,14 +350,20 @@ export const requirementDocSkill: Skill = {
     }
 
     // e. 写 memory（失败仅 warn，不阻断卡片输出）
+    //    字段对齐 contracts/MemoryRecord schema（kind / chat_id / key / content / source_skill / importance / created_at / last_access），
+    //    跟 BITABLE memory 表 schema 一致。docToken 嵌进 content 末行（无独立字段位）。
+    const now = Date.now();
     const memRes = await ctx.bitable.insert({
       table: 'memory',
       row: {
-        chatId,
-        type: 'requirement',
-        docToken: fileResult.value.docToken,
-        content: doc.title,
-        timestamp: Date.now(),
+        key: `req-${fileResult.value.docToken}`,
+        kind: 'project',
+        chat_id: chatId,
+        content: `[需求文档] ${doc.title}\n${fileResult.value.url}`,
+        importance: 5,
+        last_access: now,
+        created_at: now,
+        source_skill: 'requirementDoc',
       },
     });
     if (!memRes.ok) {

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -106,13 +106,20 @@ export const summarySkill: Skill = {
       if (!res.ok) ctx.logger.warn('summary: batchInsert todo failed', { error: res.error });
     }
 
+    // 字段对齐 contracts/MemoryRecord schema（kind / chat_id / key / content /
+    // source_skill / importance / created_at / last_access），跟 BITABLE memory 表一致
+    const now = Date.now();
     const memRes = await ctx.bitable.insert({
       table: 'memory',
       row: {
-        chatId,
-        type: 'meeting_summary',
+        key: `summary-${chatId}-${now}`,
+        kind: 'chat',
+        chat_id: chatId,
         content: summary.decisions.join(' | '),
-        timestamp: Date.now(),
+        importance: 5,
+        last_access: now,
+        created_at: now,
+        source_skill: 'summary',
       },
     });
     if (!memRes.ok) ctx.logger.warn('summary: insert memory failed', { error: memRes.error });


### PR DESCRIPTION
Closes #94

## 实测根因（真实飞书 API 验证）

issue #94 报的「\`insert memory failed: no record_id returned\`」是**两个独立 bug 叠加**导致的：

### Bug 1：skill 写入字段名跟 BITABLE memory 表 schema 完全不匹配

main 上 \`contracts/MemoryRecord\` 标准 schema 是（M5/M6 已落）：
\`\`\`
key / kind / chat_id / user_id / content / importance / last_access / created_at / source_skill
\`\`\`

但 \`requirementDoc\` 和 \`summary\` skill **都还在写 PR #84 时代的旧字段**：
\`\`\`
chatId / type / docToken / content / timestamp
\`\`\`

飞书 API 实际返回 \`code: 1254045 FieldNameNotFound\`，例如 \`fields.docToken not found\`。

### Bug 2：env 尾随空格导致 BITABLE_TABLE_* 拼出错误 URL

用户 \`.env\` 里若干 \`BITABLE_TABLE_*\` 末尾有 trailing space（复制粘贴时常见）。bot 直接用 \`process.env\` 没 trim，table_id 带空格 → 飞书 API URL 被编码成 \`%20%20%20...\` → 部分情况下飞书返回 \`code: 0\` 但 \`no record_id\`（这就是 issue #94 报的现象）。

Bug 2 把 Bug 1 的真实错误码盖了，导致用户看到的错误极度难定位。trim 之后才暴露 Bug 1 的 \`FieldNameNotFound\`。

## 修复

### 1. \`packages/skills/src/requirement-doc.ts\` 字段对齐

\`\`\`ts
{
  key: \`req-\${fileResult.value.docToken}\`,
  kind: 'project',  // SingleSelect option
  chat_id: chatId,
  content: \`[需求文档] \${doc.title}\\n\${fileResult.value.url}\`,  // docToken 嵌入 content
  importance: 5,
  last_access: now,
  created_at: now,
  source_skill: 'requirementDoc',
}
\`\`\`

### 2. \`packages/skills/src/summary.ts\` 同样对齐

\`\`\`ts
{
  key: \`summary-\${chatId}-\${now}\`,
  kind: 'chat',
  chat_id: chatId,
  content: summary.decisions.join(' | '),
  importance: 5,
  last_access: now,
  created_at: now,
  source_skill: 'summary',
}
\`\`\`

### 3. \`packages/bot/src/index.ts\` env 防御性 trim

新增 \`envTrim(name)\` helper，所有 \`LARK_*\` / \`ARK_*\` / \`BITABLE_*\` 走它读取，自动 trim 空格 / \\r / \\t。

## 真实飞书 API 验证

修复后用新 schema 直调 \`records.create\`：

\`\`\`
{ "code": 0,
  "data": { "record": { "record_id": "recviLJI3YTU0C", ... }, ... },
  "msg": "success" }
\`\`\`

真实写入成功，bot 跑起来后 \`'insert memory failed'\` warn 应该消失。

## 设计取舍

没走 \`MemoryStore\` 抽象（\`ctx.memoryStore.write(MemoryWriteInput)\`）是因为 \`SkillContext\` 里没暴露 \`memoryStore\`。直接对齐字段是最小改动；把 \`memoryStore\` 拉进 \`SkillContext\` 是更好的架构解但要动 contracts，留给后续重构 issue。

## Test plan

- [x] \`pnpm -r build\`
- [x] \`pnpm -r test\`（skills 89/89 + bot 222/222）
- [x] 真实飞书 API 验证：\`code: 0\` + \`record_id\` 返回
- [ ] 用户在 Test 群发触发消息，bot log 不再有 \`requirementDoc: insert memory failed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)