### PR TITLE
fix(archive): 项目产出去重 + URL 路径推断 label（实战 bug）

### DIFF
--- a/packages/skills/src/__tests__/archive.test.ts
+++ b/packages/skills/src/__tests__/archive.test.ts
@@ -644,4 +644,76 @@ describe('extractLinksFromMemory', () => {
     })) as unknown as BitableRow[];
     expect(extractLinksFromMemory(memories).length).toBeLessThanOrEqual(6);
   });
+
+  // ─── 实战 bug 修复回归 case（复赛实测 PR #116 后发现的）─────────────────────
+
+  // bug：同一个 PPT URL 在 3 条 memory 里出现（slides 写一次 + 群里被动观察捕获 2 次）
+  // → 原版会列 3 条（1 演示 PPT + 2 相关文档），UX 灾难
+  it('dedupes same URL across multiple memory entries — keeps prefixed entry', () => {
+    const sharedPptUrl = 'https://example.feishu.cn/slides/abc123';
+    const memories: BitableRow[] = [
+      {
+        content: '今天看一下 PPT 在这 ' + sharedPptUrl,
+        created_at: 1,
+      } as unknown as BitableRow,
+      {
+        content: `[slides] 期末汇报\n${sharedPptUrl}`,
+        created_at: 2,
+      } as unknown as BitableRow,
+      {
+        content: '@bot 这个 PPT ' + sharedPptUrl + ' 帮我看一下',
+        created_at: 3,
+      } as unknown as BitableRow,
+    ];
+    const links = extractLinksFromMemory(memories);
+    // 同 URL 只能出现 1 次，且必须是有 [slides] 前缀的"演示 PPT"标签
+    expect(links).toHaveLength(1);
+    expect(links[0]!.kind).toBe('slides');
+    expect(links[0]!.label).toBe('演示 PPT');
+    expect(links[0]!.url).toBe(sharedPptUrl);
+  });
+
+  // bug：没前缀的 PPT 链接被标"相关文档"，让用户失去信任
+  // → 改进后按 URL 路径推断：/slides/ → 演示 PPT
+  it('infers label from URL path for non-prefixed entries', () => {
+    const memories: BitableRow[] = [
+      {
+        content: '群里贴的链接 https://x.feishu.cn/slides/abc',
+        created_at: 1,
+      } as unknown as BitableRow,
+      {
+        content: '另一个 https://x.feishu.cn/sheets/xyz',
+        created_at: 2,
+      } as unknown as BitableRow,
+      {
+        content: '文档 https://x.feishu.cn/docx/doc1',
+        created_at: 3,
+      } as unknown as BitableRow,
+    ];
+    const links = extractLinksFromMemory(memories);
+    // 注意：inferred 桶最多 2 条，所以 3 条里只有 2 条入选（按 recordedAt 倒序）
+    expect(links.length).toBeLessThanOrEqual(2);
+    // 最新两条：docx + sheets
+    expect(links.find((l) => l.url.includes('/docx/'))?.label).toBe('飞书文档');
+    expect(links.find((l) => l.url.includes('/sheets/'))?.label).toBe('飞书表格');
+    // slides 那条因为按 recordedAt 排序排在第三位被截掉，没有任何 link 是 "相关文档"
+    expect(links.every((l) => l.label !== '相关文档')).toBe(true);
+  });
+
+  // canonical URL：feishu 链接带不带 query 参数都视为同一个
+  it('canonicalizes URL — same path with different query strings treated as one', () => {
+    const memories: BitableRow[] = [
+      {
+        content: '[需求文档] PRD\nhttps://x.feishu.cn/docx/abc?from=share',
+        created_at: 1,
+      } as unknown as BitableRow,
+      {
+        content: '另一个版本 https://x.feishu.cn/docx/abc#section',
+        created_at: 2,
+      } as unknown as BitableRow,
+    ];
+    const links = extractLinksFromMemory(memories);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.kind).toBe('requirementDoc'); // 显式标注 win
+  });
 });

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -60,15 +60,58 @@ const PREFIX_TABLE: ReadonlyArray<{
   { re: /^\[(任务表|todo|分工)\]/i, kind: 'taskAssignment', label: '任务分工表' },
 ];
 
