### PR TITLE
feat(memory): decision.write 工具 — 决策写 Bitable decision 表 + 同步 memory （101）

### DIFF
--- a/packages/bot/src/__tests__/memory/tool-handlers.test.ts
+++ b/packages/bot/src/__tests__/memory/tool-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ok, err, makeError, ErrorCode } from '@seedhac/contracts';
-import type { Skill, ToolCall } from '@seedhac/contracts';
+import type { BitableClient, RecordRef, Skill, ToolCall } from '@seedhac/contracts';
 import { qaSkill } from '@seedhac/skills';
 import { getLLMTools, makeExecutor } from '../../memory/tool-handlers.js';
 import type { MemoryStore } from '../../memory/memory-store.js';
@@ -41,14 +41,14 @@ function makeCall(name: string, args: Record<string, unknown>): ToolCall {
 // ─── getLLMTools ──────────────────────────────────────────────────────────────
 
 describe('getLLMTools', () => {
-  it('returns 5 tools with required fields', () => {
-    // M6（PR #87 / #85）加了 memory.write，从 4 个增到 5 个
+  it('returns 6 tools with required fields', () => {
     const tools = getLLMTools();
-    expect(tools).toHaveLength(5);
+    expect(tools).toHaveLength(6);
     const names = tools.map((t) => t.name);
     expect(names).toContain('memory.read');
     expect(names).toContain('memory.search');
     expect(names).toContain('memory.write');
+    expect(names).toContain('decision.write');
     expect(names).toContain('skill.list');
     expect(names).toContain('skill.read');
     for (const t of tools) {
@@ -245,5 +245,109 @@ describe('executor logging', () => {
       'tool called',
       expect.objectContaining({ tool: 'skill.list', ms: expect.any(Number) }),
     );
+  });
+});
+
+// ─── decision.write ───────────────────────────────────────────────────────────
+
+function makeBitable(overrides: Partial<BitableClient> = {}): BitableClient {
+  const stubRef: RecordRef = { tableId: 'tbl_decision', recordId: 'rec_001' };
+  return {
+    find: vi.fn().mockResolvedValue(ok({ records: [], hasMore: false })),
+    insert: vi.fn().mockResolvedValue(ok(stubRef)),
+    batchInsert: vi.fn().mockResolvedValue(ok([])),
+    update: vi.fn().mockResolvedValue(ok(undefined)),
+    delete: vi.fn().mockResolvedValue(ok(undefined)),
+    link: vi.fn().mockResolvedValue(ok(undefined)),
+    readTable: vi.fn().mockResolvedValue(ok('')),
+    ...overrides,
+  } as unknown as BitableClient;
+}
+
+describe('decision.write', () => {
+  it('happy path: writes to bitable decision table and memory store', async () => {
+    const store = makeStore();
+    const bitable = makeBitable();
+    const exec = makeExecutor({
+      store,
+      bitable,
+      chatId: CHAT_ID,
+      logger: mockLogger,
+      docsRoot: DOCS_ROOT,
+      sourceSkill: 'passive_observe',
+    });
+
+    const toolResult = await exec(
+      makeCall('decision.write', { key: 'launch_date', content: '确认 6月1日上线' }),
+    );
+
+    const data = JSON.parse(toolResult.content) as { ok: boolean; memoryKey: string; bitableRecordId: string };
+    expect(data.ok).toBe(true);
+    expect(data.memoryKey).toBe('decision_launch_date');
+    expect(data.bitableRecordId).toBe('rec_001');
+
+    expect(bitable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'decision',
+        row: expect.objectContaining({ chat_id: CHAT_ID, key: 'launch_date', content: '确认 6月1日上线' }),
+      }),
+    );
+    expect(store.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'project', key: 'decision_launch_date', chat_id: CHAT_ID }),
+    );
+  });
+
+  it('key already prefixed with decision_: does not double-prefix', async () => {
+    const store = makeStore();
+    const bitable = makeBitable();
+    const exec = makeExecutor({ store, bitable, chatId: CHAT_ID, logger: mockLogger, docsRoot: DOCS_ROOT });
+
+    await exec(makeCall('decision.write', { key: 'decision_mvp_scope', content: '不做 PC 端' }));
+
+    expect(store.write).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'decision_mvp_scope' }),
+    );
+  });
+
+  it('bitable insert fails: logs warn but still writes memory, returns ok', async () => {
+    const store = makeStore();
+    const bitable = makeBitable({
+      insert: vi.fn().mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'bitable down'))),
+    });
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const exec = makeExecutor({ store, bitable, chatId: CHAT_ID, logger, docsRoot: DOCS_ROOT });
+
+    const toolResult = await exec(
+      makeCall('decision.write', { key: 'some_decision', content: '决定暂停迭代' }),
+    );
+
+    const data = JSON.parse(toolResult.content) as { ok: boolean };
+    expect(data.ok).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith('decision.write: bitable insert failed', expect.anything());
+    expect(store.write).toHaveBeenCalled();
+  });
+
+  it('missing key or content: returns error JSON', async () => {
+    const store = makeStore();
+    const exec = makeExecutor({ store, chatId: CHAT_ID, logger: mockLogger, docsRoot: DOCS_ROOT });
+
+    const toolResult = await exec(makeCall('decision.write', { content: '缺 key' }));
+
+    const data = JSON.parse(toolResult.content) as { error: string };
+    expect(data.error).toContain('required');
+  });
+
+  it('no bitable provided: skips bitable insert, still writes memory', async () => {
+    const store = makeStore();
+    const exec = makeExecutor({ store, chatId: CHAT_ID, logger: mockLogger, docsRoot: DOCS_ROOT });
+
+    const toolResult = await exec(
+      makeCall('decision.write', { key: 'fallback_decision', content: '没有 bitable 也能写记忆' }),
+    );
+
+    const data = JSON.parse(toolResult.content) as { ok: boolean; bitableRecordId?: string };
+    expect(data.ok).toBe(true);
+    expect(data.bitableRecordId).toBeUndefined();
+    expect(store.write).toHaveBeenCalled();
   });
 });

