### PR TITLE
fix(summary): 接 requirementDoc 同款防幻觉 pipeline + 混合卡片/文档输出

### DIFF
--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -185,6 +185,60 @@ describe('summary card', () => {
     expect(j).toContain('待跟进');
     expect(j).toContain('@Antares');
   });
+
+  it('renders prose summary at top when present', () => {
+    const card = larkCardBuilder.build('summary', {
+      title: '会议纪要',
+      summary: '本次会议确定供应商选型，李工本周一前出方案。',
+      topics: [],
+      decisions: ['供应商选型采用 B 方案'],
+      todos: [],
+      followUps: [],
+    });
+    const j = json(card);
+    expect(j).toContain('确定供应商选型');
+    expect(j).toContain('B 方案');
+  });
+
+  it('renders loading state', () => {
+    const card = larkCardBuilder.build('summary', {
+      title: '会议纪要',
+      topics: [],
+      decisions: [],
+      todos: [],
+      followUps: [],
+      isLoading: true,
+    });
+    const j = json(card);
+    expect(noPlaceholders(j)).toBe(true);
+    expect(j).toContain('会议纪要整理中');
+  });
+
+  it('renders error state', () => {
+    const card = larkCardBuilder.build('summary', {
+      title: '会议纪要',
+      topics: [],
+      decisions: [],
+      todos: [],
+      followUps: [],
+      errorMessage: 'LLM 提取失败：timeout',
+    });
+    const j = json(card);
+    expect(j).toContain('会议纪要整理失败');
+    expect(j).toContain('timeout');
+  });
+
+  it('renders explicit fallback when all fields empty (no silent blank card)', () => {
+    const card = larkCardBuilder.build('summary', {
+      title: '会议纪要',
+      topics: [],
+      decisions: [],
+      todos: [],
+      followUps: [],
+    });
+    const j = json(card);
+    expect(j).toContain('未在群历史中识别到');
+  });
 });
 
 describe('slides card', () => {

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -315,7 +315,32 @@ function buildQa(input: QaCardInput): Card {
  * UI：议题 / 决策 / 待办 / 待跟进四段，强制可见
  */
 function buildSummary(input: SummaryCardInput): Card {
-  const elements: BodyElement[] = [md(`**${input.title}**`), hr()];
+  if (input.isLoading) {
+    return card('summary', {
+      schema: '2.0',
+      header: { title: pt('会议纪要整理中'), template: 'orange' },
+      body: {
+        elements: [
+          md(`**${input.title}**\n正在分析群历史并提取决策 / 行动项 / 遗留问题，预计 30-90 秒。`),
+        ],
+      },
+    });
+  }
+
+  if (input.errorMessage) {
+    return card('summary', {
+      schema: '2.0',
+      header: { title: pt('会议纪要整理失败'), template: 'red' },
+      body: {
+        elements: [md(`**${input.title}**\n${input.errorMessage}`)],
+      },
+    });
+  }
+
+  const elements: BodyElement[] = [md(`**${input.title}**`)];
+  if (input.summary) elements.push(md(input.summary));
+  elements.push(hr());
+
   if (input.topics.length)
     elements.push(md(`**📋 议题**\n${input.topics.map((t) => `- ${t}`).join('\n')}`));
   if (input.decisions.length)
@@ -331,6 +356,19 @@ function buildSummary(input: SummaryCardInput): Card {
   }
   if (input.followUps.length)
     elements.push(hr(), md(`**🔍 待跟进**\n${input.followUps.map((f) => `- ${f}`).join('\n')}`));
+
+  // 全部结构化字段都空 + 也没 prose summary：给用户一个明确的"无可总结"提示，
+  // 避免渲染出一张只有标题的空卡片
+  if (
+    !input.summary &&
+    !input.topics.length &&
+    !input.decisions.length &&
+    !input.todos.length &&
+    !input.followUps.length
+  ) {
+    elements.push(md('未在群历史中识别到明确的决策、行动项或会议结论，可补充后再触发。'));
+  }
+
   return card('summary', {
     schema: '2.0',
     header: { title: pt('会议 / 阶段总结'), template: 'green' },

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -315,13 +315,19 @@ function buildQa(input: QaCardInput): Card {
  * UI：议题 / 决策 / 待办 / 待跟进四段，强制可见
  */
 function buildSummary(input: SummaryCardInput): Card {
+  // 三态共用同一个模板色，仅 header 标题区分；与 slides 的「两态同色」保持一致
+  const HEADER_TEMPLATE = 'blue' as const;
+
   if (input.isLoading) {
     return card('summary', {
       schema: '2.0',
-      header: { title: pt('会议纪要整理中'), template: 'orange' },
+      header: { title: pt('会议纪要整理中'), template: HEADER_TEMPLATE },
       body: {
         elements: [
-          md(`**${input.title}**\n正在分析群历史并提取决策 / 行动项 / 遗留问题，预计 30-90 秒。`),
+          md(
+            `**${input.title}**\n\n正在分析群历史并提取决策 / 行动项 / 遗留问题，通常需要 30-90 秒。`,
+          ),
+          md('_我会从群聊上下文里提取关键信息，整理完会自动替换这条卡片。_'),
         ],
       },
     });
@@ -332,7 +338,7 @@ function buildSummary(input: SummaryCardInput): Card {
       schema: '2.0',
       header: { title: pt('会议纪要整理失败'), template: 'red' },
       body: {
-        elements: [md(`**${input.title}**\n${input.errorMessage}`)],
+        elements: [md(`**${input.title}**\n\n${input.errorMessage}`)],
       },
     });
   }
@@ -371,7 +377,7 @@ function buildSummary(input: SummaryCardInput): Card {
 
   return card('summary', {
     schema: '2.0',
-    header: { title: pt('会议 / 阶段总结'), template: 'green' },
+    header: { title: pt('会议纪要已就绪'), template: HEADER_TEMPLATE },
     body: { elements },
   });
 }

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -375,6 +375,15 @@ function buildSummary(input: SummaryCardInput): Card {
     elements.push(md('未在群历史中识别到明确的决策、行动项或会议结论，可补充后再触发。'));
   }
 
+  // 混合方案：卡片显示决策/行动项摘要，按钮跳转完整会议纪要文档
+  if (input.docUrl) {
+    elements.push(
+      hr(),
+      btn('打开完整纪要', { action: 'open_url', url: input.docUrl }, 'primary'),
+      md('_仅群内成员可查看与编辑_'),
+    );
+  }
+
   return card('summary', {
     schema: '2.0',
     header: { title: pt('会议纪要已就绪'), template: HEADER_TEMPLATE },

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -100,6 +100,10 @@ export interface SummaryCardInput {
   readonly decisions: readonly string[];
   readonly todos: readonly { text: string; assignee?: string; due?: string }[];
   readonly followUps: readonly string[];
+  /** 一句话/一段话整体摘要，渲染在顶部，结构化字段为空时仍能给用户可读的输出 */
+  readonly summary?: string;
+  readonly isLoading?: boolean;
+  readonly errorMessage?: string;
 }
 
 export interface SlidesCardInput {

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -102,6 +102,8 @@ export interface SummaryCardInput {
   readonly followUps: readonly string[];
   /** 一句话/一段话整体摘要，渲染在顶部，结构化字段为空时仍能给用户可读的输出 */
   readonly summary?: string;
+  /** 完整会议纪要飞书文档链接（混合方案：卡片内嵌 + 长版文档归档）*/
+  readonly docUrl?: string;
   readonly isLoading?: boolean;
   readonly errorMessage?: string;
 }

--- a/packages/skills/src/__tests__/summary.test.ts
+++ b/packages/skills/src/__tests__/summary.test.ts
@@ -5,10 +5,13 @@ import type { SkillContext, BotEvent, Message } from '@seedhac/contracts';
 const mockAskStructured = vi.fn();
 const mockFetchHistory = vi.fn();
 const mockFetchMessage = vi.fn();
+const mockFetchMembers = vi.fn();
 const mockSendCard = vi.fn();
 const mockPatchCard = vi.fn();
 const mockBitableBatchInsert = vi.fn();
 const mockBitableInsert = vi.fn();
+const mockDocxCreateFromMarkdown = vi.fn();
+const mockDocxGrantMembersEdit = vi.fn();
 const mockCardBuilderBuild = vi
   .fn()
   .mockReturnValue({ templateName: 'summary', content: { built: true } });
@@ -38,13 +41,13 @@ function makeCtx(event: BotEvent): SkillContext {
     runtime: {
       fetchHistory: mockFetchHistory,
       fetchMessage: mockFetchMessage,
+      fetchMembers: mockFetchMembers,
       sendText: vi.fn(),
       sendCard: mockSendCard,
       patchCard: mockPatchCard,
       on: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
-      fetchMembers: vi.fn(),
     },
     llm: { ask: vi.fn(), chat: vi.fn(), askStructured: mockAskStructured, chatWithTools: vi.fn() },
     bitable: {
@@ -55,7 +58,14 @@ function makeCtx(event: BotEvent): SkillContext {
       delete: vi.fn(),
       link: vi.fn(),
     },
-    docx: {} as SkillContext['docx'],
+    docx: {
+      create: vi.fn(),
+      appendBlocks: vi.fn(),
+      getShareLink: vi.fn(),
+      createFromMarkdown: mockDocxCreateFromMarkdown,
+      readContent: vi.fn(),
+      grantMembersEdit: mockDocxGrantMembersEdit,
+    },
     cardBuilder: { build: mockCardBuilderBuild },
     retrievers: {},
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -105,7 +115,7 @@ describe('summarySkill.match', () => {
 describe('summarySkill.run pipeline', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('happy path: sends loading card, extracts, patches final, writes side effects', async () => {
+  it('happy path: sends loading card, creates feishu doc, patches final with docUrl, writes side effects', async () => {
     mockSendCard.mockResolvedValueOnce({
       ok: true,
       value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
@@ -115,6 +125,15 @@ describe('summarySkill.run pipeline', () => {
       value: { messages: [makeMessage('会议纪要如下')], hasMore: false },
     });
     mockAskStructured.mockResolvedValueOnce({ ok: true, value: VALID_EXTRACTION });
+    mockDocxCreateFromMarkdown.mockResolvedValueOnce({
+      ok: true,
+      value: { docToken: 'doc_abc', url: 'https://feishu.cn/docx/doc_abc' },
+    });
+    mockFetchMembers.mockResolvedValueOnce({
+      ok: true,
+      value: { members: [{ userId: 'ou_1' }, { userId: 'ou_2' }] },
+    });
+    mockDocxGrantMembersEdit.mockResolvedValueOnce({ ok: true, value: undefined });
     mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
     mockBitableBatchInsert.mockResolvedValue({ ok: true, value: [] });
     mockBitableInsert.mockResolvedValueOnce({
@@ -131,20 +150,87 @@ describe('summarySkill.run pipeline', () => {
       'summary',
       expect.objectContaining({ isLoading: true }),
     );
-    // 第 2 次 build：最终卡（带 decisions / todos / summary prose）
+    // 第 2 次 build：最终卡（带 decisions / todos / summary prose / docUrl）
     expect(mockCardBuilderBuild).toHaveBeenNthCalledWith(
       2,
       'summary',
       expect.objectContaining({
         decisions: ['采用方案A'],
         summary: expect.stringContaining('方案 A'),
+        docUrl: 'https://feishu.cn/docx/doc_abc',
       }),
     );
     expect(mockSendCard).toHaveBeenCalledOnce();
+    expect(mockDocxCreateFromMarkdown).toHaveBeenCalledOnce();
+    expect(mockDocxGrantMembersEdit).toHaveBeenCalledWith('doc_abc', 'docx', ['ou_1', 'ou_2']);
     expect(mockPatchCard).toHaveBeenCalledWith(
       expect.objectContaining({ messageId: 'load_msg' }),
     );
     expect(mockBitableBatchInsert).toHaveBeenCalledTimes(2); // decision + todo
+    // memory content 含 [会议纪要] 前缀 + docUrl，archive 后续可识别
+    expect(mockBitableInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.objectContaining({
+          content: expect.stringContaining('[会议纪要]'),
+        }),
+      }),
+    );
+  });
+
+  it('doc creation failure: degrades to card-only (no docUrl)', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [makeMessage('会议纪要如下')], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({ ok: true, value: VALID_EXTRACTION });
+    mockDocxCreateFromMarkdown.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'docx creation failed' },
+    });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
+    mockBitableBatchInsert.mockResolvedValue({ ok: true, value: [] });
+    mockBitableInsert.mockResolvedValueOnce({
+      ok: true,
+      value: { tableId: 't', recordId: 'r' },
+    });
+
+    const result = await summarySkill.run(makeCtx(makeEvent('本次会议总结')));
+
+    expect(result.ok).toBe(true);
+    // 最终卡片不带 docUrl
+    const finalCallArgs = mockCardBuilderBuild.mock.calls[1]?.[1] as { docUrl?: string };
+    expect(finalCallArgs?.docUrl).toBeUndefined();
+    // 但卡片仍 patch 出去（不能因为 doc 失败就让用户什么都看不到）
+    expect(mockPatchCard).toHaveBeenCalledOnce();
+    expect(mockDocxGrantMembersEdit).not.toHaveBeenCalled();
+  });
+
+  it('empty extraction: skips doc creation entirely', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({ ok: true, value: EMPTY_EXTRACTION_VALUE });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
+    mockBitableInsert.mockResolvedValueOnce({
+      ok: true,
+      value: { tableId: 't', recordId: 'r' },
+    });
+
+    const result = await summarySkill.run(makeCtx(makeEvent('会议纪要')));
+
+    expect(result.ok).toBe(true);
+    // 全空时不应该建空文档
+    expect(mockDocxCreateFromMarkdown).not.toHaveBeenCalled();
+    expect(mockBitableBatchInsert).not.toHaveBeenCalled();
   });
 
   it('LLM failure: patches error card and returns err', async () => {
@@ -219,6 +305,11 @@ describe('summarySkill.run pipeline', () => {
       value: { messages: [], hasMore: false },
     });
     mockAskStructured.mockResolvedValueOnce({ ok: true, value: VALID_EXTRACTION });
+    mockDocxCreateFromMarkdown.mockResolvedValueOnce({
+      ok: true,
+      value: { docToken: 'doc_x', url: 'https://feishu.cn/docx/doc_x' },
+    });
+    mockFetchMembers.mockResolvedValueOnce({ ok: true, value: { members: [] } });
     mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
     mockBitableBatchInsert.mockResolvedValue({
       ok: false,

--- a/packages/skills/src/__tests__/summary.test.ts
+++ b/packages/skills/src/__tests__/summary.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { summarySkill } from '../summary.js';
 import type { SkillContext, BotEvent, Message } from '@seedhac/contracts';
 
-const mockLLMAsk = vi.fn();
+const mockAskStructured = vi.fn();
 const mockFetchHistory = vi.fn();
+const mockFetchMessage = vi.fn();
+const mockSendCard = vi.fn();
+const mockPatchCard = vi.fn();
 const mockBitableBatchInsert = vi.fn();
 const mockBitableInsert = vi.fn();
-const mockCardBuilderBuild = vi.fn().mockReturnValue({ templateName: 'summary', content: { built: true } });
+const mockCardBuilderBuild = vi
+  .fn()
+  .mockReturnValue({ templateName: 'summary', content: { built: true } });
 
-function makeMessage(text: string): Message {
+function makeMessage(text: string, overrides: Partial<Message> = {}): Message {
   return {
     messageId: 'msg_1',
     chatId: 'chat_1',
@@ -19,6 +24,7 @@ function makeMessage(text: string): Message {
     rawContent: text,
     mentions: [],
     timestamp: Date.now(),
+    ...overrides,
   };
 }
 
@@ -29,9 +35,26 @@ function makeEvent(text: string): BotEvent {
 function makeCtx(event: BotEvent): SkillContext {
   return {
     event,
-    runtime: { fetchHistory: mockFetchHistory, sendText: vi.fn(), sendCard: vi.fn(), patchCard: vi.fn(), on: vi.fn(), start: vi.fn(), stop: vi.fn() },
-    llm: { ask: mockLLMAsk, chat: vi.fn(), askStructured: vi.fn() },
-    bitable: { find: vi.fn(), insert: mockBitableInsert, batchInsert: mockBitableBatchInsert, update: vi.fn(), delete: vi.fn(), link: vi.fn() },
+    runtime: {
+      fetchHistory: mockFetchHistory,
+      fetchMessage: mockFetchMessage,
+      sendText: vi.fn(),
+      sendCard: mockSendCard,
+      patchCard: mockPatchCard,
+      on: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      fetchMembers: vi.fn(),
+    },
+    llm: { ask: vi.fn(), chat: vi.fn(), askStructured: mockAskStructured, chatWithTools: vi.fn() },
+    bitable: {
+      find: vi.fn(),
+      insert: mockBitableInsert,
+      batchInsert: mockBitableBatchInsert,
+      update: vi.fn(),
+      delete: vi.fn(),
+      link: vi.fn(),
+    },
     docx: {} as SkillContext['docx'],
     cardBuilder: { build: mockCardBuilderBuild },
     retrievers: {},
@@ -39,92 +62,205 @@ function makeCtx(event: BotEvent): SkillContext {
   } as unknown as SkillContext;
 }
 
-const VALID_LLM_RESPONSE = JSON.stringify({
-  decisions: ['采用方案A', '预算定为 10 万'],
+const VALID_EXTRACTION = {
+  summary: '本次会议决定采用方案 A。',
+  decisions: ['采用方案A'],
   actionItems: [{ owner: 'Alice', content: '完成前端开发', ddl: '2026-05-10' }],
   issues: ['后端接口未确认'],
   nextSteps: ['下周召开评审会'],
-});
+};
 
-describe('summarySkill', () => {
+const EMPTY_EXTRACTION_VALUE = {
+  summary: '本次群聊未识别到决策。',
+  decisions: [],
+  actionItems: [],
+  issues: [],
+  nextSteps: [],
+};
+
+describe('summarySkill.match', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('match returns true when message contains 会议纪要', () => {
+  it('matches 会议纪要', () => {
     expect(summarySkill.match(makeCtx(makeEvent('会议纪要已发，请大家查看')))).toBe(true);
   });
 
-  it('match returns true when message contains 妙记', () => {
+  it('matches 妙记', () => {
     expect(summarySkill.match(makeCtx(makeEvent('妙记链接来了')))).toBe(true);
   });
 
-  it('match returns false for unrelated message', () => {
+  it('does not match unrelated message', () => {
     expect(summarySkill.match(makeCtx(makeEvent('今天需要完成前端开发')))).toBe(false);
   });
 
-  it('match returns false for non-message event', () => {
-    const ctx = makeCtx({ type: 'botJoinedChat', payload: { chatId: 'c', inviter: { userId: 'u' }, timestamp: 0 } });
+  it('does not match non-message event', () => {
+    const ctx = makeCtx({
+      type: 'botJoinedChat',
+      payload: { chatId: 'c', inviter: { userId: 'u' }, timestamp: 0 },
+    });
     expect(summarySkill.match(ctx)).toBe(false);
   });
+});
 
-  it('run normal path: batchInsert called, summary card returned', async () => {
-    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [makeMessage('会议纪要如下')], hasMore: false } });
-    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: VALID_LLM_RESPONSE });
+describe('summarySkill.run pipeline', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('happy path: sends loading card, extracts, patches final, writes side effects', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [makeMessage('会议纪要如下')], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({ ok: true, value: VALID_EXTRACTION });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
     mockBitableBatchInsert.mockResolvedValue({ ok: true, value: [] });
-    mockBitableInsert.mockResolvedValueOnce({ ok: true, value: { tableId: 't', recordId: 'r' } });
+    mockBitableInsert.mockResolvedValueOnce({
+      ok: true,
+      value: { tableId: 't', recordId: 'r' },
+    });
 
     const result = await summarySkill.run(makeCtx(makeEvent('本次会议总结')));
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.card?.templateName).toBe('summary');
+    // 第 1 次 build：loading 卡（isLoading: true）
+    expect(mockCardBuilderBuild).toHaveBeenNthCalledWith(
+      1,
+      'summary',
+      expect.objectContaining({ isLoading: true }),
+    );
+    // 第 2 次 build：最终卡（带 decisions / todos / summary prose）
+    expect(mockCardBuilderBuild).toHaveBeenNthCalledWith(
+      2,
+      'summary',
+      expect.objectContaining({
+        decisions: ['采用方案A'],
+        summary: expect.stringContaining('方案 A'),
+      }),
+    );
+    expect(mockSendCard).toHaveBeenCalledOnce();
+    expect(mockPatchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'load_msg' }),
+    );
     expect(mockBitableBatchInsert).toHaveBeenCalledTimes(2); // decision + todo
-    expect(mockCardBuilderBuild).toHaveBeenCalledWith('summary', expect.objectContaining({
-      decisions: ['采用方案A', '预算定为 10 万'],
-    }));
   });
 
-  it('run: LLM failure returns err, batchInsert not called', async () => {
-    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
-    mockLLMAsk.mockResolvedValueOnce({ ok: false, error: { code: 'LLM_TIMEOUT', message: 'timeout' } });
+  it('LLM failure: patches error card and returns err', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'LLM_TIMEOUT', message: 'timeout' },
+    });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
 
     const result = await summarySkill.run(makeCtx(makeEvent('会议总结')));
 
     expect(result.ok).toBe(false);
     expect(mockBitableBatchInsert).not.toHaveBeenCalled();
+    // patch 出去的是 error 卡
+    expect(mockCardBuilderBuild).toHaveBeenCalledWith(
+      'summary',
+      expect.objectContaining({ errorMessage: expect.stringContaining('LLM 提取失败') }),
+    );
+    expect(mockPatchCard).toHaveBeenCalledOnce();
   });
 
-  it('run: fetchHistory failure returns err', async () => {
-    mockFetchHistory.mockResolvedValueOnce({ ok: false, error: { code: 'FEISHU_API_ERROR', message: 'fail' } });
+  it('fetchHistory failure: patches error card and returns err', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'fail' },
+    });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
 
     const result = await summarySkill.run(makeCtx(makeEvent('会议纪要')));
 
     expect(result.ok).toBe(false);
-    expect(mockLLMAsk).not.toHaveBeenCalled();
+    expect(mockAskStructured).not.toHaveBeenCalled();
+    expect(mockCardBuilderBuild).toHaveBeenCalledWith(
+      'summary',
+      expect.objectContaining({ errorMessage: expect.stringContaining('拉群历史失败') }),
+    );
   });
 
-  it('run: bitable write failure does not block card output', async () => {
-    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
-    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: VALID_LLM_RESPONSE });
-    mockBitableBatchInsert.mockResolvedValue({ ok: false, error: { code: 'FEISHU_API_ERROR', message: 'bitable down' } });
-    mockBitableInsert.mockResolvedValueOnce({ ok: false, error: { code: 'FEISHU_API_ERROR', message: 'bitable down' } });
+  it('loading card send failure: returns err without further work', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'send fail' },
+    });
+
+    const result = await summarySkill.run(makeCtx(makeEvent('会议纪要')));
+
+    expect(result.ok).toBe(false);
+    expect(mockFetchHistory).not.toHaveBeenCalled();
+    expect(mockAskStructured).not.toHaveBeenCalled();
+    expect(mockPatchCard).not.toHaveBeenCalled();
+  });
+
+  it('bitable write failure: still patches final card and returns ok', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({ ok: true, value: VALID_EXTRACTION });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
+    mockBitableBatchInsert.mockResolvedValue({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'bitable down' },
+    });
+    mockBitableInsert.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'bitable down' },
+    });
 
     const result = await summarySkill.run(makeCtx(makeEvent('本次会议')));
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.card?.templateName).toBe('summary');
+    expect(mockPatchCard).toHaveBeenCalled();
   });
 
-  it('run: LLM returns invalid JSON → falls back to empty extraction, still returns card', async () => {
-    mockFetchHistory.mockResolvedValueOnce({ ok: true, value: { messages: [], hasMore: false } });
-    mockLLMAsk.mockResolvedValueOnce({ ok: true, value: 'not json' });
-    mockBitableInsert.mockResolvedValueOnce({ ok: true, value: { tableId: 't', recordId: 'r' } });
+  it('empty extraction: still patches final card with prose fallback', async () => {
+    mockSendCard.mockResolvedValueOnce({
+      ok: true,
+      value: { messageId: 'load_msg', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockFetchHistory.mockResolvedValueOnce({
+      ok: true,
+      value: { messages: [], hasMore: false },
+    });
+    mockAskStructured.mockResolvedValueOnce({ ok: true, value: EMPTY_EXTRACTION_VALUE });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
+    mockBitableInsert.mockResolvedValueOnce({
+      ok: true,
+      value: { tableId: 't', recordId: 'r' },
+    });
 
     const result = await summarySkill.run(makeCtx(makeEvent('会议纪要')));
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.card?.templateName).toBe('summary');
-    expect(mockBitableBatchInsert).not.toHaveBeenCalled(); // empty arrays → no batchInsert
-    expect(mockCardBuilderBuild).toHaveBeenCalledWith('summary', expect.objectContaining({
-      decisions: [],
-    }));
+    expect(mockBitableBatchInsert).not.toHaveBeenCalled();
+    expect(mockCardBuilderBuild).toHaveBeenCalledWith(
+      'summary',
+      expect.objectContaining({
+        decisions: [],
+        summary: expect.stringContaining('未识别到'),
+      }),
+    );
   });
 });

--- a/packages/skills/src/prompts/summary.ts
+++ b/packages/skills/src/prompts/summary.ts
@@ -280,6 +280,64 @@ export function SUMMARY_PROMPT(history: readonly Message[]): string {
   ].join('\n');
 }
 
+// ─── 渲染器：structured → 飞书文档 markdown ───────────────────────────────────
+//
+// 仿 requirementDoc 的 renderRequirementDocMarkdown，给会议纪要做长版文档归档。
+// 走 JS 模板不过 LLM，避免二次幻觉。
+
+export function renderMeetingMinutesMarkdown(
+  s: SummaryExtraction,
+  meta: { readonly chatTitle?: string; readonly generatedAt: number },
+): string {
+  const lines: string[] = [];
+  const dateStr = new Date(meta.generatedAt).toLocaleDateString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  const title = meta.chatTitle ? `${meta.chatTitle} 会议纪要` : '会议纪要';
+  lines.push(`# ${title}（${dateStr}）`, '');
+
+  if (s.summary && s.summary.trim()) {
+    lines.push(`> ${s.summary.trim()}`, '');
+  }
+
+  if (s.decisions.length) {
+    lines.push('## ✅ 决策', '', ...s.decisions.map((d) => `- ${d}`), '');
+  }
+
+  if (s.actionItems.length) {
+    lines.push('## 🔲 行动项', '');
+    for (const a of s.actionItems) {
+      const owner = a.owner ? `**@${a.owner}**` : '*待指定*';
+      const ddl = a.ddl ? `（截止 ${a.ddl}）` : '';
+      lines.push(`- ${owner}: ${a.content}${ddl}`);
+    }
+    lines.push('');
+  }
+
+  if (s.issues.length) {
+    lines.push('## 🔍 遗留问题', '', ...s.issues.map((i) => `- ${i}`), '');
+  }
+
+  if (s.nextSteps.length) {
+    lines.push('## ⏭️ 下一步', '', ...s.nextSteps.map((n) => `- ${n}`), '');
+  }
+
+  if (
+    !s.summary &&
+    !s.decisions.length &&
+    !s.actionItems.length &&
+    !s.issues.length &&
+    !s.nextSteps.length
+  ) {
+    lines.push('（未在群历史中识别到明确的决策、行动项或会议结论。）');
+  }
+
+  return lines.join('\n');
+}
+
 // ─── 渲染器：structured → 卡片 summary 字段（不再过 LLM）──────────────────────
 //
 // 跟 archive 一样：渲染走 JS 模板，避免二次幻觉。

--- a/packages/skills/src/prompts/summary.ts
+++ b/packages/skills/src/prompts/summary.ts
@@ -1,31 +1,308 @@
-import type { Message } from '@seedhac/contracts';
+/**
+ * Summary 防幻觉 Prompt（参照 requirementDoc + archive 同款 ICE 框架，
+ * 治理业界公认的 meeting summary 四类幻觉）
+ *
+ * 四类 meeting-specific 幻觉（来自 2026 业界经验 / Microsoft Azure ICE 指南）：
+ *   1. False attribution：把"提问的人"说成"决策的人"
+ *   2. Temporal smoothing：把"或许、考虑、可能"渲染成"已敲定"
+ *   3. Consensus fabrication：单方说话被写成"全体同意"
+ *   4. Topic inflation：随口一句被升格成"关键议题 / 决策"
+ *
+ * 引用：
+ *   - HackerNoon "Steal My Prompt for Automating Meeting Minutes with AI"
+ *   - GoTranscript "Minutes Prompt Library: Standard Prompts for Consistent Meeting Minutes"
+ *   - Microsoft Azure: Best Practices for Mitigating LLM Hallucinations (ICE)
+ *   - 2025 Hallucination Survey (Frontiers / Nature)
+ *   - Atlassian / Notion / Fellow / Otter.ai 公开 meeting minutes 模板字段交集
+ */
+
+import type { Message, SchemaLike } from '@seedhac/contracts';
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+export interface ActionItem {
+  /** 显式被点名负责的人，如「张三」「@李四」；输入里没指名 → 留空字符串 */
+  readonly owner: string;
+  /** 行动项内容 */
+  readonly content: string;
+  /** 截止日期；输入里没明说就别填（豆包对编日期最幻觉）*/
+  readonly ddl?: string;
+}
 
 export interface SummaryExtraction {
+  /** 整体一段话摘要（80-160 字），即使后面字段都空也能给用户可读输出 */
+  readonly summary: string;
+  /** 决策列表 — 必须基于「明确表态 / 拍板」语义，不许把疑问句当决策 */
   readonly decisions: readonly string[];
-  readonly actionItems: readonly { owner: string; content: string; ddl?: string }[];
+  /** 行动项 — 必须有显式责任人，否则进 issues */
+  readonly actionItems: readonly ActionItem[];
+  /** 遗留问题 / 待澄清 — 反幻觉关键字段：含糊不清 / 未定的统统塞这里 */
   readonly issues: readonly string[];
+  /** 下一步计划 */
   readonly nextSteps: readonly string[];
 }
 
 export const EMPTY_EXTRACTION: SummaryExtraction = {
+  summary: '',
   decisions: [],
   actionItems: [],
   issues: [],
   nextSteps: [],
 };
 
+function asStringArray(value: unknown, name: string): string[] {
+  if (!Array.isArray(value)) throw new Error(`${name} must be array`);
+  return value.map((v, i) => {
+    if (typeof v !== 'string') throw new Error(`${name}[${i}] must be string`);
+    return v;
+  });
+}
+
+function parseActionItems(raw: unknown): ActionItem[] {
+  if (!Array.isArray(raw)) throw new Error('actionItems must be array');
+  return raw.map((v, i) => {
+    if (typeof v !== 'object' || v === null) {
+      throw new Error(`actionItems[${i}] must be object`);
+    }
+    const o = v as Record<string, unknown>;
+    const owner = typeof o['owner'] === 'string' ? o['owner'] : '';
+    const content = typeof o['content'] === 'string' ? o['content'] : '';
+    if (!content) throw new Error(`actionItems[${i}].content must be non-empty string`);
+    const item: ActionItem = { owner, content };
+    if (typeof o['ddl'] === 'string' && o['ddl'].trim().length > 0) {
+      return { ...item, ddl: o['ddl'] };
+    }
+    return item;
+  });
+}
+
+export const SummaryExtractionSchema: SchemaLike<SummaryExtraction> = {
+  parse(value: unknown): SummaryExtraction {
+    if (typeof value !== 'object' || value === null) {
+      throw new Error('summary extraction must be object');
+    }
+    const o = value as Record<string, unknown>;
+    return {
+      summary: typeof o['summary'] === 'string' ? o['summary'] : '',
+      decisions: asStringArray(o['decisions'] ?? [], 'decisions'),
+      actionItems: parseActionItems(o['actionItems'] ?? []),
+      issues: asStringArray(o['issues'] ?? [], 'issues'),
+      nextSteps: asStringArray(o['nextSteps'] ?? [], 'nextSteps'),
+    };
+  },
+  jsonSchema(): Record<string, unknown> {
+    const stringArray = { type: 'array', items: { type: 'string' } };
+    return {
+      type: 'object',
+      required: ['summary', 'decisions', 'actionItems', 'issues', 'nextSteps'],
+      properties: {
+        summary: { type: 'string' },
+        decisions: stringArray,
+        actionItems: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['owner', 'content'],
+            properties: {
+              owner: { type: 'string' },
+              content: { type: 'string' },
+              ddl: { type: 'string' },
+            },
+          },
+        },
+        issues: stringArray,
+        nextSteps: stringArray,
+      },
+    };
+  },
+};
+
+// ─── 4 个 Few-Shot 示例（业界公认的 meeting 反幻觉教学场景）──────────────────
+//
+// 顺序遵循 recency bias：A 教标准用法 / B 教空数据 / C 教 false attribution +
+// temporal smoothing / D 教 consensus fabrication + topic inflation
+//
+// 领域故意避开 K12 / 飞书机器人 / 海外语音，避免 LLM 抄当前用户测试场景。
+
+const FEW_SHOT_EXAMPLES = `
+### 示例 A：明确决策 + 显式责任人（教标准用法）
+
+输入：
+[张总(产品)]: 我们今天讨论下供应商选型，候选 A 和 B
+[李工(技术)]: A 集成成本低，B 性能更稳
+[张总]: 决定用 B，技术稳定性更重要
+[李工]: 好的，我下周一前出对接方案
+[王同学(测试)]: 我负责 5 月 20 日前完成压测报告
+
+正确输出：
+{
+  "summary": "本次会议决定供应商选型采用 B 方案，理由是技术稳定性优先；李工负责下周一前产出对接方案，王同学负责 5 月 20 日前完成压测报告。",
+  "decisions": ["供应商选型采用 B 方案，理由：技术稳定性优先于集成成本"],
+  "actionItems": [
+    {"owner": "李工", "content": "产出 B 方案对接方案", "ddl": "下周一"},
+    {"owner": "王同学", "content": "完成压测报告", "ddl": "5 月 20 日"}
+  ],
+  "issues": [],
+  "nextSteps": []
+}
+
+### 示例 B：闲聊 / 没有真正会议内容（最关键的反幻觉示例）
+
+输入：
+[Alice]: 早上好啊
+[Bob]: 早，今天天气不错
+[Alice]: 周末打算干嘛？
+[Bob]: 看看新出的电影
+
+正确输出（必须全部为空，绝对不能编造）：
+{
+  "summary": "本次群聊未识别到与项目相关的决策、行动项或会议结论，仅为日常寒暄。",
+  "decisions": [],
+  "actionItems": [],
+  "issues": [],
+  "nextSteps": []
+}
+
+错误示范（绝对禁止，这种是 topic inflation）：
+❌ {"decisions": ["决定周末看电影"], ...}
+理由：日常闲聊不构成项目决策。
+
+### 示例 C：False attribution + Temporal smoothing（提问≠决策；可能≠敲定）
+
+输入：
+[周经理]: 我们要不要用 React Native 做跨端？
+[周经理]: 还是分别原生开发？
+[陈工程师]: 各有取舍，RN 性能可能差点
+[周经理]: 嗯，再考虑下，下周开会再定
+
+正确输出：
+{
+  "summary": "本次讨论了跨端方案选型（RN vs 原生），未达成结论，下周二次会议再定。",
+  "decisions": [],
+  "actionItems": [],
+  "issues": [
+    "跨端方案选型未定：RN（性能可能稍弱）vs 原生（开发成本高）",
+    "下周开会前需要补充决策依据"
+  ],
+  "nextSteps": ["下周再开会决定跨端方案"]
+}
+
+错误示范 1（false attribution，绝对禁止）：
+❌ {"decisions": ["周经理决定使用 React Native"]}
+理由：周经理是在提问，不是决策。
+
+错误示范 2（temporal smoothing，绝对禁止）：
+❌ {"decisions": ["决定使用 RN（性能稍差）"]}
+理由："再考虑下"是悬而未决，不是敲定。
+
+### 示例 D：Consensus fabrication + 隐式责任人不展开（单边发言≠全员同意）
+
+输入：
+[黄总]: 我看 Q3 营销预算应该砍一半，集中投头部渠道
+[赵 PM]: 嗯
+[黄总]: 还有市场部要把活动数量从 10 个降到 5 个
+[黄总]: 大家有意见吗？
+（之后无人回复）
+
+正确输出：
+{
+  "summary": "黄总提出 Q3 营销预算砍半 + 活动数量减少的建议，群里未见明确同意或反对意见，需进一步确认。",
+  "decisions": [],
+  "actionItems": [],
+  "issues": [
+    "黄总提出 Q3 营销预算砍半、活动数量从 10 个降到 5 个，未见明确反馈",
+    "需补充市场部 / 财务部的明确反馈再形成决策"
+  ],
+  "nextSteps": ["确认 Q3 营销预算与活动数量调整方案"]
+}
+
+错误示范（consensus fabrication，绝对禁止）：
+❌ {"decisions": ["全员同意 Q3 营销预算砍半"]}
+理由：只有"嗯"和无人回复，不能等同于全员同意。
+
+错误示范（编造责任人）：
+❌ {"actionItems": [{"owner": "市场部负责人", "content": "调整活动数量"}]}
+理由：群里没人显式承诺这个动作，不许编造执行人。
+`.trim();
+
+// ─── SUMMARY_PROMPT 主函数 ────────────────────────────────────────────────────
+
+const SYSTEM_RULES = `
+你是会议纪要整理助手。任务：把下方群聊记录里的会议内容提炼成结构化纪要。
+
+# 5 条硬规则（违反任何一条都算严重错误）
+
+1. **False attribution 防御**：只把「明确做出表态 / 拍板」的发言记为决策；提问、设想、
+   "要不要"、"考虑一下"等疑问 / 商议语气**不是决策**。
+2. **Temporal smoothing 防御**：只有出现「决定 / 定了 / OK / 那就 X / 我们 X」等明确
+   敲定的语义，才能进 \`decisions\`；含糊的「可能 / 或许 / 再看看 / 下次再聊」一律进
+   \`issues\`，不许私自渲染成已定。
+3. **Consensus fabrication 防御**：单方发言、群里无人回应 / 只有「嗯」「ok」收到回执
+   等弱响应，**不能**写成"全员同意"。这种情况进 \`issues\`，提示需要进一步确认。
+4. **Action item 必须有显式责任人**：群聊里没人显式说"我做 X"或"@X 负责 X"，就**不要**
+   塞进 \`actionItems\`；改成放进 \`issues\` 里描述"X 待落实，责任人未定"。
+5. **没出现过的人名 / 数字 / 日期 / KPI 一律不许出现在输出里**。即使示例 A-D 里有具体
+   数字，也只是示例，不要往当前任务里搬运。
+
+# Topic inflation 防御
+
+\`decisions\` / \`actionItems\` 字段宁缺毋滥。一句随口的话不要升格为决策，群里日常
+寒暄不要硬总结。如果整段聊天没有真正的项目内容，按示例 B 全部输出空。
+
+# summary 字段（80-160 字）
+
+整段话用第三人称客观陈述，不许用「我们」「大家」这种主观措辞，不许把"未达成"
+渲染成"达成"。decisions / actionItems 都为空时，summary 应明确说明"未识别到决策"。
+`.trim();
+
 export function SUMMARY_PROMPT(history: readonly Message[]): string {
-  const lines = history.map((m) => `[${m.sender.name ?? m.sender.userId}]: ${m.text}`).join('\n');
+  const lines = history.length
+    ? history.map((m) => `[${m.sender.name ?? m.sender.userId}]: ${m.text}`).join('\n')
+    : '（无群聊记录）';
 
-  return `整理以下群聊记录中的会议内容，提取以下字段：
-- decisions：本次会议的决策列表（字符串数组）
-- actionItems：行动项列表，每项包含 owner（负责人）、content（内容）、ddl（截止日期，无则省略）
-- issues：遗留问题列表（字符串数组）
-- nextSteps：下一步计划列表（字符串数组）
+  return [
+    SYSTEM_RULES,
+    '',
+    '# 4 个 Few-Shot 示例',
+    '',
+    FEW_SHOT_EXAMPLES,
+    '',
+    '# 现在轮到你处理',
+    '',
+    '## 群聊记录',
+    '',
+    lines,
+    '',
+    '## 输出',
+    '',
+    '只返回符合 schema 的 JSON，不要 markdown 代码块，不要任何说明文字。',
+    'JSON schema: {"summary": string, "decisions": string[], "actionItems": [{"owner": string, "content": string, "ddl"?: string}], "issues": string[], "nextSteps": string[]}',
+  ].join('\n');
+}
 
-只返回如下 JSON，不要有额外文字：
-{"decisions":[],"actionItems":[{"owner":"","content":"","ddl":""}],"issues":[],"nextSteps":[]}
+// ─── 渲染器：structured → 卡片 summary 字段（不再过 LLM）──────────────────────
+//
+// 跟 archive 一样：渲染走 JS 模板，避免二次幻觉。
+// 主要让 summary 字段在 LLM 输出空时也能拼出可读的兜底文案。
 
-群聊记录：
-${lines}`;
+export function renderSummaryProse(s: SummaryExtraction): string {
+  // LLM 已经给了一段话，且结构化字段非全空 → 直接用
+  if (s.summary && s.summary.trim().length > 0) {
+    return s.summary.trim();
+  }
+
+  const parts: string[] = [];
+  if (s.decisions.length > 0) {
+    parts.push(`形成 ${s.decisions.length} 项决策`);
+  }
+  if (s.actionItems.length > 0) {
+    parts.push(`${s.actionItems.length} 条行动项`);
+  }
+  if (s.issues.length > 0) {
+    parts.push(`${s.issues.length} 个待澄清问题`);
+  }
+  if (parts.length > 0) {
+    return `本次会议${parts.join('、')}，详见下方分段。`;
+  }
+  return '未在群历史中识别到明确的决策、行动项或会议结论。';
 }

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -239,6 +239,14 @@ export const summarySkill: Skill = {
         code: patchRes.error.code,
         message: patchRes.error.message,
       });
+    } else {
+      // Feishu 端 code=0 不一定真的更新视图（Card 2.0 patch 偶尔不生效）。
+      // 显式 log 让排查时能区分「patch 没调」/「patch 调了但 Feishu 未刷新」
+      ctx.logger.info('summary: patch final card returned ok', {
+        loadingMessageId,
+        decisions: summary.decisions.length,
+        actionItems: summary.actionItems.length,
+      });
     }
 
     // e. 副作用写入（失败不阻断卡片输出）

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -28,6 +28,7 @@ import {
   EMPTY_EXTRACTION,
   SummaryExtractionSchema,
   renderSummaryProse,
+  renderMeetingMinutesMarkdown,
   type SummaryExtraction,
 } from './prompts/summary.js';
 import {
@@ -141,6 +142,61 @@ async function extractSummary(
   return ok(llmResult.value);
 }
 
+/**
+ * 把抽取结果落成飞书文档，并给当前群成员授「可编辑」。任何步骤失败只 warn，
+ * 卡片照常 patch 成不带 docUrl 的版本（degrade 不阻断）。
+ */
+async function createMeetingMinutesDoc(
+  ctx: SkillContext,
+  summary: SummaryExtraction,
+): Promise<string | undefined> {
+  if (ctx.event.type !== 'message') return undefined;
+  const { chatId } = ctx.event.payload;
+
+  const markdown = renderMeetingMinutesMarkdown(summary, { generatedAt: Date.now() });
+  const dateStr = new Date().toLocaleDateString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const docTitle = `会议纪要 ${dateStr}`;
+
+  const fileResult = await ctx.docx.createFromMarkdown(docTitle, markdown);
+  if (!fileResult.ok) {
+    ctx.logger.warn('summary: createFromMarkdown failed; degrade to card-only', {
+      code: fileResult.error.code,
+      message: fileResult.error.message,
+    });
+    return undefined;
+  }
+
+  // 给当前群成员授可编辑权限（仿 requirementDoc）— 失败仅 warn 不阻断
+  const membersRes = await ctx.runtime.fetchMembers({ chatId });
+  if (membersRes.ok && membersRes.value.members.length > 0) {
+    const memberIds = membersRes.value.members.map((m) => m.userId);
+    const grantRes = await ctx.docx.grantMembersEdit(fileResult.value.docToken, 'docx', memberIds);
+    if (!grantRes.ok) {
+      ctx.logger.warn('summary: grant members edit failed', {
+        code: grantRes.error.code,
+        message: grantRes.error.message,
+      });
+    } else {
+      ctx.logger.info('summary: granted members edit', { memberCount: memberIds.length });
+    }
+  } else if (!membersRes.ok) {
+    ctx.logger.warn('summary: fetchMembers failed; skip granting edit', {
+      code: membersRes.error.code,
+      message: membersRes.error.message,
+    });
+  }
+
+  ctx.logger.info('summary: created feishu meeting minutes doc', {
+    docToken: fileResult.value.docToken,
+    title: docTitle,
+  });
+  return fileResult.value.url;
+}
+
 export const summarySkill: Skill = {
   name: 'summary',
   metadata: {
@@ -220,7 +276,16 @@ export const summarySkill: Skill = {
     }
     const summary = extractResult.value;
 
-    // d. patch 成最终卡片 — 优先做这一步，让用户最快看到结果；后面的写入是异步副作用
+    // d. 创建飞书文档（混合方案）— 失败仅 warn，卡片仍照常 patch（degrade 到无 docUrl）
+    //    若群里全是闲聊（4 字段全空），跳过建 doc，避免产生空文档
+    const hasContent =
+      summary.decisions.length > 0 ||
+      summary.actionItems.length > 0 ||
+      summary.issues.length > 0 ||
+      summary.nextSteps.length > 0;
+    const docUrl = hasContent ? await createMeetingMinutesDoc(ctx, summary) : undefined;
+
+    // e. patch 成最终卡片 — 让用户最快看到结果；后面的写入是异步副作用
     const finalCard = ctx.cardBuilder.build('summary', {
       title: '会议纪要',
       summary: renderSummaryProse(summary),
@@ -232,6 +297,7 @@ export const summarySkill: Skill = {
         ...(a.ddl !== undefined ? { due: a.ddl } : {}),
       })),
       followUps: [...summary.issues, ...summary.nextSteps],
+      ...(docUrl ? { docUrl } : {}),
     });
     const patchRes = await ctx.runtime.patchCard({ messageId: loadingMessageId, card: finalCard });
     if (!patchRes.ok) {
@@ -246,6 +312,7 @@ export const summarySkill: Skill = {
         loadingMessageId,
         decisions: summary.decisions.length,
         actionItems: summary.actionItems.length,
+        docUrl: docUrl ?? '(none)',
       });
     }
 
@@ -274,6 +341,7 @@ export const summarySkill: Skill = {
     }
 
     // memory 记一条 chat 类型 audit（PR #96 后所有 skill 字段对齐 MemoryRecord）
+    // 含 docUrl 时把 [会议纪要] 前缀 + URL 嵌进 content，archive skill 能识别为产出物
     const now = Date.now();
     const memRes = await ctx.bitable.insert({
       table: 'memory',
@@ -282,7 +350,7 @@ export const summarySkill: Skill = {
         kind: 'chat',
         chat_id: chatId,
         content: [
-          summary.summary,
+          docUrl ? `[会议纪要] ${summary.summary || '会议纪要已生成'}\n${docUrl}` : summary.summary,
           summary.decisions.length ? `决策：${summary.decisions.join('；')}` : '',
           summary.actionItems.length
             ? `行动项：${summary.actionItems.map((a) => `${a.owner || '?'}: ${a.content}`).join('；')}`
@@ -302,7 +370,7 @@ export const summarySkill: Skill = {
     return ok({
       reasoning: `提取到 ${summary.decisions.length} 条决策，${summary.actionItems.length} 条行动项${
         summary.issues.length ? `，${summary.issues.length} 个待澄清` : ''
-      }`,
+      }${docUrl ? '；已归档至飞书文档' : ''}`,
     });
   },
 };

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -1,12 +1,19 @@
 /**
- * summary — 会议纪要自动整理
+ * summary — 会议纪要自动整理（与 requirementDoc / archive 同款防幻觉 pipeline）
  *
- * 触发：群里出现会议纪要 / 妙记内容（被动监听，无需 @bot）
- * 数据流：fetchHistory → LLM 结构化提取 → batchInsert Bitable → summary 卡片
- * 输出：决策 / 行动项 / 遗留问题 / 下一步 4 段
+ * 触发：群里出现会议纪要 / 妙记 / 会议总结（被动监听，无需 @bot）
+ *
+ * 数据流：
+ *   1. 立刻发 loading 卡片占位
+ *   2. fetchHistory + 展开合并转发（妙记导出常以转发形式贴入）
+ *   3. lite 模型相关性预筛（剔除 bot 噪音 / 跨项目闲聊）
+ *   4. pro 模型 askStructured 提取（带 4 类 meeting 幻觉硬约束 + 4 个 few-shot）
+ *   5. patchCard 替换为最终 summary 卡 / 任意失败 patch 成 error 卡
+ *   6. 写 decision / todo / memory（异步副作用，失败不阻断卡片）
  */
 
 import {
+  type Message,
   type Skill,
   type SkillContext,
   type SkillResult,
@@ -16,41 +23,122 @@ import {
   ErrorCode,
   makeError,
 } from '@seedhac/contracts';
-import { SUMMARY_PROMPT, EMPTY_EXTRACTION, type SummaryExtraction } from './prompts/summary.js';
+import {
+  SUMMARY_PROMPT,
+  EMPTY_EXTRACTION,
+  SummaryExtractionSchema,
+  renderSummaryProse,
+  type SummaryExtraction,
+} from './prompts/summary.js';
+import {
+  RELEVANCE_PROMPT,
+  RelevanceJudgmentSchema,
+  type RelevanceCandidate,
+} from './prompts/requirement-doc.js';
 
 const TRIGGER_RE = /会议纪要|妙记|会议总结|本次会议/i;
 
+/**
+ * 把历史消息里的「合并转发」展开。妙记或他人会议记录常以合并转发形式贴入群。
+ * 失败时保留父原样并 logger.warn。
+ */
+async function expandMergeForward(
+  ctx: SkillContext,
+  history: readonly Message[],
+): Promise<readonly Message[]> {
+  const out: Message[] = [];
+  for (const m of history) {
+    if ((m.contentType as string) !== 'merge_forward') {
+      out.push(m);
+      continue;
+    }
+    const fetched = await ctx.runtime.fetchMessage(m.messageId);
+    if (!fetched.ok) {
+      ctx.logger.warn('summary: fetchMessage failed for merge_forward; keeping as-is', {
+        messageId: m.messageId,
+        code: fetched.error.code,
+        message: fetched.error.message,
+      });
+      out.push(m);
+      continue;
+    }
+    const children = fetched.value.messages.filter(
+      (c) => (c.contentType as string) === 'text' && c.text.trim().length > 0,
+    );
+    if (children.length === 0) {
+      out.push(m);
+      continue;
+    }
+    ctx.logger.info('summary: merge_forward expanded', {
+      messageId: m.messageId,
+      childCount: children.length,
+    });
+    for (const child of children) out.push(child);
+  }
+  return out;
+}
+
+function summarize(value: string, max = 200): string {
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+/**
+ * 用 lite 模型预筛历史 — 群里可能掺多个项目讨论 / bot 诊断噪音。
+ * 失败时降级为原 history（不致命）。
+ */
+async function filterByRelevance(
+  ctx: SkillContext,
+  trigger: Message,
+  history: readonly Message[],
+): Promise<readonly Message[]> {
+  if (history.length <= 5) return history;
+
+  const candidates: RelevanceCandidate[] = history.map((m, i) => ({
+    id: `m${i}`,
+    kind: 'message',
+    excerpt: `[${m.sender.name ?? m.sender.userId}] ${summarize(m.text, 200)}`,
+  }));
+
+  const judgmentResult = await ctx.llm.askStructured(
+    RELEVANCE_PROMPT(trigger.text, candidates),
+    RelevanceJudgmentSchema,
+    { model: 'lite', timeoutMs: 30_000 },
+  );
+
+  if (!judgmentResult.ok) {
+    ctx.logger.warn('summary: relevance filter failed, falling back to full history', {
+      code: judgmentResult.error.code,
+      message: judgmentResult.error.message,
+    });
+    return history;
+  }
+
+  if (judgmentResult.value.results.length === 0) return history;
+
+  const keepIds = new Set(judgmentResult.value.results.filter((r) => r.keep).map((r) => r.id));
+  const kept = history.filter((_, i) => keepIds.has(`m${i}`));
+
+  ctx.logger.info('summary: relevance pre-filter done', {
+    kept: `${kept.length}/${history.length}`,
+  });
+
+  // 如果筛完几乎全没了，可能是模型误判：保底退回原 history
+  return kept.length >= Math.min(3, history.length) ? kept : history;
+}
+
 async function extractSummary(
   ctx: SkillContext,
-  chatId: string,
+  history: readonly Message[],
 ): Promise<Result<SummaryExtraction>> {
-  const histResult = await ctx.runtime.fetchHistory({ chatId, pageSize: 50 });
-  if (!histResult.ok) return err(histResult.error);
-
-  const llmResult = await ctx.llm.ask(SUMMARY_PROMPT(histResult.value.messages), { model: 'pro' });
+  // pro 默认 30s 不够：长 prompt + few-shot，35-90s 是常态（参考 requirementDoc）
+  const llmResult = await ctx.llm.askStructured(
+    SUMMARY_PROMPT(history),
+    SummaryExtractionSchema,
+    { model: 'pro', timeoutMs: 90_000 },
+  );
   if (!llmResult.ok) return err(llmResult.error);
-
-  try {
-    const cleaned = llmResult.value
-      .trim()
-      .replace(/```json|```/g, '')
-      .trim();
-    const parsed = JSON.parse(cleaned) as SummaryExtraction;
-    return ok({
-      decisions: Array.isArray(parsed.decisions) ? parsed.decisions.map(String) : [],
-      actionItems: Array.isArray(parsed.actionItems)
-        ? parsed.actionItems.map((a) => ({
-            owner: String(a.owner ?? ''),
-            content: String(a.content ?? ''),
-            ...(a.ddl ? { ddl: String(a.ddl) } : {}),
-          }))
-        : [],
-      issues: Array.isArray(parsed.issues) ? parsed.issues.map(String) : [],
-      nextSteps: Array.isArray(parsed.nextSteps) ? parsed.nextSteps.map(String) : [],
-    });
-  } catch {
-    return ok(EMPTY_EXTRACTION);
-  }
+  return ok(llmResult.value);
 }
 
 export const summarySkill: Skill = {
@@ -64,7 +152,7 @@ export const summarySkill: Skill = {
     events: ['message'],
     requireMention: false,
     keywords: ['会议纪要', '妙记', '会议总结', '本次会议'],
-    description: '检测到会议纪要时自动整理并写入项目记忆',
+    description: '检测到会议纪要时整理结构化决策 / 行动项 / 遗留问题',
   },
 
   match(ctx: SkillContext): boolean {
@@ -76,13 +164,84 @@ export const summarySkill: Skill = {
     if (ctx.event.type !== 'message') {
       return err(makeError(ErrorCode.INVALID_INPUT, 'summary only handles message events'));
     }
-    const { chatId } = ctx.event.payload;
+    const msg = ctx.event.payload;
+    const { chatId } = msg;
 
-    const extractResult = await extractSummary(ctx, chatId);
-    if (!extractResult.ok) return err(extractResult.error);
+    // 0. 立刻发 loading 卡片占位（仿 requirementDoc / slides）
+    const loadingCard = ctx.cardBuilder.build('summary', {
+      title: '会议纪要',
+      topics: [],
+      decisions: [],
+      todos: [],
+      followUps: [],
+      isLoading: true,
+    });
+    const loadingSent = await ctx.runtime.sendCard({ chatId, card: loadingCard });
+    if (!loadingSent.ok) return err(loadingSent.error);
+    const loadingMessageId = loadingSent.value.messageId;
+
+    const patchToError = async (message: string): Promise<void> => {
+      const errCard = ctx.cardBuilder.build('summary', {
+        title: '会议纪要',
+        topics: [],
+        decisions: [],
+        todos: [],
+        followUps: [],
+        errorMessage: message,
+      });
+      const patchRes = await ctx.runtime.patchCard({ messageId: loadingMessageId, card: errCard });
+      if (!patchRes.ok) {
+        ctx.logger.warn('summary: patch error card failed', {
+          code: patchRes.error.code,
+          message: patchRes.error.message,
+        });
+      }
+    };
+
+    // a. 拉历史 + 展开合并转发
+    const histResult = await ctx.runtime.fetchHistory({ chatId, pageSize: 50 });
+    if (!histResult.ok) {
+      await patchToError(`拉群历史失败：${histResult.error.message}`);
+      return err(histResult.error);
+    }
+    const expanded = await expandMergeForward(ctx, histResult.value.messages);
+
+    // b. lite 相关性预筛（数量较小或筛完几乎空时自动 fallback）
+    const filtered = await filterByRelevance(ctx, msg, expanded);
+
+    // c. pro 模型结构化提取
+    ctx.logger.info('summary: asking LLM for structured extraction', {
+      historyCount: filtered.length,
+    });
+    const extractResult = await extractSummary(ctx, filtered);
+    if (!extractResult.ok) {
+      await patchToError(`LLM 提取失败：${extractResult.error.message}`);
+      return err(extractResult.error);
+    }
     const summary = extractResult.value;
 
-    // 写 Bitable — 失败不阻断卡片输出，仅记录日志
+    // d. patch 成最终卡片 — 优先做这一步，让用户最快看到结果；后面的写入是异步副作用
+    const finalCard = ctx.cardBuilder.build('summary', {
+      title: '会议纪要',
+      summary: renderSummaryProse(summary),
+      topics: [],
+      decisions: summary.decisions,
+      todos: summary.actionItems.map((a) => ({
+        text: a.content,
+        assignee: a.owner,
+        ...(a.ddl !== undefined ? { due: a.ddl } : {}),
+      })),
+      followUps: [...summary.issues, ...summary.nextSteps],
+    });
+    const patchRes = await ctx.runtime.patchCard({ messageId: loadingMessageId, card: finalCard });
+    if (!patchRes.ok) {
+      ctx.logger.warn('summary: patch final card failed; final card not visible', {
+        code: patchRes.error.code,
+        message: patchRes.error.message,
+      });
+    }
+
+    // e. 副作用写入（失败不阻断卡片输出）
     if (summary.decisions.length > 0) {
       const res = await ctx.bitable.batchInsert({
         table: 'decision',
@@ -106,8 +265,7 @@ export const summarySkill: Skill = {
       if (!res.ok) ctx.logger.warn('summary: batchInsert todo failed', { error: res.error });
     }
 
-    // 字段对齐 contracts/MemoryRecord schema（kind / chat_id / key / content /
-    // source_skill / importance / created_at / last_access），跟 BITABLE memory 表一致
+    // memory 记一条 chat 类型 audit（PR #96 后所有 skill 字段对齐 MemoryRecord）
     const now = Date.now();
     const memRes = await ctx.bitable.insert({
       table: 'memory',
@@ -115,7 +273,15 @@ export const summarySkill: Skill = {
         key: `summary-${chatId}-${now}`,
         kind: 'chat',
         chat_id: chatId,
-        content: summary.decisions.join(' | '),
+        content: [
+          summary.summary,
+          summary.decisions.length ? `决策：${summary.decisions.join('；')}` : '',
+          summary.actionItems.length
+            ? `行动项：${summary.actionItems.map((a) => `${a.owner || '?'}: ${a.content}`).join('；')}`
+            : '',
+        ]
+          .filter(Boolean)
+          .join('\n'),
         importance: 5,
         last_access: now,
         created_at: now,
@@ -124,21 +290,14 @@ export const summarySkill: Skill = {
     });
     if (!memRes.ok) ctx.logger.warn('summary: insert memory failed', { error: memRes.error });
 
-    const card = ctx.cardBuilder.build('summary', {
-      title: '会议纪要',
-      topics: [],
-      decisions: summary.decisions,
-      todos: summary.actionItems.map((a) => ({
-        text: a.content,
-        assignee: a.owner,
-        ...(a.ddl !== undefined ? { due: a.ddl } : {}),
-      })),
-      followUps: [...summary.issues, ...summary.nextSteps],
-    });
-
+    // 不再返回 card：已通过 patchCard 替换 loading 卡，wiring 不需要再发一条
     return ok({
-      card,
-      reasoning: `提取到 ${summary.decisions.length} 条决策，${summary.actionItems.length} 条行动项`,
+      reasoning: `提取到 ${summary.decisions.length} 条决策，${summary.actionItems.length} 条行动项${
+        summary.issues.length ? `，${summary.issues.length} 个待澄清` : ''
+      }`,
     });
   },
 };
+
+// 兼容旧 import（已迁到 prompts/summary）— 保持向后兼容
+export { EMPTY_EXTRACTION };


### PR DESCRIPTION
## Summary

- 给 summary skill 接上 loading / error / 终态三态卡片，跟 requirementDoc & slides 拉齐用户体感
- 整套防幻觉 pipeline 仿 requirementDoc：lite 相关性预筛 → pro 模型 askStructured + Schema 校验 → patchCard
- prompt 重写直击业界公认的 meeting summary 4 类幻觉：false attribution / temporal smoothing / consensus fabrication / topic inflation
- 混合输出方案：卡片内嵌决策/行动项 + 飞书 docx 长版纪要（按 Otter / Fellow / 字节飞书妙记的产品形态）
- timeoutMs 90s，pro 模型对长 prompt 默认 30s 不够

## 起因

旧版 summary 一上来直接 fetchHistory + llm.ask + JSON.parse，跑完才返回卡片。中途 LLM_TIMEOUT 时 wiring 只 logger.error，群里完全无声 —— 用户视角"发完消息后什么都没有"，跟 requirementDoc / slides 反差明显。

## 改动

### Pipeline（仿 requirementDoc）

1. 立刻 sendCard loading 卡（30-90s ETA 提示）
2. fetchHistory + 展开合并转发（妙记常以转发形式贴入）
3. lite 模型相关性预筛（剔除 bot 噪音 / 跨项目闲聊；筛完几乎空时自动 fallback 全量）
4. pro 模型 askStructured + Schema 验证（取代旧 JSON.parse）
5. **混合方案**：抽取成功后调 createFromMarkdown 建飞书 docx + fetchMembers + grantMembersEdit
6. patchCard 替换为最终卡 / 任意失败 patchCard 成 error 卡
7. 不再返回 card —— 已通过 patchCard 替换，避免 wiring 再发一条

### Prompt（防幻觉）

针对业界公认 meeting summary 的 4 类专属幻觉：

| 幻觉类型 | 治理 |
|---------|------|
| **False attribution**（提问 ≠ 决策） | 硬规则 1 + Few-shot C |
| **Temporal smoothing**（"考虑" ≠ "敲定"） | 硬规则 2 + Few-shot C |
| **Consensus fabrication**（"嗯" ≠ 全员同意） | 硬规则 3 + Few-shot D |
| **Topic inflation**（闲聊 ≠ 决策） | 单独段 + Few-shot B |

参照 archive 的 ICE 框架（Microsoft Azure 反幻觉指南）+ requirementDoc 的 few-shot pattern：
- 5 条硬约束 + topic inflation 单独段落
- 4 个 few-shot：A 标准用法 / B 闲聊空数据 / C false attribution + temporal smoothing / D consensus fabrication
- SchemaLike 强约束输出 5 字段，actionItem 必须有显式责任人
- renderSummaryProse 走 JS 模板兜底，避免二次 LLM

### 卡片层

- \`SummaryCardInput\` 新增可选 \`summary\` / \`docUrl\` / \`isLoading\` / \`errorMessage\`
- buildSummary 加 loading / error / 终态三态，三态都用 blue 主色仅切 header 标题（"会议纪要整理中" → "会议纪要已就绪" → "会议纪要整理失败"），仿 slides "两态同色"
- 终态有 docUrl 时底部追加 primary "打开完整纪要" 按钮 + "仅群内成员可查看与编辑" 提示，跟 docPush 体感一致
- 全字段空时输出明确兜底文案"未在群历史中识别到…"，避免 silent blank card

### 文档归档（混合方案）

- 新增 \`renderMeetingMinutesMarkdown\` 渲染器，按 决策 / 行动项 / 遗留 / 下一步 4 段输出 markdown，标题自动带日期
- doc 创建失败 / fetchMembers 失败 / grantMembersEdit 失败任意一步只 warn，degrade 成不带按钮的卡片
- 全字段空（纯闲聊）跳过建 doc，不污染
- memory content 写入 \`[会议纪要] {url}\` 前缀，archive skill 后续复盘可识别为本次产出物

## Test Plan

- \`./node_modules/.bin/tsc -b packages/contracts packages/skills packages/bot\`：0 error
- \`vitest run packages/bot/src/__tests__ packages/skills/src/__tests__\`：26 files / 372 tests passed
  - card-builder 新增 4 个 case：loading / error / prose 渲染 / 全空兜底
  - summary.test 完全重写覆盖 8 个 case：happy + docx 链路 / loading send 失败 / fetchHistory 失败 / LLM 失败 / bitable 失败不阻断 / 空提取走 prose fallback / doc 创建失败 degrade / 空提取跳过 doc 创建
- \`eslint\` 0 error

## 业界参考

- HackerNoon: [Steal My Prompt for Automating Meeting Minutes with AI](https://hackernoon.com/steal-my-prompt-for-automating-meeting-minutes-with-ai)
- GoTranscript: [Minutes Prompt Library: Standard Prompts for Consistent Meeting Minutes (With Timecode Citations)](https://gotranscript.com/en/blog/minutes-prompt-library-standard-prompts-consistent-minutes-timecode-citations)
- Microsoft Azure: Best Practices for Mitigating LLM Hallucinations (ICE 框架)
- 2025 Hallucination Survey (Frontiers / Nature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)