+const KIND_ORDER: Record<NonNullable<ArchiveLink['kind']>, number> = {
+  requirementDoc: 0,
+  slides: 1,
+  taskAssignment: 2,
+  bitable: 3,
+  other: 9,
+};
+
+/**
+ * 把 URL 规范化用作去重 key：去掉 query / fragment / 末尾斜杠，转小写。
+ * 飞书同一文档的多种链接形式（带 from 参数 / 不带）都能匹配。
+ */
+function canonicalizeUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname.replace(/\/$/, '')}`.toLowerCase();
+  } catch {
+    return url.toLowerCase().replace(/[?#].*$/, '').replace(/\/$/, '');
+  }
+}
+
+/**
+ * 没前缀的 memory 条目走这里：根据 URL 路径推断 kind / label。
+ * 这样"群聊里贴的 PPT 链接"也能被正确归类，不再统称"相关文档"。
+ */
+function inferFromUrl(url: string): { kind: NonNullable<ArchiveLink['kind']>; label: string } {
+  if (/\/slides\//i.test(url)) return { kind: 'slides', label: '演示 PPT' };
+  if (/\/(sheets|base)\//i.test(url)) return { kind: 'bitable', label: '飞书表格' };
+  if (/\/(docx|doc|wiki|file)\//i.test(url)) return { kind: 'other', label: '飞书文档' };
+  return { kind: 'other', label: '相关链接' };
+}
+
+interface CandidateLink extends ExtractedLink {
+  /** 是否来自 [前缀] 显式标注（vs 从 URL 路径推断） */
+  readonly fromPrefix: boolean;
+}
+
 /**
  * 从 memory records 提取产出物链接。
  *
- * 同 kind+label 组合取最新一条；总数上限 6 条避免卡片爆掉。
+ * 防重复策略（实测发现 3 个链接全是同一个 PPT URL 的 bug）：
+ *   1. 按规范化 URL 去重 —— 同 URL 只保留一条；同 URL 多个候选取 kind 高优先 +
+ *      显式标注优先 + recordedAt 最新
+ *   2. 显式标注（prefix 匹配的 named entry）：每个 (kind, label) 保留最新一条
+ *      — 避免出现"两次生成的 PRD 同时列出"
+ *   3. URL 推断（没前缀）：直接按 URL 路径推断 label，最多保留 2 条 — 避免群
+ *      聊里乱贴的链接刷屏卡片
+ *
+ * 总数上限 6 避免卡片爆掉。
  */
 export function extractLinksFromMemory(memories: readonly BitableRow[]): readonly ArchiveLink[] {
-  // 用 "kind|label" 作为去重 key，让"汇报分工文稿"和"任务分工表"能并存（都是 taskAssignment）
-  const byKey = new Map<string, ExtractedLink>();
-  const others: ExtractedLink[] = [];
+  const byUrl = new Map<string, CandidateLink>();
 
   for (const m of memories) {
     const content = String(m['content'] ?? '');
@@ -77,43 +120,58 @@ export function extractLinksFromMemory(memories: readonly BitableRow[]): readonl
 
     const urls = content.match(FEISHU_URL_RE);
     if (!urls || urls.length === 0) continue;
-    const url = urls[0]!;
+    const rawUrl = urls[0]!;
+    const canonUrl = canonicalizeUrl(rawUrl);
 
     const matched = PREFIX_TABLE.find((p) => p.re.test(content));
-    if (!matched) {
-      others.push({ kind: 'other', label: '相关文档', url, recordedAt });
+    const candidate: CandidateLink = matched
+      ? { kind: matched.kind, label: matched.label, url: rawUrl, recordedAt, fromPrefix: true }
+      : { ...inferFromUrl(rawUrl), url: rawUrl, recordedAt, fromPrefix: false };
+
+    const existing = byUrl.get(canonUrl);
+    if (!existing) {
+      byUrl.set(canonUrl, candidate);
       continue;
     }
 
-    const dedupeKey = `${matched.kind}|${matched.label}`;
-    const existing = byKey.get(dedupeKey);
-    if (!existing || existing.recordedAt < recordedAt) {
-      byKey.set(dedupeKey, { kind: matched.kind, label: matched.label, url, recordedAt });
-    }
+    // 同 URL 已存在 → 选更优的：显式标注 > kind 等级高 > recordedAt 新
+    const candBetter =
+      (candidate.fromPrefix && !existing.fromPrefix) ||
+      (candidate.fromPrefix === existing.fromPrefix &&
+        KIND_ORDER[candidate.kind ?? 'other'] < KIND_ORDER[existing.kind ?? 'other']) ||
+      (candidate.fromPrefix === existing.fromPrefix &&
+        candidate.kind === existing.kind &&
+        candidate.recordedAt > existing.recordedAt);
+    if (candBetter) byUrl.set(canonUrl, candidate);
   }
 
-  // 主分类排在前面，按 kind 优先级 + recordedAt 新→旧
-  const kindOrder: Record<NonNullable<ArchiveLink['kind']>, number> = {
-    requirementDoc: 0,
-    slides: 1,
-    taskAssignment: 2,
-    bitable: 3,
-    other: 9,
-  };
-  const ordered: ArchiveLink[] = [...byKey.values()]
-    .sort((a, b) => {
-      const ka = kindOrder[a.kind ?? 'other'];
-      const kb = kindOrder[b.kind ?? 'other'];
+  const candidates = [...byUrl.values()];
+
+  // 显式标注：每个 (kind, label) 保留 recordedAt 最新 —— 避免重复列出同类
+  const named = new Map<string, CandidateLink>();
+  for (const c of candidates.filter((c) => c.fromPrefix)) {
+    const k = `${c.kind}|${c.label}`;
+    const ex = named.get(k);
+    if (!ex || ex.recordedAt < c.recordedAt) named.set(k, c);
+  }
+  const namedList = [...named.values()];
+
+  // 推断的"其它"：最多 2 条，按 recordedAt 倒序
+  const inferredList = candidates
+    .filter((c) => !c.fromPrefix)
+    .sort((a, b) => b.recordedAt - a.recordedAt)
+    .slice(0, 2);
+
+  // 排序：先 named 按 kind 优先级，再 inferred 按 recordedAt
+  const ordered: ArchiveLink[] = [
+    ...namedList.sort((a, b) => {
+      const ka = KIND_ORDER[a.kind ?? 'other'];
+      const kb = KIND_ORDER[b.kind ?? 'other'];
       if (ka !== kb) return ka - kb;
       return b.recordedAt - a.recordedAt;
-    })
-    .map((l) => ({ kind: l.kind ?? ('other' as const), label: l.label, url: l.url }));
-
-  // others 补充最近 2 条
-  others
-    .sort((a, b) => b.recordedAt - a.recordedAt)
-    .slice(0, 2)
-    .forEach((l) => ordered.push({ kind: 'other' as const, label: l.label, url: l.url }));
+    }),
+    ...inferredList,
+  ].map((l) => ({ kind: l.kind ?? ('other' as const), label: l.label, url: l.url }));
 
   return ordered.slice(0, 6);
 }


### PR DESCRIPTION
## 实战 bug 报告

复赛实测发现 archive 卡片显示：
- 1× **演示 PPT** → https://x.feishu.cn/slides/abc
- 1× **相关文档** → https://x.feishu.cn/slides/abc（同上）
- 1× **相关文档** → https://x.feishu.cn/slides/abc（同上）

3 条全是**同一个 PPT URL**，标签还不一致 —— 用户对 bot 失去信任。

## 根因

- 同 URL 多次写入 memory：slides skill 写 [slides] 前缀一次 + 被动监听捕获群消息原文若干次（无前缀）
- 原版 \`extractLinksFromMemory\` 只按 \`(kind, label)\` 去重，**不按 URL 去重**
- "其它" 桶统称 "相关文档"，标签信息失真

## 修复

### 按 canonical URL 去重
\`canonicalizeUrl()\` 去 query / fragment / 末尾斜杠，转小写。同 URL 多候选时按优先级：
1. **显式标注（fromPrefix）** > 推断
2. **kind 等级**：requirementDoc > slides > taskAssignment > bitable > other
3. **recordedAt** 新 > 旧

### URL 路径推断 label
\`inferFromUrl()\` 不再统称"相关文档"：
- \`/slides/\` → 演示 PPT
- \`/sheets/\` \`/base/\` → 飞书表格
- \`/docx/\` \`/doc/\` \`/wiki/\` \`/file/\` → 飞书文档
- 其它 → 相关链接

### 区分 named vs inferred 桶
- **named** (有 [前缀])：每个 (kind, label) 保留最新 1 条 — 防同类重复
- **inferred** (推断)：最多 2 条，按 recordedAt 倒序 — 防群聊乱贴的链接刷屏

## Test plan

- [x] 同 PPT URL 在 3 条 memory 出现 → 仅 1 条（带 [slides] 那条）
- [x] /slides/, /sheets/, /docx/ URL 自动推断 label，不再 "相关文档"
- [x] canonical URL：?from=share / #section 被视为同 URL
- [x] 全本地：119 skills + 268 bot tests + 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)