--- a/packages/bot/src/__tests__/memory/tool-handlers.test.ts
+++ b/packages/bot/src/__tests__/memory/tool-handlers.test.ts
@@ -289,7 +289,12 @@ describe('decision.write', () => {
     expect(bitable.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         table: 'decision',
-        row: expect.objectContaining({ chat_id: CHAT_ID, key: 'launch_date', content: '确认 6月1日上线' }),
+        row: expect.objectContaining({
+          chatId: CHAT_ID,
+          title: 'launch_date',
+          content: '确认 6月1日上线',
+          status: 'open',
+        }),
       }),
     );
     expect(store.write).toHaveBeenCalledWith(
@@ -309,7 +314,41 @@ describe('decision.write', () => {
     );
   });
 
-  it('bitable insert fails: logs warn but still writes memory, returns ok', async () => {
+  it('existing decision key: updates bitable row and still writes memory', async () => {
+    const store = makeStore();
+    const bitable = makeBitable({
+      find: vi.fn().mockResolvedValue(
+        ok({
+          records: [{ tableId: 'tbl_decision', recordId: 'rec_existing', chatId: CHAT_ID, title: 'launch_date' }],
+          hasMore: false,
+        }),
+      ),
+    });
+    const exec = makeExecutor({ store, bitable, chatId: CHAT_ID, logger: mockLogger, docsRoot: DOCS_ROOT });
+
+    const toolResult = await exec(
+      makeCall('decision.write', { key: 'launch_date', content: '确认延期到 6月8日' }),
+    );
+
+    const data = JSON.parse(toolResult.content) as { ok: boolean; bitableRecordId: string };
+    expect(data.ok).toBe(true);
+    expect(data.bitableRecordId).toBe('rec_existing');
+    expect(bitable.insert).not.toHaveBeenCalled();
+    expect(bitable.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'decision',
+        recordId: 'rec_existing',
+        patch: expect.objectContaining({
+          chatId: CHAT_ID,
+          title: 'launch_date',
+          content: '确认延期到 6月8日',
+        }),
+      }),
+    );
+    expect(store.write).toHaveBeenCalled();
+  });
+
+  it('bitable insert fails: returns error and does not write memory', async () => {
     const store = makeStore();
     const bitable = makeBitable({
       insert: vi.fn().mockResolvedValue(err(makeError(ErrorCode.FEISHU_API_ERROR, 'bitable down'))),
@@ -322,9 +361,9 @@ describe('decision.write', () => {
     );
 
     const data = JSON.parse(toolResult.content) as { ok: boolean };
-    expect(data.ok).toBe(true);
-    expect(logger.warn).toHaveBeenCalledWith('decision.write: bitable insert failed', expect.anything());
-    expect(store.write).toHaveBeenCalled();
+    expect(data).toEqual({ error: 'bitable down' });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(store.write).not.toHaveBeenCalled();
   });
 
   it('missing key or content: returns error JSON', async () => {
@@ -335,6 +374,21 @@ describe('decision.write', () => {
 
     const data = JSON.parse(toolResult.content) as { error: string };
     expect(data.error).toContain('required');
+  });
+
+  it('invalid key: returns error before writing bitable or memory', async () => {
+    const store = makeStore();
+    const bitable = makeBitable();
+    const exec = makeExecutor({ store, bitable, chatId: CHAT_ID, logger: mockLogger, docsRoot: DOCS_ROOT });
+
+    const toolResult = await exec(
+      makeCall('decision.write', { key: 'bad key with space', content: '确认不做 PC 端' }),
+    );
+
+    const data = JSON.parse(toolResult.content) as { error: string };
+    expect(data.error).toContain('key must only contain');
+    expect(bitable.insert).not.toHaveBeenCalled();
+    expect(store.write).not.toHaveBeenCalled();
   });
 
   it('no bitable provided: skips bitable insert, still writes memory', async () => {

--- a/packages/bot/src/memory/tool-handlers.ts
+++ b/packages/bot/src/memory/tool-handlers.ts
@@ -1,17 +1,19 @@
 /**
  * M3 — LLM 工具处理器
  *
- * 4 个供 chatWithTools 调用的工具：
- *   memory.read   按 (kind, key) 精确读取单条记忆
- *   memory.search 按 chat_id + 关键词模糊检索记忆
- *   skill.list    列出所有 Skill 名称与一句话描述
- *   skill.read    返回指定 Skill 的 docs/bot-memory/skills/<name>.md 全文
+ * 6 个供 chatWithTools 调用的工具：
+ *   memory.read    按 (kind, key) 精确读取单条记忆
+ *   memory.search  按 chat_id + 关键词模糊检索记忆
+ *   memory.write   写入一条记忆（事实/背景/分工/截止日期等）
+ *   decision.write 记录正式决策到 decision 表，并同步写入 memory（可被 memory.search 召回）
+ *   skill.list     列出所有 Skill 名称与一句话描述
+ *   skill.read     返回指定 Skill 的 docs/bot-memory/skills/<name>.md 全文
  */
 
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import type { LLMTool, Skill, ToolCall, ToolResult } from '@seedhac/contracts';
+import type { BitableClient, LLMTool, Skill, ToolCall, ToolResult } from '@seedhac/contracts';
 import type { MemoryKind } from '@seedhac/contracts';
 import { skills as defaultSkills } from '@seedhac/skills';
 
@@ -77,6 +79,32 @@ const TOOLS: readonly LLMTool[] = [
     },
   },
   {
+    name: 'decision.write',
+    description:
+      '把群内正式决策写入 decision 表并同步进记忆，使其可被后续 memory.search 召回。' +
+      '判断标准：消息中出现明确结论（"我们决定…""最终确认…""不做…""验收标准是…"），而非讨论或提议。',
+    parameters: {
+      type: 'object',
+      properties: {
+        key: {
+          type: 'string',
+          description: '幂等键（snake_case），相同决策复用同一 key 实现覆盖，例：decision_launch_date',
+        },
+        content: {
+          type: 'string',
+          description: '决策正文，简洁描述结论，不超过 500 字',
+        },
+        importance: {
+          type: 'number',
+          minimum: 1,
+          maximum: 10,
+          description: '可选，1-10 重要度；不传默认 8（决策通常重要）',
+        },
+      },
+      required: ['key', 'content'],
+    },
+  },
+  {
     name: 'skill.list',
     description: '列出所有已注册 Skill 的名称和一句话描述',
     parameters: { type: 'object', properties: {} },
@@ -110,6 +138,8 @@ export interface ToolLogger {
 
 export interface ExecutorDeps {
   readonly store: IMemoryStore;
+  /** decision.write 需要往 Bitable decision 表写行；不传时跳过 Bitable 写入仅写 memory */
+  readonly bitable?: BitableClient;
   /** 当前 runtime 实际启用的 Skill 集合；不传时使用默认全量注册表。 */
   readonly skills?: readonly Skill[];
   /** 当前群组 ID，memory.read 的隐式上下文 */
@@ -167,6 +197,8 @@ async function dispatch(
       return handleMemorySearch(args, deps);
     case 'memory.write':
       return handleMemoryWrite(args, deps);
+    case 'decision.write':
+      return handleDecisionWrite(args, deps);
     case 'skill.list':
       return handleSkillList(deps.skills ?? defaultSkills);
     case 'skill.read':
@@ -242,6 +274,65 @@ async function handleMemoryWrite(
     recordId: r.value.id,
     kind: r.value.kind,
     key: r.value.key,
+  });
+}
+
+async function handleDecisionWrite(
+  args: Record<string, unknown>,
+  deps: ExecutorDeps,
+): Promise<string> {
+  const key = String(args['key'] ?? '');
+  const content = String(args['content'] ?? '');
+  if (!key || !content) return JSON.stringify({ error: 'key and content are required' });
+
+  const importance =
+    typeof args['importance'] === 'number'
+      ? Math.min(Math.max(args['importance'], 1), 10)
+      : 8; // 决策默认重要度 8
+
+  const sourceSkill = deps.sourceSkill ?? 'harness';
+  const now = Date.now();
+
+  // 1. 写 Bitable decision 表（主存储），无 bitable 时静默跳过
+  let bitableRecordId: string | undefined;
+  if (deps.bitable) {
+    const insertResult = await deps.bitable.insert({
+      table: 'decision',
+      row: {
+        chat_id: deps.chatId,
+        key,
+        content,
+        importance,
+        source_skill: sourceSkill,
+        created_at: now,
+      },
+    });
+    if (!insertResult.ok) {
+      deps.logger.warn('decision.write: bitable insert failed', {
+        code: insertResult.error.code,
+        message: insertResult.error.message,
+      });
+    } else {
+      bitableRecordId = insertResult.value.recordId;
+    }
+  }
+
+  // 2. 同步写 memory store（使 memory.search 可召回决策）
+  const memKey = key.startsWith('decision_') ? key : `decision_${key}`;
+  const memResult = await deps.store.write({
+    kind: 'project',
+    chat_id: deps.chatId,
+    key: memKey,
+    content,
+    source_skill: sourceSkill,
+    importance,
+  });
+  if (!memResult.ok) return JSON.stringify({ error: memResult.error.message });
+
+  return JSON.stringify({
+    ok: true,
+    memoryKey: memKey,
+    ...(bitableRecordId !== undefined && { bitableRecordId }),
   });
 }
 

--- a/packages/bot/src/memory/tool-handlers.ts
+++ b/packages/bot/src/memory/tool-handlers.ts
@@ -241,6 +241,8 @@ async function handleMemorySearch(
 }
 
 const VALID_KINDS: ReadonlySet<MemoryKind> = new Set(['project', 'chat', 'user', 'skill_log']);
+const SAFE_DECISION_KEY_RE = /^[A-Za-z0-9_:.-]+$/;
+const MAX_DECISION_KEY_LENGTH = 120;
 
 async function handleMemoryWrite(
   args: Record<string, unknown>,
@@ -281,38 +283,59 @@ async function handleDecisionWrite(
   args: Record<string, unknown>,
   deps: ExecutorDeps,
 ): Promise<string> {
-  const key = String(args['key'] ?? '');
-  const content = String(args['content'] ?? '');
+  const key = String(args['key'] ?? '').trim();
+  const content = String(args['content'] ?? '').trim();
   if (!key || !content) return JSON.stringify({ error: 'key and content are required' });
+  if (key.length > MAX_DECISION_KEY_LENGTH || !SAFE_DECISION_KEY_RE.test(key)) {
+    return JSON.stringify({
+      error: 'key must only contain A-Za-z0-9_:.- and be at most 120 characters',
+    });
+  }
 
   const importance =
-    typeof args['importance'] === 'number'
+    typeof args['importance'] === 'number' && Number.isFinite(args['importance'])
       ? Math.min(Math.max(args['importance'], 1), 10)
       : 8; // 决策默认重要度 8
 
   const sourceSkill = deps.sourceSkill ?? 'harness';
   const now = Date.now();
 
-  // 1. 写 Bitable decision 表（主存储），无 bitable 时静默跳过
+  // 1. 写 Bitable decision 表（主存储），字段对齐现有 decision schema。
+  //    key 映射为 title，用 (chatId, title) 做幂等 upsert。
   let bitableRecordId: string | undefined;
   if (deps.bitable) {
-    const insertResult = await deps.bitable.insert({
+    const decisionRow = {
+      title: key,
+      chatId: deps.chatId,
+      archivedAt: now,
+      content,
+      deciders: sourceSkill,
+      status: 'open',
+    };
+    const existing = await deps.bitable.find({
       table: 'decision',
-      row: {
-        chat_id: deps.chatId,
-        key,
-        content,
-        importance,
-        source_skill: sourceSkill,
-        created_at: now,
-      },
+      where: { chatId: deps.chatId, title: key },
+      pageSize: 1,
     });
-    if (!insertResult.ok) {
-      deps.logger.warn('decision.write: bitable insert failed', {
-        code: insertResult.error.code,
-        message: insertResult.error.message,
+    if (!existing.ok) {
+      return JSON.stringify({ error: existing.error.message });
+    }
+
+    const existingRecord = existing.value.records[0];
+    if (existingRecord) {
+      const updateResult = await deps.bitable.update({
+        table: 'decision',
+        recordId: existingRecord.recordId,
+        patch: decisionRow,
       });
+      if (!updateResult.ok) return JSON.stringify({ error: updateResult.error.message });
+      bitableRecordId = existingRecord.recordId;
     } else {
+      const insertResult = await deps.bitable.insert({
+        table: 'decision',
+        row: decisionRow,
+      });
+      if (!insertResult.ok) return JSON.stringify({ error: insertResult.error.message });
       bitableRecordId = insertResult.value.recordId;
     }
   }

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -302,6 +302,7 @@ async function handleWithHarness(
   const systemPrompt = harness.promptCache.build({ chatId, mention: true });
   const executor = makeExecutor({
     store: harness.memoryStore,
+    bitable: ctx.bitable,
     skills: registeredSkillValues(skills),
     chatId,
     logger,
@@ -311,7 +312,8 @@ async function handleWithHarness(
   const skillChoices = [...registeredSkillNames(skills), 'silent'].join(' | ');
   const decisionInstruction =
     '可调用工具：skill.list / skill.read / memory.search 用于检索，' +
-    'memory.write 用于把消息中的可记忆事实（项目目标/用户群体/截止日期/分工/关键决策/文档链接）写入记忆。' +
+    'memory.write 用于把消息中的可记忆事实（项目目标/用户群体/截止日期/分工/文档链接）写入记忆，' +
+    'decision.write 用于记录明确决策（"我们决定…""最终确认…""不做…""验收标准是…"）。' +
     '工具调用完成后只输出 JSON：' +
     `{"skill":"<以下之一: ${skillChoices}>","reason":"一句话原因","args":{}}。` +
     `skill 字段必须是 ${skillChoices} 中的一个，不要输出其他值。` +
@@ -514,11 +516,12 @@ async function handleSchedule(
 // 失败/超时静默 warn，不阻塞 SkillRouter 的主路径。
 
 const PASSIVE_MEMORY_KEYWORDS_RE =
-  /项目|需求|PRD|目标用户|背景|MVP|交付|deadline|截止|分工|负责|决定|确定|结论|文档/i;
+  /项目|需求|PRD|目标用户|背景|MVP|交付|deadline|截止|分工|负责|决定|确定|结论|不做|验收标准|文档/i;
 
 const PASSIVE_MIN_TEXT_LENGTH = 12;
 
 const MEMORY_WRITE_TOOL_NAME = 'memory.write';
+const DECISION_WRITE_TOOL_NAME = 'decision.write';
 
 export function shouldObservePassively(text: string): boolean {
   // 太短的消息（"好的""嗯"）一律跳过
@@ -534,15 +537,18 @@ async function handlePassiveObserve(
   const { llm, logger } = ctx;
   const chatId = msg.chatId;
 
-  // 只暴露 memory.write，不暴露 search/read/skill.* — 避免模型走偏
-  const writeTool = getLLMTools().find((t) => t.name === MEMORY_WRITE_TOOL_NAME);
-  if (!writeTool) {
-    logger.warn('passive observe: memory.write tool missing', { chatId });
+  // 只暴露 memory.write + decision.write，不暴露 search/read/skill.* — 避免模型走偏
+  const allTools = getLLMTools();
+  const writeTool = allTools.find((t) => t.name === MEMORY_WRITE_TOOL_NAME);
+  const decisionTool = allTools.find((t) => t.name === DECISION_WRITE_TOOL_NAME);
+  if (!writeTool || !decisionTool) {
+    logger.warn('passive observe: required tools missing', { chatId });
     return;
   }
 
   const executor = makeExecutor({
     store: harness.memoryStore,
+    bitable: ctx.bitable,
     chatId,
     logger,
     docsRoot: harness.docsRoot,
@@ -551,8 +557,9 @@ async function handlePassiveObserve(
 
   const systemPrompt =
     '你是一个静默的记忆观察者。读到的消息**不要回复用户**。\n' +
-    '如果消息包含值得群组长期记住的事实（项目目标/用户群体/截止日期/分工/关键文档/重要决策），' +
-    '调用 memory.write 写入；importance 只在很重要时（≥7）才指定。\n' +
+    '如果消息包含值得群组长期记住的事实（项目目标/用户群体/截止日期/分工/关键文档），调用 memory.write 写入。\n' +
+    '如果消息包含明确决策（"我们决定…""最终确认…""不做…""验收标准是…"），调用 decision.write 记录。\n' +
+    'key 命名规范：snake_case 语义英文短语，相同主题复用同一 key。\n' +
     '若消息是闲聊/重复/没有事实信息，什么都不调，直接输出 SKIP。';
 
   const messages: ChatMessage[] = [
@@ -563,7 +570,7 @@ async function handlePassiveObserve(
   const result = await observeWithTimeout(
     llm,
     messages,
-    [writeTool],
+    [writeTool, decisionTool],
     executor,
     600_000, // 10 分钟：与主动路径对齐，避免 LLM 写记忆中途被切
   );


### PR DESCRIPTION
…closes #101）

- tool-handlers: 新增 decision.write 工具；ExecutorDeps 加 bitable? 字段；写 decision 表同时同步 memory.project 使其可被 search 召回
- wiring: PASSIVE_MEMORY_KEYWORDS_RE 补充「不做」「验收标准」；handlePassiveObserve 同时暴露 memory.write + decision.write；harness/passive executor 均透传 ctx.bitable
- tests: 5 个 decision.write 测试（happy path / key 前缀幂等 / bitable 失败降级 / 参数缺失 / 无 bitable 场景）