### PR TITLE
feat(bot): 飞书 API 限流响应感知 — 429/99991400 自动重试 + QuotaTracker 主动收紧

### DIFF
--- a/packages/bot/src/__tests__/bot-runtime.test.ts
+++ b/packages/bot/src/__tests__/bot-runtime.test.ts
@@ -262,6 +262,24 @@ describe('LarkBotRuntime', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  // 8. 撞 99991400 → 自动 retry 一次 → 成功（issue #91 Layer A 集成）
+  it('sendText auto-retries once on feishu rate limit code 99991400', async () => {
+    mockMessageCreate
+      .mockResolvedValueOnce({ code: 99991400, msg: 'rate limit' })
+      .mockResolvedValueOnce({ code: 0, data: { message_id: 'msg_after_retry' } });
+    const runtime = makeRuntime();
+    // recordRateLimited 是同步副作用 —— 在 sleep 之前打的标记，spy 进去而不走真实时间
+    const tracker = runtime.getQuotaTracker();
+    const recordSpy = vi.spyOn(tracker, 'recordRateLimited');
+
+    const result = await runtime.sendText({ chatId: 'oc_chat1', text: '撞限流' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.messageId).toBe('msg_after_retry');
+    expect(mockMessageCreate).toHaveBeenCalledTimes(2);
+    expect(recordSpy).toHaveBeenCalledOnce(); // QuotaTracker 被标记过节流
+  });
+
   it('card action event triggers handler with action payload', async () => {
     const runtime = makeRuntime();
     const handler: EventHandler = vi.fn();

--- a/packages/bot/src/__tests__/bot-runtime.test.ts
+++ b/packages/bot/src/__tests__/bot-runtime.test.ts
@@ -262,6 +262,43 @@ describe('LarkBotRuntime', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  // 回归：fetchHistory / fetchMessage 不能把 SDK 方法摘下来调用，否则丢 `this`
+  // 触发 TypeError（PR #97 review 抓到的真 bug）。这里用一个 strict-this mock 检查。
+  it('fetchHistory preserves `this` binding when calling SDK list', async () => {
+    const observed: { value: unknown } = { value: undefined };
+    mockMessageList.mockImplementation(function (this: unknown, _arg: unknown) {
+      observed.value = this;
+      return Promise.resolve({ code: 0, data: { has_more: false, items: [] } });
+    });
+
+    const runtime = makeRuntime();
+    const result = await runtime.fetchHistory({ chatId: 'oc_chat1' });
+
+    expect(result.ok).toBe(true);
+    // strict mode 下 `this` 丢失会是 undefined；正确绑定时是 mock 所在的对象
+    expect(observed.value).not.toBeUndefined();
+    expect(observed.value).not.toBeNull();
+  });
+
+  it('fetchMessage preserves `this` binding when calling SDK get', async () => {
+    const mockGet = vi.fn();
+    const observed: { value: unknown } = { value: undefined };
+    mockGet.mockImplementation(function (this: unknown, _arg: unknown) {
+      observed.value = this;
+      return Promise.resolve({ code: 0, data: { items: [] } });
+    });
+    // im.message.get 没在顶层 mock 里 —— 直接给 client 临时挂上
+    const runtime = makeRuntime();
+    (runtime as unknown as { client: { im: { message: Record<string, unknown> } } }).client.im.message.get =
+      mockGet;
+
+    const result = await runtime.fetchMessage('msg_1');
+
+    expect(result.ok).toBe(true);
+    expect(observed.value).not.toBeUndefined();
+    expect(observed.value).not.toBeNull();
+  });
+
   // 8. 撞 99991400 → 自动 retry 一次 → 成功（issue #91 Layer A 集成）
   it('sendText auto-retries once on feishu rate limit code 99991400', async () => {
     mockMessageCreate

--- a/packages/bot/src/__tests__/rate-limit.test.ts
+++ b/packages/bot/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  detectRateLimit,
+  globalQuotaTracker,
+  QuotaTracker,
+  withRateLimitRetry,
+} from '../rate-limit.js';
+
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+describe('detectRateLimit', () => {
+  it('detects HTTP 429 thrown by SDK with reset header', () => {
+    const thrown = {
+      response: {
+        status: 429,
+        headers: { 'x-ogw-ratelimit-reset': '3', 'x-ogw-ratelimit-limit': '5' },
+      },
+    };
+    const info = detectRateLimit(thrown, undefined);
+    expect(info).not.toBeNull();
+    expect(info!.resetSec).toBe(3);
+    expect(info!.limit).toBe('5');
+  });
+
+  it('detects feishu rate limit code 99991400 in returned response', () => {
+    const res = { code: 99991400, msg: 'rate limited' };
+    const info = detectRateLimit(undefined, res);
+    expect(info).not.toBeNull();
+    expect(info!.resetSec).toBe(0); // 无 header → 0，调用方退化为 1s
+  });
+
+  it('detects rate limit when SDK throws with body code 99991401', () => {
+    const thrown = { response: { data: { code: 99991401 }, headers: {} } };
+    const info = detectRateLimit(thrown, undefined);
+    expect(info).not.toBeNull();
+  });
+
+  it('returns null for non-rate-limit error', () => {
+    expect(detectRateLimit(new Error('network'), undefined)).toBeNull();
+    expect(detectRateLimit(undefined, { code: 99991663, msg: 'app token invalid' })).toBeNull();
+    expect(detectRateLimit(undefined, { code: 0 })).toBeNull();
+  });
+
+  it('handles array-valued headers', () => {
+    const thrown = {
+      response: { status: 429, headers: { 'X-Ogw-Ratelimit-Reset': ['7'] } },
+    };
+    const info = detectRateLimit(thrown, undefined);
+    expect(info!.resetSec).toBe(7);
+  });
+});
+
+describe('QuotaTracker', () => {
+  beforeEach(() => {
+    globalQuotaTracker.reset();
+  });
+
+  it('isThrottled() flips on after recordRateLimited and back off after window', async () => {
+    const tracker = new QuotaTracker();
+    expect(tracker.isThrottled()).toBe(false);
+    tracker.recordRateLimited(1); // 1s 窗口
+    expect(tracker.isThrottled()).toBe(true);
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(tracker.isThrottled()).toBe(false);
+  });
+
+  it('recordObservation stores last quota snapshot', () => {
+    const tracker = new QuotaTracker();
+    tracker.recordObservation(100, 12, 30);
+    const snap = tracker.getLastObservation();
+    expect(snap?.limit).toBe(100);
+    expect(snap?.remaining).toBe(12);
+    expect(snap?.resetAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('takes the later resetAt when racing recordRateLimited calls', () => {
+    const tracker = new QuotaTracker();
+    tracker.recordRateLimited(1);
+    const before = (tracker as unknown as { resetAtMs: number }).resetAtMs;
+    tracker.recordRateLimited(60);
+    const after = (tracker as unknown as { resetAtMs: number }).resetAtMs;
+    expect(after).toBeGreaterThan(before);
+  });
+});
+
+describe('withRateLimitRetry', () => {
+  beforeEach(() => {
+    globalQuotaTracker.reset();
+  });
+
+  it('returns response immediately on success — no retry', async () => {
+    const fn = vi.fn().mockResolvedValue({ code: 0, data: { ok: true } });
+    const res = await withRateLimitRetry(fn, { context: 'test', sleepFn: noSleep });
+    expect(res).toEqual({ code: 0, data: { ok: true } });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on 99991400 then succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 99991400, msg: 'rate limit' })
+      .mockResolvedValueOnce({ code: 0, data: { id: 'm1' } });
+    const tracker = new QuotaTracker();
+    const res = await withRateLimitRetry(fn, {
+      context: 'test',
+      sleepFn: noSleep,
+      tracker,
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ code: 0, data: { id: 'm1' } });
+    expect(tracker.isThrottled()).toBe(true);
+  });
+
+  it('retries once on HTTP 429 thrown then succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({
+        response: {
+          status: 429,
+          headers: { 'x-ogw-ratelimit-reset': '2' },
+        },
+      })
+      .mockResolvedValueOnce({ code: 0 });
+    const sleepFn = vi.fn(noSleep);
+    await withRateLimitRetry(fn, { context: 'test', sleepFn });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledWith(2000);
+  });
+
+  it('throws original error when not rate-limited', async () => {
+    const error = new Error('network failure');
+    const fn = vi.fn().mockRejectedValue(error);
+    await expect(
+      withRateLimitRetry(fn, { context: 'test', sleepFn: noSleep }),
+    ).rejects.toThrow('network failure');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the still-rate-limited response after exhausting retries', async () => {
+    const fn = vi.fn().mockResolvedValue({ code: 99991400, msg: 'rate limit' });
+    const res = await withRateLimitRetry(fn, {
+      context: 'test',
+      sleepFn: noSleep,
+      maxRetries: 1,
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ code: 99991400, msg: 'rate limit' });
+  });
+
+  it('rethrows the last thrown 429 after exhausting retries', async () => {
+    const error = { response: { status: 429, headers: { 'x-ogw-ratelimit-reset': '1' } } };
+    const fn = vi.fn().mockRejectedValue(error);
+    await expect(
+      withRateLimitRetry(fn, { context: 'test', sleepFn: noSleep, maxRetries: 1 }),
+    ).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('floors reset to 1s when header missing', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 99991400, msg: 'no header' })
+      .mockResolvedValueOnce({ code: 0 });
+    const sleepFn = vi.fn(noSleep);
+    await withRateLimitRetry(fn, { context: 'test', sleepFn });
+    expect(sleepFn).toHaveBeenCalledWith(1000);
+  });
+
+  it('caps reset to 60s if header is unreasonably large', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({
+        response: { status: 429, headers: { 'x-ogw-ratelimit-reset': '3600' } },
+      })
+      .mockResolvedValueOnce({ code: 0 });
+    const sleepFn = vi.fn(noSleep);
+    await withRateLimitRetry(fn, { context: 'test', sleepFn });
+    // > 60 → 退化为 1s（防止单次睡死整个 demo）
+    expect(sleepFn).toHaveBeenCalledWith(1000);
+  });
+
+  it('logs warn with limit/remaining context when retrying', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({
+        response: {
+          status: 429,
+          headers: {
+            'x-ogw-ratelimit-reset': '2',
+            'x-ogw-ratelimit-limit': '5',
+            'x-ogw-ratelimit-remaining': '0',
+          },
+        },
+      })
+      .mockResolvedValueOnce({ code: 0 });
+    const warn = vi.fn();
+    const logger = { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+    await withRateLimitRetry(fn, { context: 'sendText', logger, sleepFn: noSleep });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]![0]).toContain('sendText');
+    expect(warn.mock.calls[0]![1]).toMatchObject({ limit: '5', remaining: '0', attempt: 1 });
+  });
+});

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -400,22 +400,22 @@ export class LarkBotRuntime implements BotRuntime {
   async fetchHistory(params: FetchHistoryParams): Promise<Result<FetchHistoryResult>> {
     await this.limiter.acquire();
     try {
-      const list = (
-        this.client.im.message as unknown as {
-          list: (p: unknown) => Promise<{
-            code?: number;
-            msg?: string;
-            data?: {
-              has_more?: boolean;
-              page_token?: string;
-              items?: Array<Record<string, unknown>>;
-            };
-          }>;
-        }
-      ).list;
+      // 直接在 lambda 里 obj.method(...) 调用，避免摘下方法导致 this 丢失
       const res = await withRateLimitRetry(
         () =>
-          list({
+          (
+            this.client.im.message as unknown as {
+              list: (p: unknown) => Promise<{
+                code?: number;
+                msg?: string;
+                data?: {
+                  has_more?: boolean;
+                  page_token?: string;
+                  items?: Array<Record<string, unknown>>;
+                };
+              }>;
+            }
+          ).list({
             params: {
               container_id: params.chatId,
               container_id_type: 'chat',
@@ -477,17 +477,18 @@ export class LarkBotRuntime implements BotRuntime {
     try {
       // GET /open-apis/im/v1/messages/{message_id}
       // 返回值：data.items[] —— 普通消息只有 1 条；merge_forward 则父在前 + 全部嵌套子
-      const get = (
-        this.client.im.message as unknown as {
-          get: (p: unknown) => Promise<{
-            code?: number;
-            msg?: string;
-            data?: { items?: Array<Record<string, unknown>> };
-          }>;
-        }
-      ).get;
+      // 直接在 lambda 里 obj.method(...) 调用，避免摘下方法导致 this 丢失
       const res = await withRateLimitRetry(
-        () => get({ path: { message_id: messageId } }),
+        () =>
+          (
+            this.client.im.message as unknown as {
+              get: (p: unknown) => Promise<{
+                code?: number;
+                msg?: string;
+                data?: { items?: Array<Record<string, unknown>> };
+              }>;
+            }
+          ).get({ path: { message_id: messageId } }),
         { context: 'fetchMessage', logger: this.logger, tracker: this.tracker },
       );
 

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -12,6 +12,7 @@ import {
   type FetchHistoryResult,
   type FetchMembersParams,
   type FetchMembersResult,
+  type Logger,
   type Message,
   type Mention,
   type UserRef,
@@ -22,8 +23,12 @@ import {
   makeError,
   ErrorCode,
 } from '@seedhac/contracts';
+import { type QuotaTracker, globalQuotaTracker, withRateLimitRetry } from './rate-limit.js';
 
 // ─── 限流器：100 req/min + 5 req/sec ─────────────────────────────────────────
+//
+// Layer B（issue #91）：QuotaTracker.isThrottled() 时把 sec/min 配额减半，
+// 主动收紧本地限流，配合 withRateLimitRetry 的事后退避形成双层防护。
 
 class RateLimiter {
   private secTokens = 5;
@@ -32,6 +37,8 @@ class RateLimiter {
   private lastMin = Date.now();
   private readonly queue: Array<() => void> = [];
   private processing = false;
+
+  constructor(private readonly tracker: QuotaTracker = globalQuotaTracker) {}
 
   acquire(): Promise<void> {
     return new Promise((resolve) => {
@@ -57,9 +64,12 @@ class RateLimiter {
 
   private refill(): void {
     const now = Date.now();
-    this.secTokens = Math.min(5, this.secTokens + ((now - this.lastSec) / 1000) * 5);
+    const factor = this.tracker.isThrottled() ? 0.5 : 1;
+    const maxSec = 5 * factor;
+    const maxMin = 100 * factor;
+    this.secTokens = Math.min(maxSec, this.secTokens + ((now - this.lastSec) / 1000) * maxSec);
     this.lastSec = now;
-    this.minTokens = Math.min(100, this.minTokens + ((now - this.lastMin) / 60000) * 100);
+    this.minTokens = Math.min(maxMin, this.minTokens + ((now - this.lastMin) / 60000) * maxMin);
     this.lastMin = now;
   }
 }
@@ -179,7 +189,9 @@ function parseCardAction(data: Record<string, unknown>): CardAction {
 export class LarkBotRuntime implements BotRuntime {
   private readonly client: lark.Client;
   private readonly wsClient: lark.WSClient;
-  private readonly limiter = new RateLimiter();
+  private readonly tracker: QuotaTracker;
+  private readonly limiter: RateLimiter;
+  private readonly logger: Logger | undefined;
   private readonly handlers = new Set<EventHandler>();
   /** patchCard 节流：messageId → 上次 patch 完成的时间 */
   private readonly patchTimes = new Map<string, number>();
@@ -191,6 +203,8 @@ export class LarkBotRuntime implements BotRuntime {
       verificationToken?: string;
       encryptKey?: string;
       logLevel?: lark.LoggerLevel;
+      logger?: Logger;
+      quotaTracker?: QuotaTracker;
     },
   ) {
     this.client = new lark.Client({
@@ -202,6 +216,14 @@ export class LarkBotRuntime implements BotRuntime {
       appSecret: env.appSecret,
       ...(env.logLevel !== undefined && { loggerLevel: env.logLevel }),
     });
+    this.tracker = env.quotaTracker ?? globalQuotaTracker;
+    this.limiter = new RateLimiter(this.tracker);
+    this.logger = env.logger;
+  }
+
+  /** 暴露给测试 / 监控用，运行时可读取当前配额观测。 */
+  getQuotaTracker(): QuotaTracker {
+    return this.tracker;
   }
 
   on(handler: EventHandler): () => void {
@@ -286,15 +308,19 @@ export class LarkBotRuntime implements BotRuntime {
     await this.limiter.acquire();
     try {
       const content = JSON.stringify({ text: params.text });
-      const res = params.replyTo
-        ? await this.client.im.message.reply({
-            path: { message_id: params.replyTo },
-            data: { msg_type: 'text', content },
-          })
-        : await this.client.im.message.create({
-            params: { receive_id_type: 'chat_id' },
-            data: { receive_id: params.chatId, msg_type: 'text', content },
-          });
+      const res = await withRateLimitRetry(
+        () =>
+          params.replyTo
+            ? this.client.im.message.reply({
+                path: { message_id: params.replyTo! },
+                data: { msg_type: 'text', content },
+              })
+            : this.client.im.message.create({
+                params: { receive_id_type: 'chat_id' },
+                data: { receive_id: params.chatId, msg_type: 'text', content },
+              }),
+        { context: 'sendText', logger: this.logger, tracker: this.tracker },
+      );
 
       if (res.code !== 0) {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `sendText failed: ${res.msg}`));
@@ -314,15 +340,19 @@ export class LarkBotRuntime implements BotRuntime {
     await this.limiter.acquire();
     try {
       const content = JSON.stringify(params.card.content);
-      const res = params.replyTo
-        ? await this.client.im.message.reply({
-            path: { message_id: params.replyTo },
-            data: { msg_type: 'interactive', content },
-          })
-        : await this.client.im.message.create({
-            params: { receive_id_type: 'chat_id' },
-            data: { receive_id: params.chatId, msg_type: 'interactive', content },
-          });
+      const res = await withRateLimitRetry(
+        () =>
+          params.replyTo
+            ? this.client.im.message.reply({
+                path: { message_id: params.replyTo! },
+                data: { msg_type: 'interactive', content },
+              })
+            : this.client.im.message.create({
+                params: { receive_id_type: 'chat_id' },
+                data: { receive_id: params.chatId, msg_type: 'interactive', content },
+              }),
+        { context: 'sendCard', logger: this.logger, tracker: this.tracker },
+      );
 
       if (res.code !== 0) {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `sendCard failed: ${res.msg}`));
@@ -346,10 +376,14 @@ export class LarkBotRuntime implements BotRuntime {
 
     await this.limiter.acquire();
     try {
-      const res = await this.client.im.message.patch({
-        path: { message_id: params.messageId },
-        data: { content: JSON.stringify(params.card.content) },
-      });
+      const res = await withRateLimitRetry(
+        () =>
+          this.client.im.message.patch({
+            path: { message_id: params.messageId },
+            data: { content: JSON.stringify(params.card.content) },
+          }),
+        { context: 'patchCard', logger: this.logger, tracker: this.tracker },
+      );
 
       this.patchTimes.set(params.messageId, Date.now());
 
@@ -366,7 +400,7 @@ export class LarkBotRuntime implements BotRuntime {
   async fetchHistory(params: FetchHistoryParams): Promise<Result<FetchHistoryResult>> {
     await this.limiter.acquire();
     try {
-      const res = await (
+      const list = (
         this.client.im.message as unknown as {
           list: (p: unknown) => Promise<{
             code?: number;
@@ -378,17 +412,22 @@ export class LarkBotRuntime implements BotRuntime {
             };
           }>;
         }
-      ).list({
-        params: {
-          container_id: params.chatId,
-          container_id_type: 'chat',
-          page_size: params.pageSize ?? 20,
-          ...(params.pageToken && { page_token: params.pageToken }),
-          ...(params.startTime && { start_time: String(Math.floor(params.startTime / 1000)) }),
-          ...(params.endTime && { end_time: String(Math.floor(params.endTime / 1000)) }),
-          sort_type: 'ByCreateTimeDesc',
-        },
-      });
+      ).list;
+      const res = await withRateLimitRetry(
+        () =>
+          list({
+            params: {
+              container_id: params.chatId,
+              container_id_type: 'chat',
+              page_size: params.pageSize ?? 20,
+              ...(params.pageToken && { page_token: params.pageToken }),
+              ...(params.startTime && { start_time: String(Math.floor(params.startTime / 1000)) }),
+              ...(params.endTime && { end_time: String(Math.floor(params.endTime / 1000)) }),
+              sort_type: 'ByCreateTimeDesc',
+            },
+          }),
+        { context: 'fetchHistory', logger: this.logger, tracker: this.tracker },
+      );
 
       if (res.code !== 0) {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchHistory failed: ${res.msg}`));
@@ -438,7 +477,7 @@ export class LarkBotRuntime implements BotRuntime {
     try {
       // GET /open-apis/im/v1/messages/{message_id}
       // 返回值：data.items[] —— 普通消息只有 1 条；merge_forward 则父在前 + 全部嵌套子
-      const res = await (
+      const get = (
         this.client.im.message as unknown as {
           get: (p: unknown) => Promise<{
             code?: number;
@@ -446,7 +485,11 @@ export class LarkBotRuntime implements BotRuntime {
             data?: { items?: Array<Record<string, unknown>> };
           }>;
         }
-      ).get({ path: { message_id: messageId } });
+      ).get;
+      const res = await withRateLimitRetry(
+        () => get({ path: { message_id: messageId } }),
+        { context: 'fetchMessage', logger: this.logger, tracker: this.tracker },
+      );
 
       if (res.code !== 0) {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchMessage failed: ${res.msg}`));
@@ -493,10 +536,14 @@ export class LarkBotRuntime implements BotRuntime {
   async fetchMembers(params: FetchMembersParams): Promise<Result<FetchMembersResult>> {
     await this.limiter.acquire();
     try {
-      const res = await this.client.im.v1.chatMembers.get({
-        path: { chat_id: params.chatId },
-        params: { member_id_type: 'open_id', page_size: 100 },
-      });
+      const res = await withRateLimitRetry(
+        () =>
+          this.client.im.v1.chatMembers.get({
+            path: { chat_id: params.chatId },
+            params: { member_id_type: 'open_id', page_size: 100 },
+          }),
+        { context: 'fetchMembers', logger: this.logger, tracker: this.tracker },
+      );
 
       if (res.code !== 0) {
         return err(makeError(ErrorCode.FEISHU_API_ERROR, `fetchMembers failed: ${res.msg}`));
@@ -526,7 +573,7 @@ export class LarkBotRuntime implements BotRuntime {
 
 // ─── 工厂函数 ──────────────────────────────────────────────────────────────────
 
-export function createBotRuntime(): LarkBotRuntime {
+export function createBotRuntime(opts: { logger?: Logger } = {}): LarkBotRuntime {
   const appId = process.env['LARK_APP_ID'];
   const appSecret = process.env['LARK_APP_SECRET'];
   if (!appId) throw new Error('Missing env var: LARK_APP_ID');
@@ -546,5 +593,6 @@ export function createBotRuntime(): LarkBotRuntime {
     encryptKey: process.env['LARK_ENCRYPT_KEY'] ?? '',
     logLevel:
       logLevelMap[(process.env['LARK_LOG_LEVEL'] ?? 'info').toLowerCase()] ?? lark.LoggerLevel.info,
+    ...(opts.logger !== undefined && { logger: opts.logger }),
   });
 }

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -36,7 +36,7 @@ function buildDeps() {
   if (!appId) throw new Error('Missing env var: LARK_APP_ID');
   if (!appSecret) throw new Error('Missing env var: LARK_APP_SECRET');
 
-  const runtime = createBotRuntime();
+  const runtime = createBotRuntime({ logger });
   const router = new SkillRouter(envTrim('LARK_BOT_OPEN_ID'));
 
   const llm = new VolcanoLLMClient({

--- a/packages/bot/src/rate-limit.ts
+++ b/packages/bot/src/rate-limit.ts
@@ -1,0 +1,191 @@
+/**
+ * 飞书 API 限流响应感知（issue #91）
+ *
+ * Layer A：withRateLimitRetry — 检测 429 / 99991400 / 99991401，读
+ *   x-ogw-ratelimit-reset header，sleep 后重试 1 次。
+ * Layer B：QuotaTracker — 单例，记录最近一次被限流的 reset 时刻；
+ *   RateLimiter.refill() 在窗口内时速率减半，主动收紧本地限流。
+ *
+ * 飞书限流文档：https://open.feishu.cn/document/server-docs/api-call-guide/calling-frequency
+ */
+
+import type { Logger } from '@seedhac/contracts';
+
+// ─── QuotaTracker ─────────────────────────────────────────────────────────────
+
+/** 单例，记录最近一次被飞书限流的恢复时刻；用于 RateLimiter 主动收紧。 */
+export class QuotaTracker {
+  private resetAtMs = 0;
+  private lastObserved: { limit: number; remaining: number; resetAtMs: number } | null = null;
+
+  /** 标记进入限流窗口，windowSec 秒后自动恢复正常速率。 */
+  recordRateLimited(windowSec: number): void {
+    const ms = Math.max(1, windowSec) * 1000;
+    this.resetAtMs = Math.max(this.resetAtMs, Date.now() + ms);
+  }
+
+  /** 记录成功响应里观测到的配额（暂时只为日志和未来扩展）。 */
+  recordObservation(limit: number, remaining: number, resetSec: number): void {
+    this.lastObserved = {
+      limit,
+      remaining,
+      resetAtMs: Date.now() + Math.max(0, resetSec) * 1000,
+    };
+  }
+
+  /** 当前是否处于上次限流的恢复窗口内 —— RateLimiter 据此减速。 */
+  isThrottled(): boolean {
+    return Date.now() < this.resetAtMs;
+  }
+
+  /** 仅供测试 / 日志：最近一次观测到的配额。 */
+  getLastObservation(): { limit: number; remaining: number; resetAtMs: number } | null {
+    return this.lastObserved;
+  }
+
+  /** 仅供测试：重置内部状态。 */
+  reset(): void {
+    this.resetAtMs = 0;
+    this.lastObserved = null;
+  }
+}
+
+/** 进程级单例 —— 所有 RateLimiter / withRateLimitRetry 共享。 */
+export const globalQuotaTracker = new QuotaTracker();
+
+// ─── 限流检测 ────────────────────────────────────────────────────────────────
+
+/** 飞书 OpenAPI 已知的限流错误码。 */
+const RATE_LIMIT_CODES = new Set<number>([99991400, 99991401, 99991408]);
+
+/** 飞书限流响应头 → 解析出的恢复秒数 / 配额上下文。 */
+interface RateLimitInfo {
+  resetSec: number;
+  limit: string | undefined;
+  remaining: string | undefined;
+}
+
+function readHeaders(headers: unknown): Record<string, string> {
+  if (!headers || typeof headers !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k.toLowerCase()] = v;
+    else if (Array.isArray(v) && typeof v[0] === 'string') out[k.toLowerCase()] = v[0];
+    else if (v != null) out[k.toLowerCase()] = String(v);
+  }
+  return out;
+}
+
+function parseRateLimitInfo(headers: Record<string, string>): RateLimitInfo {
+  const reset = parseInt(headers['x-ogw-ratelimit-reset'] ?? '0', 10);
+  return {
+    resetSec: Number.isFinite(reset) && reset > 0 ? reset : 0,
+    limit: headers['x-ogw-ratelimit-limit'],
+    remaining: headers['x-ogw-ratelimit-remaining'],
+  };
+}
+
+/**
+ * 检测一次 SDK 调用是否撞了限流。同时覆盖两条路径：
+ *  1) SDK 直接 throw（多见于 axios 401/429）→ 看 e.response.status / headers
+ *  2) SDK 返回 { code, msg, data } 且 code 是已知限流码（飞书绝大多数走这条）
+ */
+export function detectRateLimit(
+  thrown: unknown,
+  res: { code?: number; msg?: string } | undefined,
+): RateLimitInfo | null {
+  if (thrown !== undefined) {
+    const e = thrown as {
+      response?: { status?: number; headers?: unknown; data?: { code?: number } };
+      code?: number;
+    };
+    const headers = readHeaders(e.response?.headers);
+    const status = e.response?.status;
+    const bodyCode = e.response?.data?.code;
+    const errCode = typeof e.code === 'number' ? e.code : undefined;
+    if (
+      status === 429 ||
+      (typeof bodyCode === 'number' && RATE_LIMIT_CODES.has(bodyCode)) ||
+      (typeof errCode === 'number' && RATE_LIMIT_CODES.has(errCode))
+    ) {
+      return parseRateLimitInfo(headers);
+    }
+    return null;
+  }
+  if (res && typeof res.code === 'number' && RATE_LIMIT_CODES.has(res.code)) {
+    return parseRateLimitInfo({});
+  }
+  return null;
+}
+
+// ─── withRateLimitRetry ──────────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface WithRateLimitRetryOptions {
+  context: string;
+  logger?: Logger | undefined;
+  tracker?: QuotaTracker | undefined;
+  maxRetries?: number | undefined;
+  /** 测试用：注入 sleep 实现，避免真实等待。 */
+  sleepFn?: ((ms: number) => Promise<void>) | undefined;
+}
+
+/**
+ * 包一个返回 `{code, msg, data}` 风格响应的飞书 API 调用：
+ *  - 成功（code === 0 或非限流码）→ 直接返回
+ *  - 限流（429 / 99991400 / 99991401 / 99991408）→ sleep reset 秒，重试一次
+ *  - 其它错误 → 透传抛出
+ *
+ * `fn` 既可能 throw 也可能返回非零 code，两种路径都处理。
+ */
+export async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  options: WithRateLimitRetryOptions,
+): Promise<T> {
+  const {
+    context,
+    logger,
+    tracker = globalQuotaTracker,
+    maxRetries = 1,
+    sleepFn = sleep,
+  } = options;
+
+  let lastThrown: unknown;
+  let lastRes: T | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let res: T | undefined;
+    let thrown: unknown;
+    try {
+      res = await fn();
+    } catch (e) {
+      thrown = e;
+    }
+
+    const info = detectRateLimit(thrown, res as { code?: number; msg?: string } | undefined);
+    if (!info) {
+      if (thrown !== undefined) throw thrown;
+      return res as T;
+    }
+
+    lastThrown = thrown;
+    lastRes = res;
+
+    if (attempt >= maxRetries) break;
+
+    // reset 头缺失或异常时退化为 1s —— 不能 0 否则可能再撞同一个窗口
+    const waitSec = info.resetSec > 0 && info.resetSec <= 60 ? info.resetSec : 1;
+    tracker.recordRateLimited(waitSec);
+    logger?.warn(`[${context}] hit feishu rate limit, sleeping ${waitSec}s`, {
+      limit: info.limit,
+      remaining: info.remaining,
+      attempt: attempt + 1,
+      maxRetries,
+    });
+    await sleepFn(waitSec * 1000);
+  }
+
+  if (lastThrown !== undefined) throw lastThrown;
+  return lastRes as T;
+}


### PR DESCRIPTION
Closes #91

## Summary

- **Layer A**（复赛 5/6 必做）：`withRateLimitRetry` 包装所有 6 个 API 入口（`sendText` / `sendCard` / `patchCard` / `fetchHistory` / `fetchMembers` / `fetchMessage`），撞 HTTP 429 或飞书码 99991400 / 99991401 / 99991408 时读 `x-ogw-ratelimit-reset` header → sleep → 重试一次
- **Layer B**：进程级 `QuotaTracker` 单例，撞限流时记录 reset 窗口；`RateLimiter.refill()` 在窗口内把本地 sec/min 配额减半，主动收紧速率，配合事后退避形成双层防护
- **健壮性**：reset 缺失或 > 60 退化为 1s（不能 0，否则可能再撞同一窗口），> 60 同样退化避免单次睡死 demo

## 关键决策

- 不依赖 axios interceptor 注入 lark SDK 内部（issue 原方案）—— 改为 `withRateLimitRetry` 同时检测两条路径：(1) SDK throw（HTTP 429）(2) SDK 返回非零 code（飞书绝大多数走这条）。两路径都覆盖，无侵入
- `QuotaTracker.recordRateLimited(s)` 是同步副作用，发生在 sleep 之前，单元测试可 spy
- `Math.max(this.resetAtMs, Date.now() + ms)` —— 多个并发请求都撞限流时，取最远的恢复时刻

## Test plan

- [x] `rate-limit.test.ts` 新增 17 个 case：`detectRateLimit` 三条路径 + retry 行为（成功/失败/header 缺失/异常值/log 注入）+ QuotaTracker 窗口逻辑
- [x] `bot-runtime.test.ts` 新增 1 个集成 case：sendText 撞 99991400 自动 retry 成功
- [x] `pnpm typecheck`：全绿
- [x] `pnpm test`：bot 244 / skills 89 全绿
- [x] `pnpm lint`：0 errors

## Out of scope

- 跨进程持久化 quota（留 #92）
- 多 bot 实例间协调（留 #92）
- 长连接 backfill（#86，正交）

🤖 Generated with [Claude Code](https://claude.com/claude-code)