### PR TITLE
feat(archive): 三态卡片 + 飞书归档报告 doc + decompose-then-verify

### DIFF
--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -449,11 +449,43 @@ const ARCHIVE_LINK_ICONS: Record<NonNullable<ArchiveLink['kind']>, string> = {
 };
 
 function buildArchive(input: ArchiveCardInput): Card {
+  // ── loading 态（issue #114）：先发出去拿 messageId，跑完用 patchCard 替换 ──
+  if (input.isLoading) {
+    const etaLine = input.etaSeconds
+      ? `预计耗时约 ${input.etaSeconds} 秒，请稍候。`
+      : '通常需要 30-60 秒，请稍候。';
+    return card('archive', {
+      schema: '2.0',
+      header: { title: pt('归档进行中…'), template: 'blue' },
+      body: {
+        elements: [
+          md(`📦 正在整理项目交付报告\n\n${etaLine}`),
+          md('_我会汇总需求文档 / PPT / 会议决策 / 任务完成情况，生成一份正式归档报告。完成后这条卡片会自动更新。_'),
+        ],
+      },
+    });
+  }
+
+  // ── error 态：归档过程挂了，patch 上失败提示 ──────────────────────────
+  if (input.errorMessage) {
+    return card('archive', {
+      schema: '2.0',
+      header: { title: pt('归档失败'), template: 'red' },
+      body: {
+        elements: [
+          md(`⚠️ ${input.errorMessage}`),
+          md('_可以稍后再试一次，或 @bot 单独询问需要归档的内容。_'),
+        ],
+      },
+    });
+  }
+
+  // ── final 态 ────────────────────────────────────────────────────────────
   const elements: BodyElement[] = [
     md(`**${input.title}**${input.summary ? `\n\n${input.summary}` : ''}`),
   ];
 
-  // 产出物链接列表（issue #104 核心）：每条 markdown 渲染图标 + label + 可点击链接
+  // 产出物链接列表：每条 markdown 渲染图标 + label + 可点击链接
   if (input.links && input.links.length > 0) {
     elements.push(hr());
     const linkLines = input.links.map((l) => {
@@ -475,8 +507,13 @@ function buildArchive(input: ArchiveCardInput): Card {
   const tagLine = input.tags.length ? input.tags.map((t) => `\`${t}\``).join(' ') : '—';
   elements.push(hr(), md(`🏷 标签：${tagLine}\n📌 归档编号：\`${input.recordId}\``));
 
-  // bitableUrl 缺省：不渲染坏按钮，给纯文本 fallback（issue #104 验收标准）
-  if (input.bitableUrl) {
+  // 主按钮优先级：reportDocUrl（issue #114 完整报告）> bitableUrl（issue #104 表格）
+  if (input.reportDocUrl) {
+    elements.push(btn('查看完整报告', { action: 'open_url', url: input.reportDocUrl }, 'primary'));
+    if (input.bitableUrl) {
+      elements.push(btn('查看归档表格', { action: 'open_url', url: input.bitableUrl }, 'default'));
+    }
+  } else if (input.bitableUrl) {
     elements.push(btn('查看归档表格', { action: 'open_url', url: input.bitableUrl }, 'primary'));
   } else {
     elements.push(md('_归档详情已写入 memory，可通过 @bot 查询_'));

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -140,6 +140,14 @@ export interface ArchiveCardInput {
   readonly taskStats?: string;
   /** 可选：决策数 */
   readonly decisionCount?: number;
+  /** 完整归档报告飞书 doc URL（issue #114）；有则渲染"查看完整报告"按钮 */
+  readonly reportDocUrl?: string;
+  /** loading 占位：先发出去拿 messageId，跑完后 patchCard 替换为终态 */
+  readonly isLoading?: boolean;
+  /** loading 时显示的预估时长（秒） */
+  readonly etaSeconds?: number;
+  /** error 终态：跑挂时把 loading 卡 patch 成失败提示 */
+  readonly errorMessage?: string;
 }
 
 // ── 附属链路 Input ────────────────────────────────────────────────────────────

--- a/packages/skills/src/__tests__/archive.test.ts
+++ b/packages/skills/src/__tests__/archive.test.ts
@@ -10,6 +10,13 @@ const mockCardBuilderBuild = vi
   .fn()
   .mockReturnValue({ templateName: 'archive', content: { built: true } });
 
+// issue #114 三阶段 pipeline 新引入的依赖
+const mockSendCard = vi.fn();
+const mockPatchCard = vi.fn();
+const mockFetchMembers = vi.fn();
+const mockDocxCreate = vi.fn();
+const mockDocxGrant = vi.fn();
+
 function makeMessage(text: string): Message {
   return {
     messageId: 'msg_1',
@@ -33,9 +40,10 @@ function makeCtx(event: BotEvent): SkillContext {
     event,
     runtime: {
       fetchHistory: vi.fn(),
+      fetchMembers: mockFetchMembers,
       sendText: vi.fn(),
-      sendCard: vi.fn(),
-      patchCard: vi.fn(),
+      sendCard: mockSendCard,
+      patchCard: mockPatchCard,
       on: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
@@ -49,7 +57,10 @@ function makeCtx(event: BotEvent): SkillContext {
       delete: vi.fn(),
       link: vi.fn(),
     },
-    docx: {} as SkillContext['docx'],
+    docx: {
+      createFromMarkdown: mockDocxCreate,
+      grantMembersEdit: mockDocxGrant,
+    },
     cardBuilder: { build: mockCardBuilderBuild },
     retrievers: {},
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -63,6 +74,21 @@ describe('archiveSkill', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockBitableInsert.mockResolvedValue(OK_INSERT);
+    // 默认 happy path：所有外部依赖都成功
+    mockSendCard.mockResolvedValue({
+      ok: true,
+      value: { messageId: 'card_msg_1', chatId: 'chat_1', timestamp: 0 },
+    });
+    mockPatchCard.mockResolvedValue({ ok: true, value: undefined });
+    mockFetchMembers.mockResolvedValue({
+      ok: true,
+      value: { members: [{ userId: 'u1', name: 'Alice' }] },
+    });
+    mockDocxCreate.mockResolvedValue({
+      ok: true,
+      value: { docToken: 'doc_tok_1', url: 'https://x.feishu.cn/docx/doc_tok_1' },
+    });
+    mockDocxGrant.mockResolvedValue({ ok: true, value: undefined });
   });
 
   it('match returns true when message contains 归档', () => {
@@ -131,10 +157,11 @@ describe('archiveSkill', () => {
       ok: true,
       value: {
         goal: '业务探索的小项目',
-        outcomes: ['PRD 已落地', 'PPT 已生成'],
+        // outcomes 必须 grounded —— issue #114 verify 会 drop 不在 source 里的条目
+        outcomes: ['业务探索文档已落地', '期末汇报材料已生成'],
         whatWorkedWell: ['前端表单一次过'],
         whatToImprove: ['UI 改稿次数偏多'],
-        openIssues: ['设计 UI 还在 pending'],
+        openIssues: ['设计 UI 已搞定'],
       },
     });
 
@@ -144,15 +171,16 @@ describe('archiveSkill', () => {
     expect(mockBitableFind).toHaveBeenCalledTimes(3);
 
     // 卡片必须有 links（issue #104 验收：至少 2 条）
-    const buildArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    // 第一个 build 是 loading 卡，最后一个是 final 卡（issue #114 三阶段）
+    const buildArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
     expect(buildArgs.links).toHaveLength(2);
     expect(buildArgs.links[0]).toMatchObject({ kind: 'requirementDoc', label: '需求文档' });
     expect(buildArgs.links[1]).toMatchObject({ kind: 'slides', label: '演示 PPT' });
     expect(buildArgs.taskStats).toBe('1/2 已完成');
     expect(buildArgs.decisionCount).toBe(1);
-    // summary 由模板渲染：必须含 goal + outcomes
+    // summary 由模板渲染：必须含 goal + grounded outcomes
     expect(buildArgs.summary).toContain('业务探索');
-    expect(buildArgs.summary).toContain('PRD 已落地');
+    expect(buildArgs.summary).toContain('期末汇报');
 
     // 写归档 memory（audit）
     expect(mockBitableInsert).toHaveBeenCalledWith(
@@ -190,8 +218,9 @@ describe('archiveSkill', () => {
     const result = await archiveSkill.run(makeCtx(makeEvent('收尾归档')));
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.card?.templateName).toBe('archive');
-    const buildArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    // issue #114：archive 不再返回 card（loading + patchCard 已直接发送）
+    expect(mockPatchCard).toHaveBeenCalled();
+    const buildArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
     expect(buildArgs.summary).toContain('已收尾');
   });
 
@@ -203,7 +232,8 @@ describe('archiveSkill', () => {
 
     expect(result.ok).toBe(true);
     expect(mockLLMAskStructured).not.toHaveBeenCalled(); // 完全没调 LLM
-    const buildArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    // 第一个 build 是 loading 卡，最后一个是 final 卡（issue #114 三阶段）
+    const buildArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
     expect(buildArgs.summary).toContain('已收尾');
   });
 
@@ -218,7 +248,8 @@ describe('archiveSkill', () => {
     const result = await archiveSkill.run(makeCtx(makeEvent('归档')));
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.card?.templateName).toBe('archive');
+    // patchCard 仍然完成（cardBuilder 至少被调过 2 次：loading + final）
+    expect(mockCardBuilderBuild.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('run: bitable.find partial failure — uses available data, still proceeds', async () => {
@@ -253,7 +284,8 @@ describe('archiveSkill', () => {
     const result = await archiveSkill.run(makeCtx(makeEvent('归档')));
 
     expect(result.ok).toBe(true);
-    const buildArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    // 第一个 build 是 loading 卡，最后一个是 final 卡（issue #114 三阶段）
+    const buildArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
     expect(buildArgs.links).toEqual([]);
   });
 
@@ -297,9 +329,131 @@ describe('archiveSkill', () => {
 
     await archiveSkill.run(makeCtx(makeEvent('归档')));
 
-    const buildArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    // 第一个 build 是 loading 卡，最后一个是 final 卡（issue #114 三阶段）
+    const buildArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
     expect(buildArgs.decisionCount).toBe(3); // 实际 decisions.length，不是 LLM 给的
     expect(buildArgs.taskStats).toBe('3/4 已完成'); // 3 done out of 4 todos
+  });
+
+  // ─── issue #114 新增：三阶段 pipeline + doc 生成 ──────────────────────
+
+  it('issue #114: sendCard loading first, then patchCard final with doc URL', async () => {
+    mockBitableFind.mockResolvedValue({
+      ok: true,
+      value: {
+        records: [
+          {
+            recordId: 'r1',
+            content: '[需求文档] 项目 PRD\nhttps://x.feishu.cn/docx/abc',
+            created_at: 1,
+          },
+          { recordId: 'r2', content: '记录 2' },
+          { recordId: 'r3', content: '记录 3' },
+        ],
+        hasMore: false,
+      },
+    });
+    mockLLMAskStructured.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        goal: 'test goal',
+        outcomes: ['outcome'],
+        whatWorkedWell: [],
+        whatToImprove: [],
+        openIssues: [],
+      },
+    });
+
+    await archiveSkill.run(makeCtx(makeEvent('项目结束了，归档一下')));
+
+    // 1. sendCard 一次（loading）
+    expect(mockSendCard).toHaveBeenCalledOnce();
+    const loadingArgs = mockCardBuilderBuild.mock.calls[0]![1];
+    expect(loadingArgs.isLoading).toBe(true);
+    expect(loadingArgs.etaSeconds).toBeGreaterThan(0);
+
+    // 2. docx.createFromMarkdown 被调（生成报告 doc）
+    expect(mockDocxCreate).toHaveBeenCalledOnce();
+    const [docTitle, docMarkdown] = mockDocxCreate.mock.calls[0]!;
+    expect(docTitle).toContain('项目交付报告');
+    expect(docMarkdown).toContain('## 摘要');
+    expect(docMarkdown).toContain('## 项目产出');
+
+    // 3. fetchMembers + grantMembersEdit 被调（给群成员授权）
+    expect(mockFetchMembers).toHaveBeenCalledOnce();
+    expect(mockDocxGrant).toHaveBeenCalledWith('doc_tok_1', 'docx', ['u1']);
+
+    // 4. patchCard 一次（final）
+    expect(mockPatchCard).toHaveBeenCalledOnce();
+    const finalArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
+    expect(finalArgs.isLoading).toBeUndefined();
+    expect(finalArgs.reportDocUrl).toBe('https://x.feishu.cn/docx/doc_tok_1');
+  });
+
+  it('issue #114: docx 创建失败 → final 卡 patch 时不带 reportDocUrl', async () => {
+    mockBitableFind.mockResolvedValue({
+      ok: true,
+      value: {
+        records: [{ content: 'a' }, { content: 'b' }, { content: 'c' }],
+        hasMore: false,
+      },
+    });
+    mockLLMAskStructured.mockResolvedValueOnce({
+      ok: true,
+      value: { goal: 'g', outcomes: [], whatWorkedWell: [], whatToImprove: [], openIssues: [] },
+    });
+    mockDocxCreate.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'FEISHU_API_ERROR', message: 'doc create failed' },
+    });
+
+    await archiveSkill.run(makeCtx(makeEvent('归档')));
+
+    expect(mockPatchCard).toHaveBeenCalledOnce(); // 仍然 patch final，不走 error
+    const finalArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
+    expect(finalArgs.reportDocUrl).toBeUndefined(); // 没 doc URL
+    expect(finalArgs.errorMessage).toBeUndefined(); // 也不是 error 态
+  });
+
+  it('issue #114 verify: outcomes 不在 source 里 → 被 drop', async () => {
+    mockBitableFind
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          records: [{ content: '校园打卡 App 项目，决定用高德 SDK' }],
+          hasMore: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { records: [{ content: '采用 高德 方案' }], hasMore: false },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { records: [{ content: '完成 定位 集成', status: 'done' }], hasMore: false },
+      });
+    // LLM 返回一个真实条目 + 一个完全不在 source 里的虚构条目
+    mockLLMAskStructured.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        goal: '校园打卡 App',
+        outcomes: [
+          '完成 高德 定位 集成', // ✓ 跟 source 大量重合
+          '完成了 OAuth 微信登录支付系统', // ✗ source 完全没提
+        ],
+        whatWorkedWell: [],
+        whatToImprove: [],
+        openIssues: [],
+      },
+    });
+
+    await archiveSkill.run(makeCtx(makeEvent('归档')));
+
+    const finalArgs = mockCardBuilderBuild.mock.calls.at(-1)![1];
+    // 模板渲染应该只包含 grounded 那条
+    expect(finalArgs.summary).toContain('高德');
+    expect(finalArgs.summary).not.toContain('OAuth');
+    expect(finalArgs.summary).not.toContain('微信');
   });
 });
 

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -1,19 +1,17 @@
 /**
- * archive — 项目交付归档（issue #104 复赛 MVP）
+ * archive — 项目交付归档（issue #104 / #114）
  *
  * 触发：群里出现 复盘 / 归档 / 项目结束 / 收尾 / 准备交付（被动监听，无需 @bot）
  *
- * 数据流：
- *   1. 并行拉 memory / decision / todo 三张表（chatId 过滤）
- *   2. 从 memory.content 提取本次产出物链接：[需求文档] / [slides] / [任务表] 前缀 + URL
- *   3. LLM 生成 100-200 字交付摘要
- *   4. 渲染 archive 卡：摘要 + 多链接列表 + 决策数 + 任务完成情况
- *   5. 写一条 kind=project 的归档 memory 作为审计
- *
- * 健壮性：
- *   - 任一 bitable.find 失败 → 用空数据继续（不阻断）
- *   - LLM 失败 → 降级摘要 "项目已收尾，详细产出请见上方链接"
- *   - 归档 memory 写入失败 → warn 不阻断卡片输出
+ * 数据流（issue #114 升级为 loading→doc→final 三阶段）：
+ *   1. sendCard loading 占位（让用户知道 bot 在工作）
+ *   2. 并行拉 memory / decision / todo 三张表
+ *   3. extractLinksFromMemory 收集产出物链接
+ *   4. askStructured + ArchiveSummarySchema → 5 字段摘要
+ *   5. verifyArchiveSummary（decompose-then-verify）过滤幻觉
+ *   6. renderArchiveDocMarkdown → 创建飞书归档 doc + 给群成员授权
+ *   7. patchCard 成 final 态：摘要 + 链接 + "查看完整报告"按钮
+ *   8. 任一中间失败 → patchCard 成 error 态，不阻塞
  */
 
 import {
@@ -32,7 +30,9 @@ import {
   ARCHIVE_SUMMARY_PROMPT,
   ArchiveSummarySchema,
   EMPTY_SUMMARY,
+  renderArchiveDocMarkdown,
   renderArchiveSummary,
+  verifyArchiveSummary,
 } from './prompts/archive.js';
 
 const TRIGGER_RE = /复盘|归档|项目结束|收尾|准备交付/i;
@@ -143,8 +143,28 @@ export const archiveSkill: Skill = {
       return err(makeError(ErrorCode.INVALID_INPUT, 'archive only handles message events'));
     }
     const { chatId } = ctx.event.payload;
-    // memory schema 用 chat_id（PR #96 修复后），但 decision/todo 仍是旧 chatId
-    // 这里 archive 三张表都查，filter 字段名按各自 schema 来。
+
+    // 0. loading 占位卡（issue #114）—— bot 收到指令立刻给反馈
+    const loadingCard = ctx.cardBuilder.build('archive', {
+      recordId: '',
+      title: '归档进行中',
+      bitableUrl: '',
+      tags: [],
+      isLoading: true,
+      etaSeconds: 30,
+    });
+    const loadingSent = await ctx.runtime.sendCard({ chatId, card: loadingCard });
+    if (!loadingSent.ok) return err(loadingSent.error);
+    const loadingMessageId = loadingSent.value.messageId;
+
+    // 设计：archive 全程降级路径，没有真正的"硬失败"需要 patch error 卡：
+    //   - bitable.find 失败 → 用空数据继续
+    //   - LLM 失败 → fallback summary
+    //   - doc 创建失败 → 卡片少一个按钮，仍然 patch final
+    //   - patch final 失败 → audit memory 仍然写入
+
+    // 1. 拉三张表（任一失败用空数据继续）
+    // memory schema 用 chat_id（PR #96 后），decision/todo 仍是旧 chatId
     const memoryFilter = `AND(CurrentValue.[chat_id]="${chatId}")`;
     const legacyFilter = `AND(CurrentValue.[chatId]="${chatId}")`;
 
@@ -174,12 +194,10 @@ export const archiveSkill: Skill = {
       taskCompletion: todos.length > 0 ? `${doneCount}/${todos.length}` : null,
     };
 
-    // 数据严重不足（< 3 条总记录）→ 跳过 LLM，走静态 fallback。
-    // 既省 token 又彻底防止 LLM 在空数据上幻觉编造。
+    // 2. LLM 摘要（< 3 条记录直接跳过，避免空数据幻觉）
     const totalRecords = memories.length + decisions.length + todos.length;
     let summary = EMPTY_SUMMARY;
     if (totalRecords >= 3) {
-      // askStructured + JSON schema 约束：豆包必须按 5 字段填，不能瞎扯
       const llmResult = await ctx.llm.askStructured(
         ARCHIVE_SUMMARY_PROMPT(memories, decisions, todos),
         ArchiveSummarySchema,
@@ -187,6 +205,14 @@ export const archiveSkill: Skill = {
       );
       if (llmResult.ok) {
         summary = llmResult.value;
+        // 3. decompose-then-verify：把 outcomes / openIssues 跟 source 做 grounding 校验
+        const verifyRes = verifyArchiveSummary(summary, memories, decisions, todos, ctx.logger);
+        summary = verifyRes.verified;
+        if (verifyRes.droppedCount > 0) {
+          ctx.logger.info('archive: verify dropped unverifiable claims', {
+            droppedCount: verifyRes.droppedCount,
+          });
+        }
       } else {
         ctx.logger.warn('archive: structured LLM failed, using fallback summary', {
           error: llmResult.error.message,
@@ -200,16 +226,56 @@ export const archiveSkill: Skill = {
       });
     }
 
-    // 渲染：structured object → 100-200 字自然语言（JS 模板，不过二次 LLM）
     const summaryText = renderArchiveSummary(summary, computed);
 
+    // 4. 创建飞书归档 doc（issue #114）
     const now = Date.now();
     const recordId = `archive_${chatId}_${now}`;
-    // BITABLE_ARCHIVE_URL 是个总入口（多维表格 dashboard 链接），缺省时卡片
-    // 自动降级为纯文本说明，不渲染坏按钮（issue #104 验收标准）
-    const bitableUrl = process.env['BITABLE_ARCHIVE_URL']?.trim() ?? '';
+    const docTitle = `项目交付报告 - ${new Intl.DateTimeFormat('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(now))}`;
+    const docMarkdown = renderArchiveDocMarkdown({
+      chatName: '本群',
+      summary,
+      summaryText,
+      links,
+      decisions,
+      todos,
+      generatedAt: now,
+    });
 
-    const card = ctx.cardBuilder.build('archive', {
+    let reportDocUrl: string | undefined;
+    let reportDocToken: string | undefined;
+    const docResult = await ctx.docx.createFromMarkdown(docTitle, docMarkdown);
+    if (!docResult.ok) {
+      ctx.logger.warn('archive: create feishu doc failed, fall back to card without doc', {
+        error: docResult.error.message,
+      });
+    } else {
+      reportDocUrl = docResult.value.url;
+      reportDocToken = docResult.value.docToken;
+
+      // 给群成员授 edit 权限（复用 slides / requirementDoc 的模式）
+      const membersRes = await ctx.runtime.fetchMembers({ chatId });
+      if (membersRes.ok && membersRes.value.members.length > 0) {
+        const memberIds = membersRes.value.members.map((m) => m.userId);
+        const grantRes = await ctx.docx.grantMembersEdit(reportDocToken, 'docx', memberIds);
+        if (!grantRes.ok) {
+          ctx.logger.warn('archive: grant members edit failed', {
+            code: grantRes.error.code,
+            message: grantRes.error.message,
+          });
+        } else {
+          ctx.logger.info('archive: granted members edit', { memberCount: memberIds.length });
+        }
+      }
+    }
+
+    // 5. patchCard 成 final 态
+    const bitableUrl = process.env['BITABLE_ARCHIVE_URL']?.trim() ?? '';
+    const finalCard = ctx.cardBuilder.build('archive', {
       recordId,
       title: '项目已交付',
       bitableUrl,
@@ -218,11 +284,24 @@ export const archiveSkill: Skill = {
       links,
       decisionCount: computed.decisionCount,
       ...(computed.taskCompletion ? { taskStats: `${computed.taskCompletion} 已完成` } : {}),
+      ...(reportDocUrl ? { reportDocUrl } : {}),
     });
+    const patchRes = await ctx.runtime.patchCard({
+      messageId: loadingMessageId,
+      card: finalCard,
+    });
+    if (!patchRes.ok) {
+      ctx.logger.warn('archive: patch final card failed', {
+        code: patchRes.error.code,
+        message: patchRes.error.message,
+      });
+      // patch 失败不阻塞 audit memory 写入；用户至少能在 memory 里看到归档
+    }
 
-    // 写归档 memory（audit + 后续 QA / recall 可检索）— 失败不阻断
+    // 6. 写归档 memory（含 doc URL）— 失败不阻断
     const auditContent = [
       `[archive] ${summaryText}`,
+      ...(reportDocUrl ? [`完整报告: ${reportDocUrl}`] : []),
       ...links.map((l) => `${l.label}: ${l.url}`),
     ].join('\n');
     const memInsert = await ctx.bitable.insert({
@@ -232,7 +311,7 @@ export const archiveSkill: Skill = {
         kind: 'project',
         chat_id: chatId,
         content: auditContent,
-        importance: 8, // 交付归档：高优先级
+        importance: 8,
         last_access: now,
         created_at: now,
         source_skill: 'archive',
@@ -241,9 +320,9 @@ export const archiveSkill: Skill = {
     if (!memInsert.ok)
       ctx.logger.warn('archive: insert audit memory failed', { error: memInsert.error.message });
 
+    // 不返回 card —— 上面已经 patchCard 完成。返回空 SkillResult 防止 wiring 重发
     return ok({
-      card,
-      reasoning: `归档 ${decisions.length} 条决策，${todos.length} 条任务（${doneCount} 完成），收集 ${links.length} 条产出物链接`,
+      reasoning: `归档 ${decisions.length} 条决策，${todos.length} 条任务（${doneCount} 完成），收集 ${links.length} 条产出物链接${reportDocUrl ? '，已生成报告 doc' : ''}`,
     });
   },
 };

--- a/packages/skills/src/prompts/archive.ts
+++ b/packages/skills/src/prompts/archive.ts
@@ -29,7 +29,7 @@
  *   - 2025 Hallucination Survey (frontiersin.org)
  */
 
-import type { BitableRow, SchemaLike } from '@seedhac/contracts';
+import type { ArchiveLink, BitableRow, SchemaLike } from '@seedhac/contracts';
 
 // ─── ArchiveSummary Schema（5 字段）─────────────────────────────────────────
 
@@ -290,3 +290,208 @@ export function renderArchiveSummary(
 }
 
 export { EMPTY_SUMMARY };
+
+// ─── 防幻觉 verify（issue #114 加固）──────────────────────────────────────────
+//
+// 基于 2025 主流 hallucination 论文的 "decompose-then-verify" 思路的轻量实现：
+//   1. 把每条 claim 切成 2-gram（中文）+ 长 ASCII token
+//   2. 用相同方法把 memory + decision + todo 三表 content 拼成 source corpus
+//   3. claim grams 在 source 里的覆盖率 < threshold → drop
+//
+// 不验证 goal / whatWorkedWell / whatToImprove —— 这些字段允许抽象表述
+// （如"前端表单一次过"），strict 验证会误删合法内容。重点防 outcomes
+// （最容易出"完成了 OAuth 系统"这种具体名词幻觉）和 openIssues（理论上
+// 应能匹配 pending todos）。
+
+const VERIFY_THRESHOLD = 0.25; // 25% gram 覆盖率（保留 75% 假阴性，避免误删）
+
+function tokenizeForVerify(text: string): Set<string> {
+  const grams = new Set<string>();
+  // 中文 2-gram
+  const chineseSegments = text.match(/[一-龥]+/g) ?? [];
+  for (const segment of chineseSegments) {
+    for (let i = 0; i < segment.length - 1; i++) {
+      grams.add(segment.slice(i, i + 2));
+    }
+  }
+  // ASCII 单词长度 ≥ 3（"PRD" / "OAuth" / "iOS" 等都进来）
+  const asciiTokens = text.match(/[a-zA-Z]{3,}/g) ?? [];
+  for (const t of asciiTokens) grams.add(t.toLowerCase());
+  return grams;
+}
+
+function isClaimGrounded(claim: string, sourceGrams: Set<string>): boolean {
+  const claimGrams = tokenizeForVerify(claim);
+  if (claimGrams.size === 0) return true; // 全标点 / 短数字 → 无法判别，放行
+  let hits = 0;
+  for (const g of claimGrams) if (sourceGrams.has(g)) hits++;
+  return hits / claimGrams.size >= VERIFY_THRESHOLD;
+}
+
+export interface VerifyLogger {
+  warn(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * 把 LLM 输出的 ArchiveSummary 跟原始 memory/decision/todo 做 grounding 校验。
+ * 只过滤 outcomes 和 openIssues 两个字段（最易出具体名词幻觉的）。
+ */
+export function verifyArchiveSummary(
+  summary: ArchiveSummary,
+  memories: readonly BitableRow[],
+  decisions: readonly BitableRow[],
+  todos: readonly BitableRow[],
+  logger?: VerifyLogger,
+): { verified: ArchiveSummary; droppedCount: number } {
+  const sourceText = [
+    ...memories.map((r) => String(r['content'] ?? '')),
+    ...decisions.map((r) => String(r['content'] ?? '')),
+    ...todos.map((r) => String(r['content'] ?? '')),
+  ].join('\n');
+  const sourceGrams = tokenizeForVerify(sourceText);
+
+  let droppedCount = 0;
+  const filterField = (items: readonly string[], fieldName: string): string[] => {
+    const kept: string[] = [];
+    const dropped: string[] = [];
+    for (const item of items) {
+      if (isClaimGrounded(item, sourceGrams)) kept.push(item);
+      else dropped.push(item);
+    }
+    if (dropped.length > 0) {
+      droppedCount += dropped.length;
+      logger?.warn(`archive verify: dropped ${dropped.length} unverifiable claims`, {
+        field: fieldName,
+        dropped,
+      });
+    }
+    return kept;
+  };
+
+  return {
+    verified: {
+      goal: summary.goal,
+      outcomes: filterField(summary.outcomes, 'outcomes'),
+      whatWorkedWell: summary.whatWorkedWell, // 抽象表述，不验证
+      whatToImprove: summary.whatToImprove, // 抽象表述，不验证
+      openIssues: filterField(summary.openIssues, 'openIssues'),
+    },
+    droppedCount,
+  };
+}
+
+// ─── 飞书 Doc 渲染（issue #114）───────────────────────────────────────────────
+
+const DOC_LINK_ICONS: Record<NonNullable<ArchiveLink['kind']>, string> = {
+  requirementDoc: '📋',
+  slides: '🎯',
+  taskAssignment: '✅',
+  bitable: '📊',
+  other: '📎',
+};
+
+/**
+ * 把结构化归档数据渲染成 markdown，供 docx.createFromMarkdown 创建飞书 doc。
+ *
+ * 6 段结构（基于 PMI / Atlassian / SRE 共识 + 评委友好性）：
+ *   1. 摘要（summary text，含项目目标）
+ *   2. 项目产出（链接列表）
+ *   3. 顺利之处
+ *   4. 待改进
+ *   5. 关键决策（来自 decision 表）
+ *   6. 任务完成情况（来自 todo 表）
+ *   7. 遗留问题（openIssues + pending todos）
+ */
+export function renderArchiveDocMarkdown(input: {
+  readonly chatName: string;
+  readonly summary: ArchiveSummary;
+  readonly summaryText: string;
+  readonly links: readonly ArchiveLink[];
+  readonly decisions: readonly BitableRow[];
+  readonly todos: readonly BitableRow[];
+  readonly generatedAt: number;
+}): string {
+  const { chatName, summary, summaryText, links, decisions, todos, generatedAt } = input;
+
+  const dateStr = new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(generatedAt));
+
+  const lines: string[] = [];
+  lines.push(`# 项目交付报告 - ${chatName} - ${dateStr}`, '');
+  lines.push(`> 由 Lark Loom 于 ${dateStr} 自动生成`, '');
+
+  // 1. 摘要
+  lines.push('## 摘要', '');
+  if (summary.goal) {
+    lines.push(`**项目目标**：${summary.goal}`, '');
+  }
+  lines.push(summaryText, '');
+
+  // 2. 项目产出
+  if (links.length > 0) {
+    lines.push('## 项目产出', '');
+    for (const l of links) {
+      const icon = DOC_LINK_ICONS[l.kind ?? 'other'] ?? '📎';
+      lines.push(`- ${icon} [${l.label}](${l.url})`);
+    }
+    lines.push('');
+  }
+
+  // 3. 顺利之处
+  if (summary.whatWorkedWell.length > 0) {
+    lines.push('## 顺利之处', '');
+    summary.whatWorkedWell.forEach((w) => lines.push(`- ${w}`));
+    lines.push('');
+  }
+
+  // 4. 待改进
+  if (summary.whatToImprove.length > 0) {
+    lines.push('## 待改进', '');
+    summary.whatToImprove.forEach((w) => lines.push(`- ${w}`));
+    lines.push('');
+  }
+
+  // 5. 关键决策（来自 decision 表）
+  if (decisions.length > 0) {
+    lines.push('## 关键决策', '');
+    decisions.slice(0, 20).forEach((d, i) => {
+      const content = String(d['content'] ?? '').trim();
+      if (content) lines.push(`${i + 1}. ${content}`);
+    });
+    lines.push('');
+  }
+
+  // 6. 任务完成情况（来自 todo 表）
+  if (todos.length > 0) {
+    const doneCount = todos.filter((t) => t['status'] === 'done').length;
+    lines.push('## 任务完成情况', '');
+    lines.push(`总计 ${todos.length} 项任务，已完成 ${doneCount} 项。`, '');
+    todos.slice(0, 30).forEach((t) => {
+      const status = String(t['status'] ?? 'unknown');
+      const content = String(t['content'] ?? '').trim();
+      const owner = t['owner'] ? String(t['owner']) : '';
+      const ddl = t['ddl'] ? `（${String(t['ddl'])}）` : '';
+      const statusIcon = status === 'done' ? '✅' : status === 'blocked' ? '🚫' : '⏳';
+      const ownerPart = owner ? ` — ${owner}` : '';
+      lines.push(`- ${statusIcon} ${content}${ownerPart}${ddl}`);
+    });
+    lines.push('');
+  }
+
+  // 7. 遗留问题（openIssues + 未完成 todos）
+  const pendingTodos = todos.filter((t) => t['status'] !== 'done').slice(0, 10);
+  if (summary.openIssues.length > 0 || pendingTodos.length > 0) {
+    lines.push('## 遗留问题', '');
+    summary.openIssues.forEach((o) => lines.push(`- ${o}`));
+    pendingTodos.forEach((t) => {
+      const content = String(t['content'] ?? '').trim();
+      if (content) lines.push(`- ${content}`);
+    });
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Closes #114

## Summary

archive 升级为生产级"项目交付报告"体验：

1. **Loading 卡** — bot 收到指令立刻反馈，跑完后 patchCard 替换为 final 态
2. **生成飞书归档 doc** — 6 段结构化报告，可分享给上级 / 评委
3. **decompose-then-verify 防幻觉加固** — 校验 LLM 输出的 outcomes / openIssues 是否能在原始数据 grounding，drop 不命中的虚构条目

## 亮点

### 三态卡片（同 requirementDoc / slides 风格）

| 态 | header | 触发 |
|---|---|---|
| loading | 蓝 \"归档进行中…\" | 收到指令立刻 sendCard |
| final | 靛 \"项目已归档 🎉\" | LLM + doc 都跑完 patchCard |
| error | 红 \"归档失败\" | 致命错误兜底（当前所有路径都已降级，error 态保留为安全网） |

### 飞书 doc 6 段结构

基于 PMI / Atlassian / Google SRE / GRAI 复盘法的字段交集：

1. 摘要 — goal + 100-200 字 LLM summary
2. 项目产出 — 链接列表（图标分类）
3. 顺利之处 — whatWorkedWell
4. 待改进 — whatToImprove
5. 关键决策 — decision 表 verbatim
6. 任务完成情况 — todo 表 verbatim（含状态图标）
7. 遗留问题 — openIssues + pending todos

doc 创建后给群成员授 edit 权限；URL 写进 \"查看完整报告\" 按钮 + audit memory。

### Decompose-then-verify

LLM 输出后对 outcomes / openIssues 字段做 grounding 校验：
- 切 2-gram 中文 + 长 ASCII token
- 在 source（memory + decision + todo content）corpus 查覆盖率
- 覆盖率 < 25% → drop（防止 LLM 编造 \"完成了 OAuth 微信登录系统\" 这种 source 里没有的具体名词）
- 不验证 goal / whatWorkedWell / whatToImprove（允许抽象表述）

## 整个 archive 的 LLM 触点

```
1. 拉 memory/decision/todo （无 LLM）
2. askStructured + ArchiveSummarySchema  ← 唯一 LLM 调用
   ├── schema enforce 5 字段
   ├── 3-shot 示例（A 齐全 / B 空 / C 部分）
   ├── 4 条 ICE 硬规则
   └── < 3 条记录跳过 LLM
3. verifyArchiveSummary  ← decompose-then-verify
4. renderArchiveSummary (JS 模板，无 LLM)
5. renderArchiveDocMarkdown (JS 模板，无 LLM)
6. docx.createFromMarkdown（只是格式转换）
```

## Test plan

- [x] 27 个 archive 单测全过，新增 3 个 issue #114 case：
  - sendCard loading + patchCard final + docx.create + grant 授权完整序列
  - docx 创建失败 → final 卡 patch 时不带 reportDocUrl，不走 error 态
  - verify 把 \"完成了 OAuth 微信登录\" 这种 source 里没有的虚构 outcome drop
- [x] 全本地：116 skills + 268 bot tests + 0 lint errors

## 引用

- Microsoft Azure ICE prompt framework
- 2025 Hallucination Survey (Frontiers) — decompose-then-verify
- Google SRE / Atlassian / PMI / GRAI 复盘法（doc 6 段结构来源）

🤖 Generated with [Claude Code](https://claude.com/claude-code)