### PR TITLE
feat(memory): 移除关键字过滤，所有消息进 LLM Lite 判断记忆价值 (closes    #109)     

### DIFF
--- a/packages/bot/src/__tests__/gap-detector.test.ts
+++ b/packages/bot/src/__tests__/gap-detector.test.ts
@@ -22,6 +22,7 @@ function makeLLM(askImpl: LLMClient['ask']): LLMClient {
     chat: vi.fn(),
     askStructured: vi.fn(),
     chatWithTools: vi.fn(),
+    embed: vi.fn(),
   };
 }
 

--- a/packages/bot/src/__tests__/memory-store.test.ts
+++ b/packages/bot/src/__tests__/memory-store.test.ts
@@ -4,6 +4,7 @@ import {
   MEMORY_MAX_CONTENT_BYTES,
   MEMORY_MAX_PER_CHAT_KIND,
   MEMORY_MAX_TOTAL,
+  MEMORY_SUMMARIZE_THRESHOLD_BYTES,
   evictScore,
 } from '../memory/memory-store.js';
 import type { BitableClient, LLMClient, Result, AppError } from '@seedhac/contracts';
@@ -613,9 +614,9 @@ describe('MemoryStore — 评分队列批量化', () => {
 });
 
 describe('MemoryStore — 写入前 LLM 提炼', () => {
-  it('content 超过 400 字节的纯文本会被 LLM 提炼后存入', async () => {
+  it('content 超过阈值的纯文本会被 LLM 提炼，content 存摘要，raw 存原文', async () => {
     const bitable = new FakeBitable();
-    const longText = 'A'.repeat(401);
+    const longText = 'A'.repeat(MEMORY_SUMMARIZE_THRESHOLD_BYTES + 1);
     const summary = '这是摘要';
     const llm = {
       ask: vi.fn().mockResolvedValue(ok(summary)),
@@ -634,7 +635,10 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
     });
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.content).toBe(summary);
+    if (result.ok) {
+      expect(result.value.content).toBe(summary);
+      expect(result.value.raw).toBe(longText);
+    }
     expect(llm.ask).toHaveBeenCalledOnce();
   });
 

--- a/packages/bot/src/__tests__/memory-store.test.ts
+++ b/packages/bot/src/__tests__/memory-store.test.ts
@@ -5,10 +5,11 @@ import {
   MEMORY_MAX_PER_CHAT_KIND,
   MEMORY_MAX_TOTAL,
   MEMORY_SUMMARIZE_THRESHOLD_BYTES,
+  cosineSimilarity,
   evictScore,
 } from '../memory/memory-store.js';
 import type { BitableClient, LLMClient, Result, AppError } from '@seedhac/contracts';
-import { ok } from '@seedhac/contracts';
+import { ok, err, ErrorCode, makeError } from '@seedhac/contracts';
 
 // ────────────────────────────────────────────────────────────────────
 // In-memory BitableClient mock — 模拟 Bitable 的 find/insert/update/delete
@@ -135,6 +136,9 @@ class FakeLLM implements LLMClient {
   public scoreCallCount = 0;
   /** 测试可设：默认返回 importance=7 */
   public nextScore = 7;
+  /** 测试可设：null = 不支持 embedding（返回 CONFIG_MISSING err） */
+  public nextEmbedding: readonly number[] | null = null;
+  public embedCallCount = 0;
 
   async ask(): Promise<Result<string>> {
     return ok('');
@@ -158,6 +162,13 @@ class FakeLLM implements LLMClient {
         error: { code: 'LLM_INVALID_RESPONSE' as const, message: String(e) } as AppError,
       };
     }
+  }
+  async embed(): Promise<Result<readonly number[]>> {
+    this.embedCallCount++;
+    if (this.nextEmbedding === null) {
+      return err(makeError(ErrorCode.CONFIG_MISSING, 'embed: not configured'));
+    }
+    return ok(this.nextEmbedding);
   }
 }
 
@@ -623,6 +634,7 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
       chat: vi.fn(),
       askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
       chatWithTools: vi.fn(),
+      embed: vi.fn().mockResolvedValue(err(makeError(ErrorCode.CONFIG_MISSING, 'not configured'))),
     } as unknown as LLMClient;
 
     const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
@@ -650,6 +662,7 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
       chat: vi.fn(),
       askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
       chatWithTools: vi.fn(),
+      embed: vi.fn().mockResolvedValue(err(makeError(ErrorCode.CONFIG_MISSING, 'not configured'))),
     } as unknown as LLMClient;
 
     const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
@@ -672,6 +685,7 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
       chat: vi.fn(),
       askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
       chatWithTools: vi.fn(),
+      embed: vi.fn().mockResolvedValue(err(makeError(ErrorCode.CONFIG_MISSING, 'not configured'))),
     } as unknown as LLMClient;
 
     const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
@@ -695,6 +709,7 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
       chat: vi.fn(),
       askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
       chatWithTools: vi.fn(),
+      embed: vi.fn().mockResolvedValue(err(makeError(ErrorCode.CONFIG_MISSING, 'not configured'))),
     } as unknown as LLMClient;
 
     const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
