### PR TITLE
fix(lint): 加 no-control-regex 豁免（unblock main CI）

### DIFF
--- a/packages/skills/src/__tests__/clamp.test.ts
+++ b/packages/skills/src/__tests__/clamp.test.ts
@@ -67,6 +67,7 @@ describe('clampKeyPart()', () => {
   it('strips control characters', () => {
     const withCtrl = `name${String.fromCharCode(0x07)}_${String.fromCharCode(0x1f)}`;
     const out = clampKeyPart(withCtrl);
+    // eslint-disable-next-line no-control-regex -- intentionally testing control char stripping
     expect(out).not.toMatch(/[\x00-\x1f]/);
   });
 

--- a/packages/skills/src/__tests__/progress-update.test.ts
+++ b/packages/skills/src/__tests__/progress-update.test.ts
@@ -296,6 +296,7 @@ describe('progressUpdateSkill.run() — defensive length handling', () => {
     const row = insert.mock.calls[0]![0].row;
     expect(row.key).not.toContain('|');
     expect(row.key).not.toContain('\n');
+    // eslint-disable-next-line no-control-regex -- intentionally testing control char stripping
     expect(row.key).not.toMatch(/[\x00-\x1f]/);
   });
 });


### PR DESCRIPTION
PR #105 引入了 2 处控制字符 regex 测试（`clamp.test.ts` + `progress-update.test.ts`），`no-control-regex` 报 error，导致 main 上**所有后续 PR 的 CI 都挂**（PR #117 已经撞了）。

这俩 regex 是有意为之 —— 测的就是剥离控制字符的行为，regex 本身必须含控制字符。加 `eslint-disable-next-line` 豁免 + 注释说明意图。

## Test plan
- [x] `pnpm lint` 0 errors
- [x] `pnpm typecheck` 通过

unblock 性 fix，merge 越早越好（复赛今天）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)