### PR TITLE
feat(onboarding): bot 入群发数据使用告知卡 + 启用确认

### DIFF
--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -26,7 +26,7 @@ function schema(card: ReturnType<typeof larkCardBuilder.build>) {
 // ── 主链路 ────────────────────────────────────────────────────────────────────
 
 describe('activation card', () => {
-  // 初始态：bot 入群后第一张卡，含数据使用告知 + 启用 / 暂不两按钮
+  // 初始态：1 行功能 + 1 行数据使用 + 2 按钮（参考 Slack/Teams onboarding pattern）
   it('initial state has disclosure + activate / dismiss buttons', () => {
     const card = larkCardBuilder.build('activation', {
       chatName: 'Lark Loom 测试群',
@@ -34,21 +34,20 @@ describe('activation card', () => {
     expect(card.templateName).toBe('activation');
     const j = json(card);
     expect(noPlaceholders(j)).toBe(true);
-    expect(j).toContain('Lark Loom 测试群');
-    // PIPL 合规：必须有数据使用告知
-    expect(j).toContain('数据使用告知');
-    expect(j).toContain('被动读取群聊文本');
+    // PIPL 合规：必须有数据使用告知（精简版 —— 1 行）
+    expect(j).toContain('数据使用');
+    expect(j).toContain('读取群聊文本');
     expect(j).toContain('飞书多维表格');
-    // 启用按钮（issue #98 文案：从"开启助手"改成"我已知晓"）
-    expect(j).toContain('我已知晓');
+    // 启用按钮（精简文案：从"我已知晓，启用 Lark Loom"改成"启用 Lark Loom"）
+    expect(j).toContain('启用 Lark Loom');
     expect(j).toContain('暂不需要');
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(2);
   });
 
-  // 已启用态（patch 卡片）：按钮区被替换成 audit 文本
+  // 已启用态：按钮区被替换为 audit 文本
   it('confirmed state shows who confirmed and replaces buttons', () => {
-    const at = Date.UTC(2026, 4, 5, 10, 30); // 2026-05-05 10:30 UTC
+    const at = Date.UTC(2026, 4, 5, 10, 30);
     const card = larkCardBuilder.build('activation', {
       chatName: '测试群',
       confirmedBy: '张三',
@@ -57,7 +56,6 @@ describe('activation card', () => {
     const j = json(card);
     expect(j).toContain('已启用');
     expect(j).toContain('张三');
-    // 不应再有按钮（按钮被 audit 文本替换）
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(0);
   });
@@ -72,9 +70,23 @@ describe('activation card', () => {
     const j = json(card);
     expect(j).toContain('暂停');
     expect(j).toContain('李四');
-    expect(j).toContain('@ 我重新启用');
+    expect(j).toContain('重新启用');
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(0);
+  });
+
+  // 隐私回归：永远不应出现 open_id 风格的字符串（ou_xxx）
+  it('never leaks open_id-style userId in confirmed state', () => {
+    const card = larkCardBuilder.build('activation', {
+      chatName: '测试群',
+      confirmedBy: 'ou_702fcccb0dc6807c067a885ff71b03f1', // 模拟假名 = 漏的 open_id
+      confirmedAt: Date.now(),
+    });
+    const j = json(card);
+    // 即便上层 caller 错传了 open_id，模板本身也只会原样渲染 —— 这个 case
+    // 是文档化"模板不防泄漏"，真正的防御在 onboarding handler 的 fallback 里
+    expect(j).toContain('ou_702fcccb');
+    // 业务保护层在 onboarding.ts 的 userName fallback；这里只验证模板透传
   });
 });
 

--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -26,7 +26,8 @@ function schema(card: ReturnType<typeof larkCardBuilder.build>) {
 // ── 主链路 ────────────────────────────────────────────────────────────────────
 
 describe('activation card', () => {
-  it('has yes/no buttons and chat name', () => {
+  // 初始态：bot 入群后第一张卡，含数据使用告知 + 启用 / 暂不两按钮
+  it('initial state has disclosure + activate / dismiss buttons', () => {
     const card = larkCardBuilder.build('activation', {
       chatName: 'Lark Loom 测试群',
     });
@@ -34,11 +35,46 @@ describe('activation card', () => {
     const j = json(card);
     expect(noPlaceholders(j)).toBe(true);
     expect(j).toContain('Lark Loom 测试群');
-    expect(j).toContain('开启助手');
+    // PIPL 合规：必须有数据使用告知
+    expect(j).toContain('数据使用告知');
+    expect(j).toContain('被动读取群聊文本');
+    expect(j).toContain('飞书多维表格');
+    // 启用按钮（issue #98 文案：从"开启助手"改成"我已知晓"）
+    expect(j).toContain('我已知晓');
     expect(j).toContain('暂不需要');
-    // 必须有两个按钮
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(2);
+  });
+
+  // 已启用态（patch 卡片）：按钮区被替换成 audit 文本
+  it('confirmed state shows who confirmed and replaces buttons', () => {
+    const at = Date.UTC(2026, 4, 5, 10, 30); // 2026-05-05 10:30 UTC
+    const card = larkCardBuilder.build('activation', {
+      chatName: '测试群',
+      confirmedBy: '张三',
+      confirmedAt: at,
+    });
+    const j = json(card);
+    expect(j).toContain('已启用');
+    expect(j).toContain('张三');
+    // 不应再有按钮（按钮被 audit 文本替换）
+    const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
+    expect(btns.length).toBe(0);
+  });
+
+  // 已忽略态：dismissed by 谁 + 时间
+  it('dismissed state shows who dismissed and replaces buttons', () => {
+    const card = larkCardBuilder.build('activation', {
+      chatName: '测试群',
+      dismissedBy: '李四',
+      dismissedAt: Date.now(),
+    });
+    const j = json(card);
+    expect(j).toContain('暂停');
+    expect(j).toContain('李四');
+    expect(j).toContain('@ 我重新启用');
+    const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
+    expect(btns.length).toBe(0);
   });
 });
 

--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -26,7 +26,7 @@ function schema(card: ReturnType<typeof larkCardBuilder.build>) {
 // ── 主链路 ────────────────────────────────────────────────────────────────────
 
 describe('activation card', () => {
-  // 初始态：1 行功能 + 1 行数据使用 + 2 按钮（参考 Slack/Teams onboarding pattern）
+  // 初始态：1 行功能 + 1 行数据使用 + 2 按钮（参考 ChatGPT for Slack / Linear pattern）
   it('initial state has disclosure + activate / dismiss buttons', () => {
     const card = larkCardBuilder.build('activation', {
       chatName: 'Lark Loom 测试群',
@@ -36,17 +36,26 @@ describe('activation card', () => {
     expect(noPlaceholders(j)).toBe(true);
     // PIPL 合规：必须有数据使用告知（精简版 —— 1 行）
     expect(j).toContain('数据使用');
-    expect(j).toContain('读取群聊文本');
-    expect(j).toContain('飞书多维表格');
-    // 启用按钮（精简文案：从"我已知晓，启用 Lark Loom"改成"启用 Lark Loom"）
+    expect(j).toContain('大模型分析');
+    expect(j).toContain('多维表格');
+    // 按钮文案：中性 "启用 Lark Loom" / "稍后"
     expect(j).toContain('启用 Lark Loom');
-    expect(j).toContain('暂不需要');
+    expect(j).toContain('稍后');
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(2);
   });
 
-  // 已启用态：按钮区被替换为 audit 文本
-  it('confirmed state shows who confirmed and replaces buttons', () => {
+  // header 不含 emoji，且不重复 "已加入" / "已启用 Lark Loom" 等冗余措辞
+  it('header is just product name without emoji clutter', () => {
+    const card = larkCardBuilder.build('activation', { chatName: '测试群' });
+    const header = schema(card).header;
+    expect(header.title.content).toBe('Lark Loom');
+    // 状态由 template color 表达，不靠 emoji
+    expect(header.template).toBe('blue');
+  });
+
+  // 已启用态：header template 变 green，按钮区被替换为 audit 文本
+  it('confirmed state turns header green and replaces buttons', () => {
     const at = Date.UTC(2026, 4, 5, 10, 30);
     const card = larkCardBuilder.build('activation', {
       chatName: '测试群',
@@ -54,14 +63,15 @@ describe('activation card', () => {
       confirmedAt: at,
     });
     const j = json(card);
-    expect(j).toContain('已启用');
+    expect(j).toContain('启用');
     expect(j).toContain('张三');
+    expect(schema(card).header.template).toBe('green');
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(0);
   });
 
-  // 已忽略态：dismissed by 谁 + 时间
-  it('dismissed state shows who dismissed and replaces buttons', () => {
+  // 已忽略态：header template 变 grey，dismissed by 谁 + 时间
+  it('dismissed state turns header grey and replaces buttons', () => {
     const card = larkCardBuilder.build('activation', {
       chatName: '测试群',
       dismissedBy: '李四',
@@ -71,6 +81,7 @@ describe('activation card', () => {
     expect(j).toContain('暂停');
     expect(j).toContain('李四');
     expect(j).toContain('重新启用');
+    expect(schema(card).header.template).toBe('grey');
     const btns = schema(card).body.elements.filter((e) => e.tag === 'button');
     expect(btns.length).toBe(0);
   });

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -628,6 +628,36 @@ describe('onboarding flow', () => {
     );
   });
 
+  // 隐私回归：飞书 cardAction 不传 user.name 时，patch 卡片绝不能 fallback 到 userId
+  // （PR #99 第一版上线后实战发现 open_id 露出，issue #98 review fix）
+  it('cardAction without user.name uses generic placeholder, never leaks userId', async () => {
+    const runtime = makeRuntime();
+    const event: BotEvent = {
+      type: 'cardAction',
+      payload: {
+        chatId: 'oc_chat1',
+        messageId: 'msg_activation',
+        // user.name 缺失（飞书在 cardAction 中常见情况）
+        user: { userId: 'ou_702fcccb0dc6807c067a885ff71b03f1' },
+        value: { action: 'activate', chatName: '测试群' },
+        timestamp: Date.now(),
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+    (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mockReturnValue({
+      templateName: 'activation',
+      content: { built: true },
+    });
+
+    await handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>);
+
+    // 调用 cardBuilder.build 时 confirmedBy 应该是通用占位，**不是** open_id
+    const buildCalls = (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = buildCalls[buildCalls.length - 1];
+    expect(lastCall![1]).toMatchObject({ confirmedBy: '管理员' });
+    expect(lastCall![1].confirmedBy).not.toContain('ou_'); // 永远不能 fallback 到 open_id
+  });
+
   it('audit memory still written even when patchCard fails', async () => {
     const runtime = makeRuntime();
     runtime.patchCard = vi

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -509,3 +509,149 @@ describe('handleEvent wiring', () => {
     expect(runtime.sendText).toHaveBeenCalledWith({ chatId: 'oc_chat1', text: 'fallback answer' });
   });
 });
+
+// ─── Onboarding（issue #98 数据使用告知）─────────────────────────────────────
+
+describe('onboarding flow', () => {
+  const router = new SkillRouter(BOT_ID);
+
+  it('botJoinedChat → sends activation card', async () => {
+    const runtime = makeRuntime();
+    const event: BotEvent = {
+      type: 'botJoinedChat',
+      payload: {
+        chatId: 'oc_new_chat',
+        inviter: { userId: 'ou_admin', name: '管理员' },
+        timestamp: Date.now(),
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+    (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mockReturnValue({
+      templateName: 'activation',
+      content: { built: true },
+    });
+
+    await handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>);
+
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'activation',
+      expect.objectContaining({ chatName: expect.any(String) }),
+    );
+    expect(runtime.sendCard).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'oc_new_chat' }),
+    );
+    // 不应当发普通文本（onboarding 只发卡片）
+    expect(runtime.sendText).not.toHaveBeenCalled();
+  });
+
+  it('cardAction "activate" patches card to confirmed state + writes audit memory', async () => {
+    const runtime = makeRuntime();
+    const event: BotEvent = {
+      type: 'cardAction',
+      payload: {
+        chatId: 'oc_chat1',
+        messageId: 'msg_activation',
+        user: { userId: 'ou_admin', name: '张三' },
+        value: { action: 'activate', chatName: '测试群' },
+        timestamp: Date.now(),
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+    (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mockReturnValue({
+      templateName: 'activation',
+      content: { built: true },
+    });
+
+    await handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>);
+
+    // patch 卡片成 confirmed 态
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'activation',
+      expect.objectContaining({
+        chatName: '测试群',
+        confirmedBy: '张三',
+        confirmedAt: expect.any(Number),
+      }),
+    );
+    expect(runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'msg_activation' }),
+    );
+    // audit memory 写入
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'memory',
+        row: expect.objectContaining({
+          kind: 'project',
+          chat_id: 'oc_chat1',
+          source_skill: 'onboarding',
+          content: expect.stringContaining('activate'),
+        }),
+      }),
+    );
+  });
+
+  it('cardAction "dismiss" patches to dismissed state', async () => {
+    const runtime = makeRuntime();
+    const event: BotEvent = {
+      type: 'cardAction',
+      payload: {
+        chatId: 'oc_chat1',
+        messageId: 'msg_activation',
+        user: { userId: 'ou_user', name: '李四' },
+        value: { action: 'dismiss' },
+        timestamp: Date.now(),
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+    (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mockReturnValue({
+      templateName: 'activation',
+      content: { built: true },
+    });
+
+    await handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>);
+
+    expect(ctx.cardBuilder.build).toHaveBeenCalledWith(
+      'activation',
+      expect.objectContaining({
+        dismissedBy: '李四',
+        dismissedAt: expect.any(Number),
+      }),
+    );
+    expect(runtime.patchCard).toHaveBeenCalledOnce();
+    expect(ctx.bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.objectContaining({
+          source_skill: 'onboarding',
+          content: expect.stringContaining('dismiss'),
+        }),
+      }),
+    );
+  });
+
+  it('audit memory still written even when patchCard fails', async () => {
+    const runtime = makeRuntime();
+    runtime.patchCard = vi
+      .fn()
+      .mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'patch failed')));
+    const event: BotEvent = {
+      type: 'cardAction',
+      payload: {
+        chatId: 'oc_chat1',
+        messageId: 'msg_activation',
+        user: { userId: 'ou_admin', name: '张三' },
+        value: { action: 'activate', chatName: '测试群' },
+        timestamp: Date.now(),
+      },
+    };
+    const ctx = makeCtx(event, runtime);
+    (ctx.cardBuilder.build as ReturnType<typeof vi.fn>).mockReturnValue({
+      templateName: 'activation',
+      content: { built: true },
+    });
+
+    await handleEvent(ctx, router, {} as unknown as Record<SkillName, Skill>);
+
+    // patchCard 挂了，但 audit memory 仍然写入
+    expect(ctx.bitable.insert).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -160,38 +160,39 @@ function buildActivation(input: ActivationCardInput): Card {
   const isConfirmed = input.confirmedBy !== undefined && input.confirmedAt !== undefined;
   const isDismissed = input.dismissedBy !== undefined && input.dismissedAt !== undefined;
 
-  const headerTitle = isConfirmed
-    ? '✅ Lark Loom 已启用'
-    : isDismissed
-      ? 'Lark Loom 已暂停'
-      : '👋 Lark Loom 加入了群聊';
+  // 状态用 template color 区分：blue 初始 / green 已启用 / grey 已暂停。
+  // header 标题始终是产品名，避免 "Lark Loom 已启用 Lark Loom" 这种重复。
   const headerColor = isConfirmed ? 'green' : isDismissed ? 'grey' : 'blue';
 
-  // 简洁两行：功能 + 数据使用。参考 Slack apps / MS Teams bots 的 onboarding
-  // 模式 —— 一句话功能 + 一句话 data use，单主 CTA，不堆段落。
-  const intro = md('自动整理 **项目需求 / 决策 / 行动项**，无需 @ 即可触发。');
+  // 参考 ChatGPT for Slack / Linear / Notion AI 的 onboarding 模式：
+  //   - 第一人称功能描述，去 "你好！" 这种对话化开头
+  //   - disclosure 一句话，不 meta-描述 disclosure 本身
+  //   - 中性按钮文案，无 emoji 杂质（状态用 template color 表达）
+  const intro = md(
+    '我会分析群聊内容，将 **项目需求 / 决策 / 行动项** 自动整理至团队飞书多维表格。',
+  );
   const disclosure = md(
-    '🔒 **数据使用**：本助手会读取群聊文本，调用大模型分析后写入团队飞书多维表格。所有群成员可见此告知。',
+    '**数据使用**：群聊文本将通过大模型分析，分析结果可在多维表格中查看。',
   );
 
   const elements: BodyElement[] = [intro, disclosure];
 
   if (isConfirmed) {
     const time = formatTime(input.confirmedAt!);
-    elements.push(hr(), md(`✅ 由 **${input.confirmedBy}** 于 ${time} 启用`));
+    elements.push(hr(), md(`已由 **${input.confirmedBy}** 于 ${time} 启用`));
   } else if (isDismissed) {
     const time = formatTime(input.dismissedAt!);
-    elements.push(hr(), md(`⏸ 由 **${input.dismissedBy}** 于 ${time} 暂停 · @ 我可重新启用`));
+    elements.push(hr(), md(`已由 **${input.dismissedBy}** 于 ${time} 暂停 · @ 我可重新启用`));
   } else {
     elements.push(
       btn('启用 Lark Loom', { action: 'activate', chatName: input.chatName }, 'primary'),
-      btn('暂不需要', { action: 'dismiss' }, 'default'),
+      btn('稍后', { action: 'dismiss' }, 'default'),
     );
   }
 
   return card('activation', {
     schema: '2.0',
-    header: { title: pt(headerTitle), template: headerColor },
+    header: { title: pt('Lark Loom'), template: headerColor },
     body: { elements },
   });
 }

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -145,23 +145,77 @@ function card(templateName: CardTemplateName, feishu: FeishuCard): Card {
 // ─── 主链路卡片 ───────────────────────────────────────────────────────────────
 
 /**
- * activation — 群创建后第一张卡
- * 目的：让管理员用一次点击开启助手，是整个产品的"入口"
- * UI：简洁，不堆功能介绍；两个按钮清晰对立
+ * activation — bot 入群后的第一张卡
+ *
+ * 三态：
+ *   1. 初始（默认）：自我介绍 + 数据使用告知 + [启用] / [暂不] 两按钮
+ *   2. 已启用（confirmedBy/confirmedAt 给值）：替换按钮区为"✅ 已由 X 于 Y 启用"
+ *   3. 已忽略（dismissedBy/dismissedAt 给值）：替换按钮区为"已忽略，需要时随时 @ 我"
+ *
+ * 设计意图：
+ *   - 数据使用段是 PIPL 合规告知，所有群成员可见；卡本身就是留痕的 disclosure。
+ *   - 已启用/已忽略态是 patchCard 的目标，audit 谁点了 + 什么时候点。
  */
 function buildActivation(input: ActivationCardInput): Card {
-  const desc = input.description ?? 'Lark Loom 可以自动整理需求、管理分工、生成 PPT，无需 @ 触发。';
+  const desc =
+    input.description ?? 'Lark Loom 可以自动整理项目需求、管理分工、生成 PPT，无需 @ 即可触发。';
+
+  const isConfirmed = input.confirmedBy !== undefined && input.confirmedAt !== undefined;
+  const isDismissed = input.dismissedBy !== undefined && input.dismissedAt !== undefined;
+
+  const headerTitle = isConfirmed
+    ? '✅ Lark Loom 已启用'
+    : isDismissed
+      ? 'Lark Loom 已暂停'
+      : '👋 Lark Loom 已加入群组';
+  const headerColor = isConfirmed ? 'green' : isDismissed ? 'grey' : 'blue';
+
+  const intro = md(`**${input.chatName}** ${desc}`);
+  const disclosure = md(
+    [
+      '**📢 数据使用告知**',
+      '',
+      '本助手会**被动读取群聊文本**，调用大模型分析后，把识别出的',
+      '**项目需求 / 决策 / 行动项**写入团队飞书多维表格。',
+      '',
+      '本卡片即为知情告知，所有群成员均可见。如有顾虑请在群里说明，',
+      '管理员可随时把我移出群组。',
+    ].join('\n'),
+  );
+
+  const elements: BodyElement[] = [intro, hr(), disclosure];
+
+  if (isConfirmed) {
+    const time = formatTime(input.confirmedAt!);
+    elements.push(hr(), md(`✅ 已由 **${input.confirmedBy}** 于 ${time} 确认启用`));
+  } else if (isDismissed) {
+    const time = formatTime(input.dismissedAt!);
+    elements.push(
+      hr(),
+      md(`⏸ 已由 **${input.dismissedBy}** 于 ${time} 暂停。需要时随时 @ 我重新启用。`),
+    );
+  } else {
+    elements.push(
+      btn('我已知晓，启用 Lark Loom', { action: 'activate', chatName: input.chatName }, 'primary'),
+      btn('暂不需要', { action: 'dismiss' }, 'default'),
+    );
+  }
+
   return card('activation', {
     schema: '2.0',
-    header: { title: pt('Lark Loom 已加入群组'), template: 'blue' },
-    body: {
-      elements: [
-        md(`**${input.chatName}** 需要开启项目协作助手吗？\n\n${desc}`),
-        btn('开启助手', { action: 'activate', chatName: input.chatName }, 'primary'),
-        btn('暂不需要', { action: 'dismiss' }, 'default'),
-      ],
-    },
+    header: { title: pt(headerTitle), template: headerColor },
+    body: { elements },
   });
+}
+
+function formatTime(ms: number): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(ms));
 }
 
 /**

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -157,9 +157,6 @@ function card(templateName: CardTemplateName, feishu: FeishuCard): Card {
  *   - 已启用/已忽略态是 patchCard 的目标，audit 谁点了 + 什么时候点。
  */
 function buildActivation(input: ActivationCardInput): Card {
-  const desc =
-    input.description ?? 'Lark Loom 可以自动整理项目需求、管理分工、生成 PPT，无需 @ 即可触发。';
-
   const isConfirmed = input.confirmedBy !== undefined && input.confirmedAt !== undefined;
   const isDismissed = input.dismissedBy !== undefined && input.dismissedAt !== undefined;
 
@@ -167,36 +164,27 @@ function buildActivation(input: ActivationCardInput): Card {
     ? '✅ Lark Loom 已启用'
     : isDismissed
       ? 'Lark Loom 已暂停'
-      : '👋 Lark Loom 已加入群组';
+      : '👋 Lark Loom 加入了群聊';
   const headerColor = isConfirmed ? 'green' : isDismissed ? 'grey' : 'blue';
 
-  const intro = md(`**${input.chatName}** ${desc}`);
+  // 简洁两行：功能 + 数据使用。参考 Slack apps / MS Teams bots 的 onboarding
+  // 模式 —— 一句话功能 + 一句话 data use，单主 CTA，不堆段落。
+  const intro = md('自动整理 **项目需求 / 决策 / 行动项**，无需 @ 即可触发。');
   const disclosure = md(
-    [
-      '**📢 数据使用告知**',
-      '',
-      '本助手会**被动读取群聊文本**，调用大模型分析后，把识别出的',
-      '**项目需求 / 决策 / 行动项**写入团队飞书多维表格。',
-      '',
-      '本卡片即为知情告知，所有群成员均可见。如有顾虑请在群里说明，',
-      '管理员可随时把我移出群组。',
-    ].join('\n'),
+    '🔒 **数据使用**：本助手会读取群聊文本，调用大模型分析后写入团队飞书多维表格。所有群成员可见此告知。',
   );
 
-  const elements: BodyElement[] = [intro, hr(), disclosure];
+  const elements: BodyElement[] = [intro, disclosure];
 
   if (isConfirmed) {
     const time = formatTime(input.confirmedAt!);
-    elements.push(hr(), md(`✅ 已由 **${input.confirmedBy}** 于 ${time} 确认启用`));
+    elements.push(hr(), md(`✅ 由 **${input.confirmedBy}** 于 ${time} 启用`));
   } else if (isDismissed) {
     const time = formatTime(input.dismissedAt!);
-    elements.push(
-      hr(),
-      md(`⏸ 已由 **${input.dismissedBy}** 于 ${time} 暂停。需要时随时 @ 我重新启用。`),
-    );
+    elements.push(hr(), md(`⏸ 由 **${input.dismissedBy}** 于 ${time} 暂停 · @ 我可重新启用`));
   } else {
     elements.push(
-      btn('我已知晓，启用 Lark Loom', { action: 'activate', chatName: input.chatName }, 'primary'),
+      btn('启用 Lark Loom', { action: 'activate', chatName: input.chatName }, 'primary'),
       btn('暂不需要', { action: 'dismiss' }, 'default'),
     );
   }

--- a/packages/bot/src/onboarding.ts
+++ b/packages/bot/src/onboarding.ts
@@ -1,0 +1,108 @@
+/**
+ * Onboarding 流程（issue #98）
+ *
+ * 三个能力：
+ *   1. handleBotJoinedChat：bot 加群事件 → 发 activation 卡（数据使用告知 + 启用按钮）
+ *   2. handleOnboardingAction：cardAction 'activate' → patch 成"已启用"态 + 写 audit
+ *   3. handleOnboardingAction：cardAction 'dismiss' → patch 成"已忽略"态 + 写 audit
+ *
+ * 范围限定（issue #98 轻方案）：
+ *   - 不做强制开关，点 dismiss 后 bot 不退群、其它 skill 该跑还跑
+ *   - 不做去重，每次入群都发卡
+ *   - 谁点都算群代表，不限定 inviter
+ */
+
+import type { CardAction, SkillContext } from '@seedhac/contracts';
+
+/** bot 入群事件接收到时调用：在群里发出 activation 卡片。 */
+export async function handleBotJoinedChat(
+  ctx: SkillContext,
+  payload: { chatId: string; inviterUserId: string },
+): Promise<void> {
+  const { runtime, cardBuilder, logger } = ctx;
+  const card = cardBuilder.build('activation', {
+    chatName: '本群',
+  });
+  const res = await runtime.sendCard({ chatId: payload.chatId, card });
+  if (!res.ok) {
+    logger.warn('onboarding: send activation card failed', {
+      chatId: payload.chatId,
+      code: res.error.code,
+      message: res.error.message,
+    });
+    return;
+  }
+  logger.info('onboarding: activation card sent', {
+    chatId: payload.chatId,
+    messageId: res.value.messageId,
+    inviter: payload.inviterUserId,
+  });
+}
+
+/**
+ * activation 卡片按钮被点击时调用。
+ * action: 'activate' | 'dismiss'
+ *
+ * 行为：
+ *   - patch 卡片成对应终态（已启用 / 已忽略）
+ *   - 写一条 memory 记录作为 audit trail
+ */
+export async function handleOnboardingAction(
+  ctx: SkillContext,
+  action: 'activate' | 'dismiss',
+): Promise<void> {
+  const { event, runtime, cardBuilder, bitable, logger } = ctx;
+  if (event.type !== 'cardAction') return;
+
+  const payload: CardAction = event.payload;
+  const userName = payload.user.name ?? payload.user.userId;
+  const now = Date.now();
+
+  const chatName = String(payload.value['chatName'] ?? '本群');
+
+  const card = cardBuilder.build(
+    'activation',
+    action === 'activate'
+      ? { chatName, confirmedBy: userName, confirmedAt: now }
+      : { chatName, dismissedBy: userName, dismissedAt: now },
+  );
+
+  const patchRes = await runtime.patchCard({ messageId: payload.messageId, card });
+  if (!patchRes.ok) {
+    logger.warn('onboarding: patch activation card failed', {
+      messageId: payload.messageId,
+      code: patchRes.error.code,
+      message: patchRes.error.message,
+    });
+    // 即便 patch 失败也继续写 audit —— audit 比 UI 重要
+  }
+
+  // audit 写 memory 表，用 MemoryRecord schema 字段对齐
+  // （PR #96 修复后所有 skill 都用这套字段）
+  const insertRes = await bitable.insert({
+    table: 'memory',
+    row: {
+      key: `onboarding-${payload.chatId}-${now}`,
+      kind: 'project',
+      chat_id: payload.chatId,
+      content: `[onboarding] ${action} by ${userName} (${payload.user.userId})`,
+      importance: 7, // 合规 audit：高优先级，不被 LRU 淘汰
+      last_access: now,
+      created_at: now,
+      source_skill: 'onboarding',
+    },
+  });
+  if (!insertRes.ok) {
+    logger.warn('onboarding: audit memory insert failed', {
+      chatId: payload.chatId,
+      code: insertRes.error.code,
+      message: insertRes.error.message,
+    });
+  }
+
+  logger.info(`onboarding: ${action} confirmed`, {
+    chatId: payload.chatId,
+    user: payload.user.userId,
+    userName,
+  });
+}

--- a/packages/bot/src/onboarding.ts
+++ b/packages/bot/src/onboarding.ts
@@ -55,7 +55,9 @@ export async function handleOnboardingAction(
   if (event.type !== 'cardAction') return;
 
   const payload: CardAction = event.payload;
-  const userName = payload.user.name ?? payload.user.userId;
+  // 飞书 cardAction 经常不传 user.name；不能 fallback 到 userId（会泄漏 open_id）
+  // 用通用占位 —— audit memory 里仍有完整 userId
+  const userName = payload.user.name ?? (action === 'activate' ? '管理员' : '群成员');
   const now = Date.now();
 
   const chatName = String(payload.value['chatName'] ?? '本群');

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -14,6 +14,7 @@ import type { SkillRouter } from './skill-router.js';
 import type { IMemoryStore } from './memory/memory-store.js';
 import { getLLMTools, makeExecutor } from './memory/tool-handlers.js';
 import type { SystemPromptCache } from './memory/system-prompt.js';
+import { handleBotJoinedChat, handleOnboardingAction } from './onboarding.js';
 
 export const intentToSkill: Partial<Record<RouteIntent, SkillName>> = {
   qa: 'qa',
@@ -51,6 +52,14 @@ export async function handleEvent(
   const { event, logger } = ctx;
   if (event.type === 'cardAction') {
     await handleCardAction(ctx, skills);
+    return;
+  }
+  // bot 入群 → 立刻发 onboarding 卡（issue #98 数据使用告知 + 启用按钮）
+  if (event.type === 'botJoinedChat') {
+    await handleBotJoinedChat(ctx, {
+      chatId: event.payload.chatId,
+      inviterUserId: event.payload.inviter.userId,
+    });
     return;
   }
   if (event.type !== 'message') return;
@@ -321,6 +330,13 @@ async function handleCardAction(
   const { event, logger, runtime } = ctx;
   if (event.type !== 'cardAction') return;
   const action = event.payload.value['action'];
+
+  // onboarding（issue #98）：activation 卡按钮被点击
+  if (action === 'activate' || action === 'dismiss') {
+    await handleOnboardingAction(ctx, action);
+    return;
+  }
+
   if (action !== 'qa.reanswer') return;
 
   const chatId = String(event.payload.value['chatId'] ?? event.payload.chatId);

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -53,6 +53,13 @@ export interface ActivationCardInput {
   readonly chatName: string;
   /** 可选：展示给管理员的一句话说明 */
   readonly description?: string;
+  // 卡片三态：未确认 / 已启用 / 已忽略 —— confirmed* 与 dismissed* 互斥
+  /** 启用状态：点击者 displayName 或 open_id */
+  readonly confirmedBy?: string;
+  readonly confirmedAt?: number;
+  /** 忽略状态 */
+  readonly dismissedBy?: string;
+  readonly dismissedAt?: number;
 }
 
 export interface DocPushCardInput {


### PR DESCRIPTION
Closes #98

## Summary

bot 加群后立刻发一张 **activation 卡**，包含：

1. 自我介绍 + 数据使用告知（PIPL 合规 + 群成员可见的 visible consent record）
2. [我已知晓，启用] / [暂不需要] 两按钮
3. 点击后 `patchCard` 成 confirmed / dismissed 态，audit 谁点了 + 时间

## 关键决策

| 项 | 选择 | 原因 |
|---|---|---|
| 强制开关 | ❌ 不做 | 轻方案：卡本身就是 disclosure，dismiss 后其它 skill 照跑 |
| 入群去重 | ❌ 不做 | 每次入群都发卡，简单 |
| 限定 inviter 才能确认 | ❌ 不做 | 谁点都算群代表，demo 简单 |
| audit memory | ✅ 写 | importance=7，合规留痕 |
| 实现位置 | bot/onboarding.ts | 不进 SkillName，避免架构 friction（skill 是为 message 事件设计的，botJoinedChat 是事件层关注） |

## 卡片状态机

```
[初始] ─ activate按钮点 ──→ [已启用]
       └ dismiss按钮点 ──→ [已忽略]
```

initial / confirmed / dismissed 三态都在同一个 activation 模板里渲染（按 input 字段判断态）。

## 兼容性

- 没人在用 activation 卡（grep 0 caller）→ 改造无回归
- ActivationCardInput 新增字段都是 optional → 类型兼容
- 不动现有 skill 一行代码

## Test plan

- [x] card-builder.test.ts：3 个 activation 状态 case（initial / confirmed / dismissed）
- [x] wiring.test.ts：4 个 onboarding flow case
  - botJoinedChat → 发 activation 卡
  - cardAction(activate) → patch + audit
  - cardAction(dismiss) → patch + audit
  - patchCard 失败时 audit 仍写入（回归 case）
- [x] typecheck + 252 bot tests + 89 skills tests + lint 0 errors

## Out of scope（留 follow-up）

- 强制开关（点 dismiss 后真的让 bot 沉默 / 退群）
- 多次入群去重
- chats.get 拉真实群名替换"本群"

🤖 Generated with [Claude Code](https://claude.com/claude-code)