@@ -708,5 +723,139 @@ describe('MemoryStore — 写入前 LLM 提炼', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value.content).toBe(longText);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// cosineSimilarity
+// ────────────────────────────────────────────────────────────────────
+
+describe('cosineSimilarity', () => {
+  it('相同向量相似度为 1', () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1);
+  });
+
+  it('正交向量相似度为 0', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  it('反向向量相似度为 -1', () => {
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1);
+  });
+
+  it('零向量返回 0（不崩溃）', () => {
+    expect(cosineSimilarity([0, 0], [1, 2])).toBe(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// MemoryStore — embedding 生成与语义搜索
+// ────────────────────────────────────────────────────────────────────
+
+describe('MemoryStore — embedding 写入与语义搜索', () => {
+  it('write: LLM embed 成功时把 embedding JSON 存入 bitable', async () => {
+    const bitable = new FakeBitable();
+    const llm = new FakeLLM();
+    llm.nextEmbedding = [0.1, 0.2, 0.3];
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    const result = await store.write({
+      kind: 'chat',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: 'hello world',
+      source_skill: 'qa',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.embedding).toBe(JSON.stringify([0.1, 0.2, 0.3]));
+    // bitable 中也存了
+    const row = bitable.all[0];
+    expect(row?.fields.embedding).toBe(JSON.stringify([0.1, 0.2, 0.3]));
+  });
+
+  it('write: embed 失败时静默跳过，不影响写入', async () => {
+    const bitable = new FakeBitable();
+    const llm = new FakeLLM();
+    llm.nextEmbedding = null; // 触发 CONFIG_MISSING err
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    const result = await store.write({
+      kind: 'chat',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: 'hello world',
+      source_skill: 'qa',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.embedding).toBeUndefined();
+    expect(bitable.all[0]?.fields.embedding).toBeUndefined();
+  });
+
+  it('search: 有 embedding 时按余弦相似度排序，过滤 <0.3 的结果', async () => {
+    const bitable = new FakeBitable();
+    // 查询向量 [1, 0]
+    // 记录 A：[0.9, 0.1] → cos≈0.99（高）
+    // 记录 B：[0.1, 0.9] → cos≈0.10（低，被过滤）
+    // 记录 C：[0.7, 0.7] → cos≈0.71（中）
+    const vecA = [0.9, 0.1];
+    const vecB = [0.1, 0.9];
+    const vecC = [0.7, 0.7];
+    bitable.seed([
+      { recordId: 'rec_1', fields: { kind: 'chat', chat_id: 'oc_1', key: 'kA', content: 'A', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa', embedding: JSON.stringify(vecA) } },
+      { recordId: 'rec_2', fields: { kind: 'chat', chat_id: 'oc_1', key: 'kB', content: 'B', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa', embedding: JSON.stringify(vecB) } },
+      { recordId: 'rec_3', fields: { kind: 'chat', chat_id: 'oc_1', key: 'kC', content: 'C', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa', embedding: JSON.stringify(vecC) } },
+    ]);
+
+    const llm = new FakeLLM();
+    llm.nextEmbedding = [1, 0]; // query vector
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 200 });
+    const result = await store.search('oc_1', 'anything', { limit: 5 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const contents = result.value.map((r) => r.content);
+    // A（cos≈0.99）和 C（cos≈0.71）应排在前面，顺序 A→C
+    expect(contents[0]).toBe('A');
+    expect(contents[1]).toBe('C');
+    // B（cos≈0.10）被相似度门槛过滤掉
+    expect(contents).not.toContain('B');
+  });
+
+  it('search: LLM 无 embedding 时降级到关键词匹配', async () => {
+    const bitable = new FakeBitable();
+    bitable.seed([
+      { recordId: 'rec_1', fields: { kind: 'chat', chat_id: 'oc_1', key: 'k1', content: 'hello world', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa' } },
+      { recordId: 'rec_2', fields: { kind: 'chat', chat_id: 'oc_1', key: 'k2', content: 'goodbye', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa' } },
+    ]);
+
+    const llm = new FakeLLM();
+    llm.nextEmbedding = null; // embed 返回 err → 降级
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 200 });
+    const result = await store.search('oc_1', 'hello');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.length).toBe(1);
+    expect(result.value[0]!.content).toBe('hello world');
+  });
+
+  it('search: 无 LLM 时直接走关键词匹配', async () => {
+    const bitable = new FakeBitable();
+    bitable.seed([
+      { recordId: 'rec_1', fields: { kind: 'chat', chat_id: 'oc_1', key: 'k1', content: 'project deadline', importance: 5, last_access: 100, created_at: 100, source_skill: 'qa' } },
+    ]);
+
+    const store = new MemoryStore({ bitable, scoreFlushMs: 100_000, now: () => 200 });
+    const result = await store.search('oc_1', 'deadline');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.length).toBe(1);
   });
 });

--- a/packages/bot/src/__tests__/memory-store.test.ts
+++ b/packages/bot/src/__tests__/memory-store.test.ts
@@ -611,3 +611,98 @@ describe('MemoryStore — 评分队列批量化', () => {
     if (result.ok) expect(result.value.importance).toBe(-1); // PENDING
   });
 });
+
+describe('MemoryStore — 写入前 LLM 提炼', () => {
+  it('content 超过 400 字节的纯文本会被 LLM 提炼后存入', async () => {
+    const bitable = new FakeBitable();
+    const longText = 'A'.repeat(401);
+    const summary = '这是摘要';
+    const llm = {
+      ask: vi.fn().mockResolvedValue(ok(summary)),
+      chat: vi.fn(),
+      askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
+      chatWithTools: vi.fn(),
+    } as unknown as LLMClient;
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    const result = await store.write({
+      kind: 'chat',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: longText,
+      source_skill: 'qa',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.content).toBe(summary);
+    expect(llm.ask).toHaveBeenCalledOnce();
+  });
+
+  it('content 400 字节以内不触发提炼', async () => {
+    const bitable = new FakeBitable();
+    const shortText = '短文本';
+    const llm = {
+      ask: vi.fn(),
+      chat: vi.fn(),
+      askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
+      chatWithTools: vi.fn(),
+    } as unknown as LLMClient;
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    await store.write({
+      kind: 'chat',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: shortText,
+      source_skill: 'qa',
+    });
+
+    expect(llm.ask).not.toHaveBeenCalled();
+  });
+
+  it('JSON 格式的 content 跳过提炼，直接存入', async () => {
+    const bitable = new FakeBitable();
+    const jsonContent = JSON.stringify({ skill: 'qa', output: 'A'.repeat(400), at: 123 });
+    const llm = {
+      ask: vi.fn(),
+      chat: vi.fn(),
+      askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
+      chatWithTools: vi.fn(),
+    } as unknown as LLMClient;
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    const result = await store.write({
+      kind: 'skill_log',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: jsonContent,
+      source_skill: 'qa',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(llm.ask).not.toHaveBeenCalled();
+  });
+
+  it('LLM 提炼失败时静默回退到原文', async () => {
+    const bitable = new FakeBitable();
+    const longText = 'B'.repeat(401);
+    const llm = {
+      ask: vi.fn().mockResolvedValue({ ok: false, error: { code: 'LLM_TIMEOUT', message: 'timeout' } }),
+      chat: vi.fn(),
+      askStructured: vi.fn().mockResolvedValue(ok({ importance: 5 })),
+      chatWithTools: vi.fn(),
+    } as unknown as LLMClient;
+
+    const store = new MemoryStore({ bitable, llm, scoreFlushMs: 100_000, now: () => 1000 });
+    const result = await store.write({
+      kind: 'chat',
+      chat_id: 'oc_1',
+      key: 'k1',
+      content: longText,
+      source_skill: 'qa',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.content).toBe(longText);
+  });
+});

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -48,7 +48,11 @@ function makeRuntime(): BotRuntime {
   } as unknown as BotRuntime;
 }
 
-function makeCtx(event: BotEvent, runtimeOverride?: BotRuntime): SkillContext {
+function makeCtx(
+  event: BotEvent,
+  runtimeOverride?: BotRuntime,
+  llmOverride?: Partial<SkillContext['llm']>,
+): SkillContext {
   return {
     event,
     runtime: runtimeOverride ?? makeRuntime(),
@@ -57,6 +61,8 @@ function makeCtx(event: BotEvent, runtimeOverride?: BotRuntime): SkillContext {
       chat: vi.fn(),
       askStructured: vi.fn(),
       chatWithTools: vi.fn(),
+      embed: vi.fn(),
+      ...llmOverride,
     } as unknown as SkillContext['llm'],
     bitable: {
       insert: vi.fn().mockResolvedValue(ok({ tableId: 't', recordId: 'r' })),
@@ -798,5 +804,81 @@ describe('shouldObservePassively', () => {
   it('trim 后长度不足的消息应被跳过', () => {
     const padded = '   ' + 'a'.repeat(PASSIVE_MIN_TEXT_LENGTH - 1) + '   ';
     expect(shouldObservePassively(padded)).toBe(false);
+  });
+});
+
+// ─── handlePassiveObserve（通过 handleEvent 集成） ────────────────────────────
+
+describe('handleEvent — passive observe', () => {
+  const router = new SkillRouter(BOT_ID);
+
+  it('非 @mention 长消息触发 LLM 判断', async () => {
+    const msg = makeMessage({ text: '我们决定下周五提交MVP，前端由小明负责', mentions: [] });
+    const chatWithTools = vi.fn().mockResolvedValue(ok({ content: 'SKIP', toolCalls: [], rounds: 1 }));
+    const ctx = makeCtx(makeEvent(msg), undefined, { chatWithTools });
+
+    await handleEvent(ctx, router, {}, makeHarness());
+    await new Promise((r) => setTimeout(r, 0)); // flush fire-and-forget
+
+    expect(chatWithTools).toHaveBeenCalledOnce();
+  });
+
+  it('非 @mention 短消息不触发 LLM 判断', async () => {
+    const msg = makeMessage({ text: '好的', mentions: [] });
+    const chatWithTools = vi.fn().mockResolvedValue(ok({ content: '', toolCalls: [], rounds: 0 }));
+    const ctx = makeCtx(makeEvent(msg), undefined, { chatWithTools });
+
+    await handleEvent(ctx, router, {}, makeHarness());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chatWithTools).not.toHaveBeenCalled();
+  });
+
+  it('LLM 决定调 memory.write 时写入 store', async () => {
+    const msg = makeMessage({ text: '项目截止日期确定是5月15日，请各位注意', mentions: [] });
+
+    const memoryStore = new NullMemoryStore();
+    const writeSpy = vi.spyOn(memoryStore, 'write').mockResolvedValue(
+      ok({ id: 'r1', kind: 'chat', chat_id: 'oc_chat1', key: 'project_deadline',
+           content: '截止5月15日', importance: -1, last_access: 0, created_at: 0, source_skill: 'passive_observe' }),
+    );
+
+    const chatWithTools = vi.fn().mockImplementation(
+      async (_msgs: unknown, opts: { executor: (c: { id: string; name: string; argumentsRaw: string }) => Promise<unknown> }) => {
+        await opts.executor({ id: 'tc1', name: 'memory.write',
+          argumentsRaw: JSON.stringify({ kind: 'chat', key: 'project_deadline', content: '截止5月15日' }) });
+        return ok({ content: '', toolCalls: [{ id: 'tc1', name: 'memory.write', argumentsRaw: '{}' }], rounds: 1 });
+      },
+    );
+
+    const ctx = makeCtx(makeEvent(msg), undefined, { chatWithTools });
+    const harness = { ...makeHarness(), memoryStore };
+
+    await handleEvent(ctx, router, {}, harness);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    expect(writeSpy).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'chat',
+      key: 'project_deadline',
+      source_skill: 'passive_observe',
+    }));
+  });
+
+  it('@mention 消息不走 passive observe 路径', async () => {
+    // @mention 走 Harness，不走 passive observe；chatWithTools 被 Harness 调，不是 passive observe
+    const msg = makeMessage({ text: '我们决定下周五提交MVP，前端由小明负责',
+      mentions: [{ user: { userId: BOT_ID }, key: '@_bot' }] });
+    const chatWithTools = vi.fn().mockResolvedValue(
+      ok({ content: JSON.stringify({ skill: 'silent' }), toolCalls: [], rounds: 1 }),
+    );
+    const ctx = makeCtx(makeEvent(msg), undefined, { chatWithTools });
+
+    await handleEvent(ctx, router, {}, makeHarness());
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Harness 可能调 chatWithTools，但 passive observe 不应额外再调一次
+    // 每条 @mention 消息 chatWithTools 调用次数 ≤ 1（只有 Harness，没有 passive observe）
+    expect(chatWithTools.mock.calls.length).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -10,7 +10,7 @@ import type {
   SkillName,
 } from '@seedhac/contracts';
 import { SkillRouter } from '../skill-router.js';
-import { handleEvent, type HarnessConfig } from '../wiring.js';
+import { handleEvent, shouldObservePassively, PASSIVE_MIN_TEXT_LENGTH, type HarnessConfig } from '../wiring.js';
 import { NullMemoryStore } from '../memory/memory-store.js';
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -770,8 +770,6 @@ describe('onboarding flow', () => {
 });
 
 // ─── shouldObservePassively ───────────────────────────────────────────────────
-
-import { shouldObservePassively, PASSIVE_MIN_TEXT_LENGTH } from '../wiring.js';
 
 describe('shouldObservePassively', () => {
   it('长度达标的普通对话消息应被观察', () => {

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -768,3 +768,37 @@ describe('onboarding flow', () => {
     expect(ctx.bitable.insert).toHaveBeenCalledOnce();
   });
 });
+
+// ─── shouldObservePassively ───────────────────────────────────────────────────
+
+import { shouldObservePassively, PASSIVE_MIN_TEXT_LENGTH } from '../wiring.js';
+
+describe('shouldObservePassively', () => {
+  it('长度达标的普通对话消息应被观察', () => {
+    expect(shouldObservePassively('我们明天把这个功能做完吧')).toBe(true);
+  });
+
+  it('不含关键字但有事实信息的消息也应被观察', () => {
+    expect(shouldObservePassively('小明你来写登录页，小红负责接口')).toBe(true);
+  });
+
+  it('恰好等于最小长度的消息应被观察', () => {
+    const text = 'a'.repeat(PASSIVE_MIN_TEXT_LENGTH);
+    expect(shouldObservePassively(text)).toBe(true);
+  });
+
+  it('过短的消息（闲聊/表情）应被跳过', () => {
+    expect(shouldObservePassively('好的')).toBe(false);
+    expect(shouldObservePassively('👍')).toBe(false);
+    expect(shouldObservePassively('ok')).toBe(false);
+  });
+
+  it('纯空白消息应被跳过', () => {
+    expect(shouldObservePassively('   ')).toBe(false);
+  });
+
+  it('trim 后长度不足的消息应被跳过', () => {
+    const padded = '   ' + 'a'.repeat(PASSIVE_MIN_TEXT_LENGTH - 1) + '   ';
+    expect(shouldObservePassively(padded)).toBe(false);
+  });
+});

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -64,13 +64,20 @@ function buildDeps() {
   const runtime = createBotRuntime({ logger });
   const router = new SkillRouter(envTrim('LARK_BOT_OPEN_ID'));
 
+  const embeddingModel = envTrim('ARK_MODEL_EMBEDDING');
   const llm = new VolcanoLLMClient({
     apiKey: envTrim('ARK_API_KEY'),
     modelIds: {
       lite: envTrim('ARK_MODEL_LITE'),
       pro: envTrim('ARK_MODEL_PRO'),
+      ...(embeddingModel && { embedding: embeddingModel }),
     },
   });
+  if (!embeddingModel) {
+    logger.warn(
+      'ARK_MODEL_EMBEDDING not set — memory search will fall back to keyword matching',
+    );
+  }
 
   const bitable = new LarkBitableClient({
     appId,

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -74,8 +74,8 @@ function buildDeps() {
     },
   });
   if (!embeddingModel) {
-    logger.warn(
-      'ARK_MODEL_EMBEDDING not set — memory search will fall back to keyword matching',
+    logger.info(
+      'ARK_MODEL_EMBEDDING not set — memory search will use keyword matching',
     );
   }
 

--- a/packages/bot/src/llm-client.ts
+++ b/packages/bot/src/llm-client.ts
@@ -33,6 +33,8 @@ export interface LLMConfig {
   readonly modelIds: {
     readonly lite: string;
     readonly pro: string;
+    /** 可选：embedding 模型 ID；配置后启用语义检索，否则降级到字符串匹配 */
+    readonly embedding?: string;
   };
   readonly baseUrl?: string;
 }
@@ -346,6 +348,51 @@ export class VolcanoLLMClient implements LLMClient {
     // 达到 maxRounds 仍有 tool_calls 未处理完 → 返回最后一次 content + 历史
     console.warn(`[LLMClient] chatWithTools hit maxRounds=${maxRounds}, returning last content`);
     return ok({ content: lastContent, toolCalls: allToolCalls, rounds });
+  }
+
+  async embed(text: string): Promise<Result<readonly number[]>> {
+    const embeddingModelId = this.config.modelIds.embedding;
+    if (!embeddingModelId) {
+      return err(makeError(ErrorCode.CONFIG_MISSING, 'embed: ARK_MODEL_EMBEDDING not configured'));
+    }
+
+    const body = JSON.stringify({ model: embeddingModelId, input: text });
+    let lastErr: unknown;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+      try {
+        const resp = await fetch(`${this.config.baseUrl}/embeddings`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.config.apiKey}`,
+          },
+          body,
+          signal: controller.signal,
+        });
+        clearTimeout(timer);
+        if (!resp.ok) {
+          const t = await resp.text();
+          throw new Error(`HTTP ${resp.status}: ${t}`);
+        }
+        const data = (await resp.json()) as { data?: Array<{ embedding?: number[] }> };
+        const vector = data.data?.[0]?.embedding;
+        if (!Array.isArray(vector) || vector.length === 0) {
+          throw new Error('embed: empty or missing embedding vector in response');
+        }
+        return ok(vector as readonly number[]);
+      } catch (e) {
+        clearTimeout(timer);
+        lastErr = e;
+        if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
+      }
+    }
+
+    return err(
+      makeError(ErrorCode.LLM_INVALID_RESPONSE, 'embed: failed after 3 attempts', lastErr),
+    );
   }
 
   async askStructured<T>(

--- a/packages/bot/src/llm-client.ts
+++ b/packages/bot/src/llm-client.ts
@@ -358,6 +358,7 @@ export class VolcanoLLMClient implements LLMClient {
 
     const body = JSON.stringify({ model: embeddingModelId, input: text });
     let lastErr: unknown;
+    let sawTimeout = false;
 
     for (let attempt = 0; attempt < 3; attempt++) {
       const controller = new AbortController();
@@ -386,12 +387,17 @@ export class VolcanoLLMClient implements LLMClient {
       } catch (e) {
         clearTimeout(timer);
         lastErr = e;
+        if (e instanceof Error && e.name === 'AbortError') sawTimeout = true;
         if (attempt < 2) await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
       }
     }
 
     return err(
-      makeError(ErrorCode.LLM_INVALID_RESPONSE, 'embed: failed after 3 attempts', lastErr),
+      makeError(
+        sawTimeout ? ErrorCode.LLM_TIMEOUT : ErrorCode.LLM_INVALID_RESPONSE,
+        sawTimeout ? 'embed: timed out after 3 attempts' : 'embed: failed after 3 attempts',
+        lastErr,
+      ),
     );
   }
 

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -268,9 +268,9 @@ export class MemoryStore implements IMemoryStore {
 
     const SIMILARITY_THRESHOLD = 0.3;
 
-    // 只对有 embedding 的行做余弦排序；没有 embedding 的行忽略
+    // 只对有 embedding 的行做余弦排序；没有 embedding 的旧记录直接丢弃
+    // （这些是 embedding feature 上线前写入的历史记录，语义不明，混入会引入噪声）
     const scored: Array<{ memory: MemoryRecord; score: number }> = [];
-    const noEmbedding: MemoryRecord[] = [];
 
     for (const row of findResult.value.records) {
       const memory = this.rowToMemory(row);
@@ -280,21 +280,13 @@ export class MemoryStore implements IMemoryStore {
           const score = cosineSimilarity(queryVec, vec);
           if (score >= SIMILARITY_THRESHOLD) scored.push({ memory, score });
         } catch {
-          noEmbedding.push(memory);
+          // embedding 字段损坏，跳过
         }
-      } else {
-        noEmbedding.push(memory);
       }
     }
 
     scored.sort((a, b) => b.score - a.score);
     const results = scored.slice(0, limit).map((s) => s.memory);
-
-    // 如果语义结果不足 limit，用无 embedding 记录补位（按 last_access 降序）
-    if (results.length < limit && noEmbedding.length > 0) {
-      noEmbedding.sort((a, b) => b.last_access - a.last_access);
-      results.push(...noEmbedding.slice(0, limit - results.length));
-    }
 
     void Promise.all(
       results

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -39,6 +39,7 @@ export const MEMORY_MAX_PER_CHAT_KIND = 200;
 export const MEMORY_MAX_TOTAL = 2000;
 export const MEMORY_SCORE_FLUSH_MS = 30_000;
 export const MEMORY_MAX_QUERY_LENGTH = 64;
+export const MEMORY_SUMMARIZE_THRESHOLD_BYTES = 400;
 const MEMORY_TABLE = 'memory' as const;
 const MEMORY_PENDING_SCORE = -1;
 
@@ -380,9 +381,8 @@ export class MemoryStore implements IMemoryStore {
    * LLM 不可用或失败时静默回退到原文，不阻断写入。
    */
   private async summarizeContent(content: string): Promise<string> {
-    const SUMMARIZE_THRESHOLD_BYTES = 400;
     if (!this.llm) return content;
-    if (new TextEncoder().encode(content).length <= SUMMARIZE_THRESHOLD_BYTES) return content;
+    if (new TextEncoder().encode(content).length <= MEMORY_SUMMARIZE_THRESHOLD_BYTES) return content;
     // 已是结构化 JSON（skill_log / chat 等），跳过提炼
     if (content.trimStart().startsWith('{')) return content;
 

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -277,6 +277,9 @@ export class MemoryStore implements IMemoryStore {
    *   2. 不存在 → insert + 入评分队列
    *   3. 单条 content 超 2KB → 硬截断
    *   4. 写入后异步检查容量，超限触发淘汰
+   *
+   * 写入前自动提炼：content 超过 400 字节且为纯文本时，用 LLM Lite 压缩成摘要，
+   * 提升信息密度；LLM 不可用或调用失败时静默回退到原文。
    */
   async write(input: MemoryWriteInput): Promise<Result<MemoryRecord>> {
     const v1 = this.validateSafeKey('chat_id', input.chat_id);
@@ -289,7 +292,8 @@ export class MemoryStore implements IMemoryStore {
     }
 
     const now = this.now();
-    const content = truncateBytes(input.content, MEMORY_MAX_CONTENT_BYTES);
+    const summarized = await this.summarizeContent(input.content);
+    const content = truncateBytes(summarized, MEMORY_MAX_CONTENT_BYTES);
 
     // 查现有
     const existing = await this.read(input.kind, input.chat_id, input.key);
@@ -360,6 +364,36 @@ export class MemoryStore implements IMemoryStore {
     });
 
     return ok(record);
+  }
+
+  // ─────────────────────────── summarize（写入前提炼） ───────────────────────
+
+  /**
+   * 写入前提炼：content 超过阈值且非 JSON 时，用 LLM Lite 压缩成一句话摘要。
+   * 保留关键事实（人名/决策/数字/截止日期），过滤闲聊噪声。
+   * LLM 不可用或失败时静默回退到原文，不阻断写入。
+   */
+  private async summarizeContent(content: string): Promise<string> {
+    const SUMMARIZE_THRESHOLD_BYTES = 400;
+    if (!this.llm) return content;
+    if (new TextEncoder().encode(content).length <= SUMMARIZE_THRESHOLD_BYTES) return content;
+    // 已是结构化 JSON（skill_log / chat 等），跳过提炼
+    if (content.trimStart().startsWith('{')) return content;
+
+    const result = await this.llm.ask(
+      `请把以下内容提炼成一句话摘要（不超过100字），保留关键事实（人名/决策/数字/截止日期/文档链接），过滤闲聊和噪声，直接输出摘要，不要任何前缀：\n\n${content}`,
+      { model: 'lite', maxTokens: 150 },
+    );
+
+    if (!result.ok) {
+      this.logger?.warn('memory: summarize failed, falling back to raw content', {
+        code: result.error.code,
+        message: result.error.message,
+      });
+      return content;
+    }
+
+    return result.value.trim() || content;
   }
 
   // ─────────────────────────── score（LLM 评分） ───────────────────────────

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -294,6 +294,8 @@ export class MemoryStore implements IMemoryStore {
     const now = this.now();
     const summarized = await this.summarizeContent(input.content);
     const content = truncateBytes(summarized, MEMORY_MAX_CONTENT_BYTES);
+    // 提炼后内容与原文不同时保留原文，供查阅还原
+    const raw = summarized !== input.content ? input.content : undefined;
 
     // 查现有
     const existing = await this.read(input.kind, input.chat_id, input.key);
@@ -307,6 +309,7 @@ export class MemoryStore implements IMemoryStore {
         patch: {
           content,
           last_access: now,
+          ...(raw !== undefined && { raw }),
           ...(input.importance !== undefined && { importance: input.importance }),
         },
       });
@@ -315,6 +318,7 @@ export class MemoryStore implements IMemoryStore {
         ...existing.value,
         content,
         last_access: now,
+        ...(raw !== undefined && { raw }),
         ...(input.importance !== undefined && { importance: input.importance }),
       });
     }
@@ -332,6 +336,7 @@ export class MemoryStore implements IMemoryStore {
       source_skill: input.source_skill,
     };
     if (input.user_id !== undefined) row.user_id = input.user_id;
+    if (raw !== undefined) row.raw = raw;
 
     const insertResult = await this.bitable.insert({ table: MEMORY_TABLE, row });
     if (!insertResult.ok) return insertResult;
@@ -347,6 +352,7 @@ export class MemoryStore implements IMemoryStore {
       created_at: now,
       source_skill: input.source_skill,
       ...(input.user_id !== undefined && { user_id: input.user_id }),
+      ...(raw !== undefined && { raw }),
     };
 
     // 评分队列（仅未指定 importance 且 LLM 可用时）
@@ -611,6 +617,7 @@ export class MemoryStore implements IMemoryStore {
       ...(typeof row.user_id === 'string' && row.user_id ? { user_id: row.user_id } : {}),
       key: String(row.key ?? ''),
       content: String(row.content ?? ''),
+      ...(typeof row.raw === 'string' && row.raw ? { raw: row.raw } : {}),
       importance: typeof row.importance === 'number' ? row.importance : MEMORY_PENDING_SCORE,
       last_access: typeof row.last_access === 'number' ? row.last_access : 0,
       created_at: typeof row.created_at === 'number' ? row.created_at : 0,

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -237,10 +237,12 @@ export class MemoryStore implements IMemoryStore {
       if (embedResult.ok) {
         return this.semanticSearch(chatId, embedResult.value, opts.kind, limit);
       }
-      // embed 失败（如未配置模型）→ 静默降级，不打 error
-      this.logger?.warn('memory: embed failed, falling back to keyword search', {
-        code: embedResult.error.code,
-      });
+      // CONFIG_MISSING = 预期状态（未配置模型），不打 warn；其他错误才值得关注
+      if (embedResult.error.code !== 'CONFIG_MISSING') {
+        this.logger?.warn('memory: embed failed, falling back to keyword search', {
+          code: embedResult.error.code,
+        });
+      }
     }
 
     // 降级：关键词匹配
@@ -409,7 +411,7 @@ export class MemoryStore implements IMemoryStore {
       const embedResult = await this.llm.embed(content);
       if (embedResult.ok) {
         embedding = JSON.stringify(embedResult.value);
-      } else {
+      } else if (embedResult.error.code !== 'CONFIG_MISSING') {
         this.logger?.warn('memory: embed failed on write, skipping embedding', {
           code: embedResult.error.code,
         });

--- a/packages/bot/src/memory/memory-store.ts
+++ b/packages/bot/src/memory/memory-store.ts
@@ -74,6 +74,23 @@ interface PendingScore {
 // ---------- 工具函数 ----------
 
 /**
+ * 余弦相似度：两个等长浮点向量的点积除以模长之积。
+ * 两向量之一全零时返回 0（避免除零 NaN）。
+ */
+export function cosineSimilarity(a: readonly number[], b: readonly number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!;
+    normA += a[i]! * a[i]!;
+    normB += b[i]! * b[i]!;
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom < 1e-10 ? 0 : dot / denom;
+}
+
+/**
  * 按 UTF-8 字节数硬截断；不会撕裂 UTF-8 多字节字符。
  * 实现：用 strict decoder 二分回退到最后一个合法字符边界。
  */
@@ -190,9 +207,16 @@ export class MemoryStore implements IMemoryStore {
   // ─────────────────────────── search ───────────────────────────
 
   /**
-   * 按 chat_id + 关键词模糊查询。
-   * filter 用飞书 CurrentValue.[content].contains("keyword") 语法。
-   * 命中后批量刷新 last_access（异步，不阻塞返回）。
+   * 语义搜索：优先用 embedding 向量余弦相似度；LLM 无 embedding 能力时降级到关键词匹配。
+   *
+   * 语义路径：
+   *   1. 生成 query embedding
+   *   2. 拉取该 chat 全量记录（≤200 条）
+   *   3. 对有 embedding 的记录做余弦相似度排序，返回 top-N
+   *   4. 相似度 < 0.3 的记录剪掉（低相关性噪声）
+   *
+   * 降级路径（LLM 未配置 / embed 调用失败）：
+   *   - 飞书 filter content.contains("keyword") 字符串匹配
    */
   async search(
     chatId: string,
@@ -203,14 +227,96 @@ export class MemoryStore implements IMemoryStore {
     if (!v.ok) return v;
 
     const safeQuery = this.sanitizeQuery(query);
-    if (!safeQuery) {
-      // 全空 query 没意义；返回空列表而非全表扫描
-      return ok([]);
-    }
+    if (!safeQuery) return ok([]);
 
     const limit = Math.min(Math.max(opts.limit ?? 10, 1), 50);
-    const filter = this.buildSearchFilter(chatId, safeQuery, opts.kind);
 
+    // 尝试语义路径
+    if (this.llm) {
+      const embedResult = await this.llm.embed(safeQuery);
+      if (embedResult.ok) {
+        return this.semanticSearch(chatId, embedResult.value, opts.kind, limit);
+      }
+      // embed 失败（如未配置模型）→ 静默降级，不打 error
+      this.logger?.warn('memory: embed failed, falling back to keyword search', {
+        code: embedResult.error.code,
+      });
+    }
+
+    // 降级：关键词匹配
+    return this.keywordSearch(chatId, safeQuery, opts.kind, limit);
+  }
+
+  private async semanticSearch(
+    chatId: string,
+    queryVec: readonly number[],
+    kind: MemoryKind | undefined,
+    limit: number,
+  ): Promise<Result<readonly MemoryRecord[]>> {
+    // 拉取该 chat 全量记录（最多 MEMORY_MAX_PER_CHAT_KIND=200 条，单页够）
+    const filter = this.buildFilter(
+      kind ? { chat_id: chatId, kind } : { chat_id: chatId },
+    );
+    const findResult = await this.bitable.find({
+      table: MEMORY_TABLE,
+      filter,
+      pageSize: MEMORY_MAX_PER_CHAT_KIND,
+    });
+    if (!findResult.ok) return findResult;
+
+    const SIMILARITY_THRESHOLD = 0.3;
+
+    // 只对有 embedding 的行做余弦排序；没有 embedding 的行忽略
+    const scored: Array<{ memory: MemoryRecord; score: number }> = [];
+    const noEmbedding: MemoryRecord[] = [];
+
+    for (const row of findResult.value.records) {
+      const memory = this.rowToMemory(row);
+      if (typeof memory.embedding === 'string' && memory.embedding) {
+        try {
+          const vec = JSON.parse(memory.embedding) as number[];
+          const score = cosineSimilarity(queryVec, vec);
+          if (score >= SIMILARITY_THRESHOLD) scored.push({ memory, score });
+        } catch {
+          noEmbedding.push(memory);
+        }
+      } else {
+        noEmbedding.push(memory);
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    const results = scored.slice(0, limit).map((s) => s.memory);
+
+    // 如果语义结果不足 limit，用无 embedding 记录补位（按 last_access 降序）
+    if (results.length < limit && noEmbedding.length > 0) {
+      noEmbedding.sort((a, b) => b.last_access - a.last_access);
+      results.push(...noEmbedding.slice(0, limit - results.length));
+    }
+
+    void Promise.all(
+      results
+        .filter((m) => m.id)
+        .map((m) =>
+          this.touchAccess(m.id!).catch((e) => {
+            this.logger?.warn('memory: touchAccess failed in search', {
+              recordId: m.id,
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }),
+        ),
+    );
+
+    return ok(results);
+  }
+
+  private async keywordSearch(
+    chatId: string,
+    query: string,
+    kind: MemoryKind | undefined,
+    limit: number,
+  ): Promise<Result<readonly MemoryRecord[]>> {
+    const filter = this.buildSearchFilter(chatId, query, kind);
     const findResult = await this.bitable.find({
       table: MEMORY_TABLE,
       filter,
@@ -219,7 +325,6 @@ export class MemoryStore implements IMemoryStore {
     if (!findResult.ok) return findResult;
 
     const memories = findResult.value.records.map((r) => this.rowToMemory(r));
-    // 批量刷新 last_access
     void Promise.all(
       findResult.value.records.map((r) =>
         this.touchAccess(r.recordId).catch((e) => {
@@ -298,6 +403,19 @@ export class MemoryStore implements IMemoryStore {
     // 提炼后内容与原文不同时保留原文，供查阅还原
     const raw = summarized !== input.content ? input.content : undefined;
 
+    // 异步生成 embedding（失败时静默跳过，不阻断写入）
+    let embedding: string | undefined;
+    if (this.llm) {
+      const embedResult = await this.llm.embed(content);
+      if (embedResult.ok) {
+        embedding = JSON.stringify(embedResult.value);
+      } else {
+        this.logger?.warn('memory: embed failed on write, skipping embedding', {
+          code: embedResult.error.code,
+        });
+      }
+    }
+
     // 查现有
     const existing = await this.read(input.kind, input.chat_id, input.key);
     if (!existing.ok) return existing;
@@ -311,6 +429,7 @@ export class MemoryStore implements IMemoryStore {
           content,
           last_access: now,
           ...(raw !== undefined && { raw }),
+          ...(embedding !== undefined && { embedding }),
           ...(input.importance !== undefined && { importance: input.importance }),
         },
       });
@@ -320,6 +439,7 @@ export class MemoryStore implements IMemoryStore {
         content,
         last_access: now,
         ...(raw !== undefined && { raw }),
+        ...(embedding !== undefined && { embedding }),
         ...(input.importance !== undefined && { importance: input.importance }),
       });
     }
@@ -338,6 +458,7 @@ export class MemoryStore implements IMemoryStore {
     };
     if (input.user_id !== undefined) row.user_id = input.user_id;
     if (raw !== undefined) row.raw = raw;
+    if (embedding !== undefined) row.embedding = embedding;
 
     const insertResult = await this.bitable.insert({ table: MEMORY_TABLE, row });
     if (!insertResult.ok) return insertResult;
@@ -354,6 +475,7 @@ export class MemoryStore implements IMemoryStore {
       source_skill: input.source_skill,
       ...(input.user_id !== undefined && { user_id: input.user_id }),
       ...(raw !== undefined && { raw }),
+      ...(embedding !== undefined && { embedding }),
     };
 
     // 评分队列（仅未指定 importance 且 LLM 可用时）
@@ -618,6 +740,7 @@ export class MemoryStore implements IMemoryStore {
       key: String(row.key ?? ''),
       content: String(row.content ?? ''),
       ...(typeof row.raw === 'string' && row.raw ? { raw: row.raw } : {}),
+      ...(typeof row.embedding === 'string' && row.embedding ? { embedding: row.embedding } : {}),
       importance: typeof row.importance === 'number' ? row.importance : MEMORY_PENDING_SCORE,
       last_access: typeof row.last_access === 'number' ? row.last_access : 0,
       created_at: typeof row.created_at === 'number' ? row.created_at : 0,

--- a/packages/bot/src/scripts/smoke-harness.ts
+++ b/packages/bot/src/scripts/smoke-harness.ts
@@ -103,6 +103,7 @@ const llm: LLMClient = {
       rounds: 1,
     });
   },
+  embed: async () => ok([] as readonly number[]),
 };
 
 const logger = {

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -476,6 +476,7 @@ function withFallbackSystemPrompt(ctx: SkillContext, harness: HarnessConfig): Sk
         systemPrompt: opts?.systemPrompt ?? overview,
       }),
     chatWithTools: (messages, opts) => ctx.llm.chatWithTools(messages, opts),
+    embed: (text) => ctx.llm.embed(text),
   };
   return { ...ctx, llm };
 }

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -591,6 +591,8 @@ async function handlePassiveObserve(
     '你是一个静默的记忆观察者。读到的消息**不要回复用户**。\n' +
     '如果消息包含值得群组长期记住的事实（项目目标/用户群体/截止日期/分工/关键文档/重要决策），' +
     '调用 memory.write 写入；importance 只在很重要时（≥7）才指定。\n' +
+    'key 命名规范：用稳定的语义英文短语（snake_case），相同主题复用同一 key 实现覆盖更新，避免写重复条目。\n' +
+    '示例：截止日期 → "project_deadline"；分工 → "task_owner_<姓名拼音>"；项目目标 → "project_goal"。\n' +
     '若消息是闲聊/重复/没有事实信息，什么都不调，直接输出 SKIP。';
 
   const messages: ChatMessage[] = [

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -549,20 +549,19 @@ async function handleSchedule(
 // ─── 被动 memory 观察 ─────────────────────────────────────────────────────────
 //
 // 设计：非 @mention 的消息也可能含有值得长期记忆的事实（项目背景/PRD/分工/截止日期）。
-// 关键字门先粗筛，命中再调一个轻量 LLM（只暴露 memory.write 一个工具），不发任何回复。
+// 所有足够长的消息进 LLM Lite 判断；LLM 自主决定是否调 memory.write，不发任何回复。
 // 失败/超时静默 warn，不阻塞 SkillRouter 的主路径。
+//
+// 历史注：曾有关键字前置过滤（PASSIVE_MEMORY_KEYWORDS_RE）降低 LLM 调用量，
+// 但实测遗漏太多有价值消息（#109），故移除，改为长度门是唯一前置条件。
 
-const PASSIVE_MEMORY_KEYWORDS_RE =
-  /项目|需求|PRD|目标用户|背景|MVP|交付|deadline|截止|分工|负责|决定|确定|结论|文档/i;
-
-const PASSIVE_MIN_TEXT_LENGTH = 12;
+/** 消息至少要有这么多字符才值得进 LLM 判断（过滤"好""嗯""👍"等） */
+export const PASSIVE_MIN_TEXT_LENGTH = 12;
 
 const MEMORY_WRITE_TOOL_NAME = 'memory.write';
 
 export function shouldObservePassively(text: string): boolean {
-  // 太短的消息（"好的""嗯"）一律跳过
-  if (text.trim().length < PASSIVE_MIN_TEXT_LENGTH) return false;
-  return PASSIVE_MEMORY_KEYWORDS_RE.test(text);
+  return text.trim().length >= PASSIVE_MIN_TEXT_LENGTH;
 }
 
 async function handlePassiveObserve(

--- a/packages/contracts/src/bitable.ts
+++ b/packages/contracts/src/bitable.ts
@@ -40,6 +40,8 @@ export interface MemoryRecord {
   readonly user_id?: string;
   readonly key: string;
   readonly content: string;
+  /** 原始文字，写入前提炼时保留；未提炼时为 undefined */
+  readonly raw?: string;
   readonly importance: number;
   readonly last_access: number;
   readonly created_at: number;

--- a/packages/contracts/src/bitable.ts
+++ b/packages/contracts/src/bitable.ts
@@ -42,6 +42,8 @@ export interface MemoryRecord {
   readonly content: string;
   /** 原始文字，写入前提炼时保留；未提炼时为 undefined */
   readonly raw?: string;
+  /** Embedding 向量（JSON 序列化的 number[]），用于语义检索；未生成时为 undefined */
+  readonly embedding?: string;
   readonly importance: number;
   readonly last_access: number;
   readonly created_at: number;

--- a/packages/contracts/src/llm.ts
+++ b/packages/contracts/src/llm.ts
@@ -125,4 +125,11 @@ export interface LLMClient {
     messages: readonly ChatMessage[],
     opts: ChatWithToolsOptions,
   ): Promise<Result<ChatWithToolsResult>>;
+
+  /**
+   * 向量化单条文本（Embedding）。
+   * 返回浮点数组，维度由模型决定（Doubao text-embedding-3 为 2048 维）。
+   * 不支持 embedding 的实现应返回 CONFIG_MISSING err，调用方据此降级。
+   */
+  embed(text: string): Promise<Result<readonly number[]>>;
 }


### PR DESCRIPTION
## Summary                                                                    
  - 移除 PASSIVE_MEMORY_KEYWORDS_RE 关键字前置过滤，原因：漏掉大量有价值消息    
    （"小明你来写登录页"、"我们明天把功能做完吧" 等均无法命中旧关键字）         
  - shouldObservePassively 现在只做长度门（≥12 字符），LLM Lite 是唯一判断是否写
   memory 的门槛                                                                
  - 导出 PASSIVE_MIN_TEXT_LENGTH 常量，方便测试引用边界值       
                                                                                
  ## Test plan                                                                  
  - [ ] 长度达标但无关键字的普通对话消息 → 应被观察                             
  - [ ] 过短消息（"好的"、"👍"、"ok"）→ 跳过                                    
  - [ ] 纯空白 / trim 后不足长度 → 跳过                                         
  - 279 tests passed                            