### PR TITLE
feat(core-doc): 项目核心文档（living doc）— ADR + Confluence + Changelog 融合

### DIFF
--- a/packages/bot/src/docx-client.ts
+++ b/packages/bot/src/docx-client.ts
@@ -287,6 +287,98 @@ export class LarkDocxClient implements DocxClient {
 
     return ok(createRes.value);
   }
+
+  /**
+   * 在指定 H2 section 末尾追加 blocks（issue #120）。
+   *
+   * 飞书 docx 是 flat children 结构（H2 不会"包含"它后面的段落，是 sibling）。
+   * 实现思路：
+   *   1. 列出 doc 顶层 children
+   *   2. 找到 sectionTitle 对应的 heading2 block index
+   *   3. 找下一个 heading2 的 index（或 children 长度，如果是最后一段）
+   *   4. 调 documentBlockChildren.create 时传 index = nextH2Index
+   *      → 新 blocks 插入到下一个 H2 之前 = 当前 section 末尾
+   *
+   * 找不到 section → 退化为 appendBlocks（追加到文档末尾）+ warn level 不报错。
+   */
+  async appendToSection(
+    docToken: string,
+    sectionTitle: string,
+    blocks: readonly DocBlock[],
+  ): Promise<Result<void>> {
+    if (blocks.length === 0) return ok(undefined);
+
+    // 1. 列出 doc 顶层 children
+    let children: Array<{ block_id?: string; block_type?: number; heading2?: { elements?: Array<{ text_run?: { content?: string } }> } }> = [];
+    try {
+      const res = await (this.client.docx.v1.documentBlockChildren as any).list({
+        path: { document_id: docToken, block_id: docToken },
+        params: { page_size: 200 },
+      });
+      if (res.code !== 0) {
+        // 列表失败也别死，降级为整体 append
+        return this.appendBlocks(docToken, blocks);
+      }
+      children = res.data?.items ?? [];
+    } catch {
+      return this.appendBlocks(docToken, blocks);
+    }
+
+    // 2. 找 sectionTitle 对应的 H2 index
+    // block_type 4 = heading2
+    let sectionIdx = -1;
+    let nextH2Idx = children.length;
+    for (let i = 0; i < children.length; i++) {
+      const c = children[i]!;
+      if (c.block_type === 4) {
+        const txt = c.heading2?.elements?.[0]?.text_run?.content ?? '';
+        if (sectionIdx < 0 && txt === sectionTitle) {
+          sectionIdx = i;
+        } else if (sectionIdx >= 0) {
+          nextH2Idx = i;
+          break;
+        }
+      }
+    }
+
+    if (sectionIdx < 0) {
+      // 找不到 section，退化为整体 append
+      return this.appendBlocks(docToken, blocks);
+    }
+
+    // 3. 构造 children payload + 调 create with index
+    const safeBlocks = blocks.filter((b) => b.text && b.text.trim().length > 0);
+    if (safeBlocks.length === 0) return ok(undefined);
+
+    const childrenPayload = safeBlocks.map((block) => {
+      switch (block.type) {
+        case 'heading1':
+          return { block_type: 3, heading1: { elements: [{ text_run: { content: block.text } }] } };
+        case 'heading2':
+          return { block_type: 4, heading2: { elements: [{ text_run: { content: block.text } }] } };
+        case 'paragraph':
+          return { block_type: 2, text: { elements: [{ text_run: { content: block.text } }] } };
+        case 'bullet':
+          return { block_type: 12, bullet: { elements: [{ text_run: { content: block.text } }] } };
+      }
+    });
+
+    try {
+      const res = await (this.client.docx.v1.documentBlockChildren as any).create({
+        path: { document_id: docToken, block_id: docToken },
+        data: { children: childrenPayload, index: nextH2Idx },
+      });
+      if (res.code !== 0) {
+        return err(
+          makeError(ErrorCode.FEISHU_API_ERROR, `appendToSection failed: ${res.msg}`),
+        );
+      }
+      return ok(undefined);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return err(makeError(ErrorCode.FEISHU_API_ERROR, `appendToSection error: ${msg}`, e));
+    }
+  }
 }
 
 export function createDocxClient(): LarkDocxClient {

--- a/packages/bot/src/onboarding.ts
+++ b/packages/bot/src/onboarding.ts
@@ -1,9 +1,9 @@
 /**
- * Onboarding 流程（issue #98）
+ * Onboarding 流程（issue #98 + #120）
  *
  * 三个能力：
  *   1. handleBotJoinedChat：bot 加群事件 → 发 activation 卡（数据使用告知 + 启用按钮）
- *   2. handleOnboardingAction：cardAction 'activate' → patch 成"已启用"态 + 写 audit
+ *   2. handleOnboardingAction：cardAction 'activate' → patch + audit + **创建项目核心文档**（issue #120）
  *   3. handleOnboardingAction：cardAction 'dismiss' → patch 成"已忽略"态 + 写 audit
  *
  * 范围限定（issue #98 轻方案）：
@@ -12,7 +12,7 @@
  *   - 谁点都算群代表，不限定 inviter
  */
 
-import type { CardAction, SkillContext } from '@seedhac/contracts';
+import type { CardAction, DocBlock, SkillContext } from '@seedhac/contracts';
 
 /** bot 入群事件接收到时调用：在群里发出 activation 卡片。 */
 export async function handleBotJoinedChat(
@@ -40,12 +40,124 @@ export async function handleBotJoinedChat(
 }
 
 /**
+ * 项目核心文档的 5 段固定结构（issue #120）。
+ *
+ * 设计依据（业界 5 个主流 living doc 模式融合）：
+ *   - Atlassian Project Poster：顶部摘要 + 历史 + 约束
+ *   - ADR (Michael Nygard)：决策日志（append-only + Superseded 链）
+ *   - Keep a Changelog：里程碑 reverse chronological
+ *   - Confluence：阻塞与风险段
+ *
+ * Section 顺序很关键 —— skill 后续 appendToSection 时按 H2 标题精确匹配，
+ * 顺序保证完整时间线永远在最后（reverse chronological 拼接最容易）。
+ */
+export const CORE_DOC_SECTIONS = [
+  '项目摘要',
+  '决策日志',
+  '项目里程碑',
+  '阻塞与风险',
+  '完整时间线',
+] as const;
+
+export type CoreDocSection = (typeof CORE_DOC_SECTIONS)[number];
+
+/** 初始化的核心文档 markdown blocks —— 每个 section 一个空 placeholder paragraph。 */
+function buildCoreDocInitialBlocks(chatName: string, createdAtIso: string): DocBlock[] {
+  return [
+    { type: 'heading1', text: '项目核心文档' },
+    { type: 'paragraph', text: `${chatName} · 由 Lark Loom 自动维护 · 创建于 ${createdAtIso}` },
+    { type: 'heading2', text: '项目摘要' },
+    { type: 'paragraph', text: `项目：${chatName} · 状态：进行中 · 最后更新：${createdAtIso}` },
+    { type: 'heading2', text: '决策日志' },
+    { type: 'paragraph', text: '（暂无关键决策。当群里出现"决定 / 选用"时会自动记录。）' },
+    { type: 'heading2', text: '项目里程碑' },
+    { type: 'paragraph', text: '（PRD / 演示 PPT / 分工表生成后会自动追加。）' },
+    { type: 'heading2', text: '阻塞与风险' },
+    { type: 'paragraph', text: '（任务被标 blocked 或群里讨论风险时会自动记录。）' },
+    { type: 'heading2', text: '完整时间线' },
+    { type: 'paragraph', text: '（所有事件按发生时间正序排列。）' },
+  ];
+}
+
+/**
+ * 创建项目核心文档（issue #120 P1）—— activate 路径异步调用。
+ *
+ * 失败仅 warn 不阻塞 onboarding 流程：核心文档是 nice-to-have，
+ * 没它 archive 仍然能从 memory/decision/todo 工作。
+ */
+async function bootstrapProjectDoc(
+  ctx: SkillContext,
+  chatId: string,
+  chatName: string,
+): Promise<void> {
+  const { docx, runtime, bitable, logger } = ctx;
+  const now = Date.now();
+  const createdAtIso = new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(now));
+
+  const docTitle = `项目核心文档 - ${chatName}`;
+  const created = await docx.create(docTitle);
+  if (!created.ok) {
+    logger.warn('onboarding: create core doc failed', { error: created.error.message });
+    return;
+  }
+
+  const initBlocks = buildCoreDocInitialBlocks(chatName, createdAtIso);
+  const append = await docx.appendBlocks(created.value.docToken, initBlocks);
+  if (!append.ok) {
+    logger.warn('onboarding: append initial blocks failed', { error: append.error.message });
+    // 即便初始化失败，doc 已创建，URL 还是有用 —— 继续写 memory 指针
+  }
+
+  // 给群成员授 edit 权限（同 slides / requirementDoc 模式）
+  const members = await runtime.fetchMembers({ chatId });
+  if (members.ok && members.value.members.length > 0) {
+    const ids = members.value.members.map((m) => m.userId);
+    const grant = await docx.grantMembersEdit(created.value.docToken, 'docx', ids);
+    if (!grant.ok) {
+      logger.warn('onboarding: grant core doc edit failed', { error: grant.error.message });
+    }
+  }
+
+  // 写 memory 指针：[核心文档] 前缀让 archive / 后续 skill 能找到
+  const memInsert = await bitable.insert({
+    table: 'memory',
+    row: {
+      key: `core-doc-${chatId}-${now}`,
+      kind: 'project',
+      chat_id: chatId,
+      content: `[核心文档] ${docTitle}\n${created.value.url}`,
+      importance: 9, // 比 archive (8) 还高 —— 核心文档是项目执行的 single source of truth
+      last_access: now,
+      created_at: now,
+      source_skill: 'onboarding',
+    },
+  });
+  if (!memInsert.ok) {
+    logger.warn('onboarding: insert core doc memory failed', { error: memInsert.error.message });
+  }
+
+  logger.info('onboarding: core doc bootstrapped', {
+    chatId,
+    docToken: created.value.docToken,
+    url: created.value.url,
+  });
+}
+
+/**
  * activation 卡片按钮被点击时调用。
  * action: 'activate' | 'dismiss'
  *
  * 行为：
  *   - patch 卡片成对应终态（已启用 / 已忽略）
  *   - 写一条 memory 记录作为 audit trail
+ *   - activate 时额外创建项目核心文档（issue #120）
  */
 export async function handleOnboardingAction(
   ctx: SkillContext,
@@ -99,6 +211,16 @@ export async function handleOnboardingAction(
       chatId: payload.chatId,
       code: insertRes.error.code,
       message: insertRes.error.message,
+    });
+  }
+
+  // activate 路径：创建项目核心文档（issue #120 P1）
+  // fire-and-forget —— 即便 docx 调用慢或失败都不阻塞 onboarding 用户体验
+  if (action === 'activate') {
+    void bootstrapProjectDoc(ctx, payload.chatId, chatName).catch((e: unknown) => {
+      logger.warn('onboarding: bootstrapProjectDoc threw', {
+        error: e instanceof Error ? e.message : String(e),
+      });
     });
   }
 

--- a/packages/bot/src/scripts/smoke-harness.ts
+++ b/packages/bot/src/scripts/smoke-harness.ts
@@ -135,6 +135,7 @@ const ctx: SkillContext = {
     createFromMarkdown: async () => ok({ docToken: 'doc', url: 'https://example.test/doc' }),
     readContent: async () => ok(''),
     grantMembersEdit: async () => ok(undefined),
+    appendToSection: async () => ok(undefined),
   },
   cardBuilder: larkCardBuilder,
   retrievers: {},

--- a/packages/contracts/src/docx.ts
+++ b/packages/contracts/src/docx.ts
@@ -21,4 +21,15 @@ export interface DocxClient {
   readContent(token: string, kind?: 'doc' | 'wiki' | 'slides'): Promise<Result<string>>;
   /** 将指定用户加为 Drive 文件的编辑协作者 */
   grantMembersEdit(token: string, type: 'docx' | 'slides', userIds: readonly string[]): Promise<Result<void>>;
+  /**
+   * 在文档某个 H2 section 末尾追加 blocks（issue #120 项目核心文档）。
+   * 找到匹配 sectionTitle 的 heading2 block，把 blocks 插入到下一个 heading2
+   * 之前（即该 section 内容的末尾）。
+   * - 找不到 section → 退化为 appendBlocks（追加到文档末尾）+ warn
+   */
+  appendToSection(
+    docToken: string,
+    sectionTitle: string,
+    blocks: readonly DocBlock[],
+  ): Promise<Result<void>>;
 }

--- a/packages/skills/src/__tests__/core-doc.test.ts
+++ b/packages/skills/src/__tests__/core-doc.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ok } from '@seedhac/contracts';
+import {
+  appendBlocker,
+  appendDecision,
+  appendMilestone,
+  findCoreDocToken,
+  type CoreDocCtx,
+} from '../core-doc.js';
+
+const findMock = vi.fn();
+const insertMock = vi.fn();
+const appendToSectionMock = vi.fn();
+
+function makeCtx(): CoreDocCtx {
+  return {
+    bitable: {
+      find: findMock,
+      insert: insertMock,
+    } as unknown as CoreDocCtx['bitable'],
+    docx: {
+      appendToSection: appendToSectionMock,
+    } as unknown as CoreDocCtx['docx'],
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+}
+
+describe('findCoreDocToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appendToSectionMock.mockResolvedValue(ok(undefined));
+  });
+
+  it('returns docToken when memory has [核心文档] entry', async () => {
+    findMock.mockResolvedValueOnce(
+      ok({
+        records: [
+          {
+            content: '[核心文档] 项目核心文档 - 测试群\nhttps://x.feishu.cn/docx/abc123',
+            created_at: 100,
+          },
+        ],
+        hasMore: false,
+      }),
+    );
+    const token = await findCoreDocToken(makeCtx(), 'chat_1');
+    expect(token).toBe('abc123');
+  });
+
+  it('picks the latest entry when multiple exist', async () => {
+    findMock.mockResolvedValueOnce(
+      ok({
+        records: [
+          {
+            content: '[核心文档] old\nhttps://x.feishu.cn/docx/old123',
+            created_at: 100,
+          },
+          {
+            content: '[核心文档] new\nhttps://x.feishu.cn/docx/new123',
+            created_at: 200,
+          },
+        ],
+        hasMore: false,
+      }),
+    );
+    const token = await findCoreDocToken(makeCtx(), 'chat_1');
+    expect(token).toBe('new123');
+  });
+
+  it('returns null when no [核心文档] entry exists', async () => {
+    findMock.mockResolvedValueOnce(
+      ok({ records: [{ content: '[需求文档] foo\nhttps://x.feishu.cn/docx/r1' }], hasMore: false }),
+    );
+    const token = await findCoreDocToken(makeCtx(), 'chat_1');
+    expect(token).toBe(null);
+  });
+
+  it('returns null when bitable.find fails', async () => {
+    findMock.mockResolvedValueOnce({ ok: false, error: { code: 'X', message: 'fail' } });
+    const token = await findCoreDocToken(makeCtx(), 'chat_1');
+    expect(token).toBe(null);
+  });
+
+  it('returns null when content has no docx URL', async () => {
+    findMock.mockResolvedValueOnce(
+      ok({
+        records: [{ content: '[核心文档] no url here', created_at: 100 }],
+        hasMore: false,
+      }),
+    );
+    const token = await findCoreDocToken(makeCtx(), 'chat_1');
+    expect(token).toBe(null);
+  });
+});
+
+describe('appendDecision / appendMilestone / appendBlocker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findMock.mockResolvedValue(
+      ok({
+        records: [
+          {
+            content: '[核心文档] doc\nhttps://x.feishu.cn/docx/dt1',
+            created_at: 100,
+          },
+        ],
+        hasMore: false,
+      }),
+    );
+    appendToSectionMock.mockResolvedValue(ok(undefined));
+  });
+
+  it('appendDecision writes to 决策日志 + 完整时间线', async () => {
+    await appendDecision(makeCtx(), 'chat_1', { title: '选用高德 SDK' });
+    // 至少 2 次：决策日志 + 时间线
+    expect(appendToSectionMock).toHaveBeenCalledTimes(2);
+    const sections = appendToSectionMock.mock.calls.map((c) => c[1]);
+    expect(sections).toContain('决策日志');
+    expect(sections).toContain('完整时间线');
+  });
+
+  it('appendDecision includes [Supersedes Dxx] when supersedes set', async () => {
+    await appendDecision(makeCtx(), 'chat_1', {
+      title: '改用百度',
+      supersedes: 'D1',
+    });
+    const decisionCall = appendToSectionMock.mock.calls.find((c) => c[1] === '决策日志');
+    expect(decisionCall).toBeDefined();
+    const blockText = (decisionCall![2] as Array<{ text: string }>)[0]!.text;
+    expect(blockText).toContain('改用百度');
+    expect(blockText).toContain('Supersedes D1');
+  });
+
+  it('appendMilestone with url writes to 项目里程碑', async () => {
+    await appendMilestone(makeCtx(), 'chat_1', {
+      type: 'completion',
+      title: '演示 PPT 已生成',
+      url: 'https://x.feishu.cn/slides/abc',
+    });
+    const milestoneCall = appendToSectionMock.mock.calls.find((c) => c[1] === '项目里程碑');
+    expect(milestoneCall).toBeDefined();
+    const blockText = (milestoneCall![2] as Array<{ text: string }>)[0]!.text;
+    expect(blockText).toContain('演示 PPT');
+    expect(blockText).toContain('https://x.feishu.cn/slides/abc');
+  });
+
+  it('appendBlocker writes to 阻塞与风险 with [Open] tag', async () => {
+    await appendBlocker(makeCtx(), 'chat_1', { title: 'iOS 后台定位权限 pending' });
+    const blockerCall = appendToSectionMock.mock.calls.find((c) => c[1] === '阻塞与风险');
+    expect(blockerCall).toBeDefined();
+    const blockText = (blockerCall![2] as Array<{ text: string }>)[0]!.text;
+    expect(blockText).toContain('iOS 后台定位');
+    expect(blockText).toContain('[Open]');
+  });
+
+  it('skips silently when no core doc found (memory has no [核心文档] entry)', async () => {
+    findMock.mockResolvedValueOnce(ok({ records: [], hasMore: false }));
+    await appendDecision(makeCtx(), 'chat_1', { title: '选用高德' });
+    expect(appendToSectionMock).not.toHaveBeenCalled();
+  });
+
+  it('warns but does not throw when appendToSection fails', async () => {
+    appendToSectionMock.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'X', message: 'patch failed' },
+    });
+    await expect(
+      appendDecision(makeCtx(), 'chat_1', { title: '选用高德' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -40,6 +40,43 @@ const TRIGGER_RE = /复盘|归档|项目结束|收尾|准备交付/i;
 // 飞书域名 URL 提取（docs / wiki / lark / sheets / bitable）
 const FEISHU_URL_RE = /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/g;
 
+const CORE_DOC_PREFIX_RE = /^\[核心文档\]/;
+const CORE_DOC_TOKEN_RE = /\/docx\/([a-zA-Z0-9]+)/;
+const CORE_DOC_MAX_CHARS = 8000;
+
+/**
+ * 从 memory 找到项目核心文档（issue #120）并读取正文，作为 archive 的 Tier-1 输入。
+ * 失败 / 找不到都返回 undefined，archive 退化为只用 Tier-2（memory/decision/todo）。
+ */
+async function fetchCoreDocContent(
+  ctx: SkillContext,
+  memories: readonly BitableRow[],
+): Promise<string | undefined> {
+  // 找最新的 [核心文档] memory 条目
+  const candidates = memories
+    .filter((m) => CORE_DOC_PREFIX_RE.test(String(m['content'] ?? '')))
+    .sort((a, b) => Number(b['created_at'] ?? 0) - Number(a['created_at'] ?? 0));
+  if (candidates.length === 0) return undefined;
+
+  const content = String(candidates[0]!['content'] ?? '');
+  const tokenMatch = content.match(CORE_DOC_TOKEN_RE);
+  if (!tokenMatch) return undefined;
+  const docToken = tokenMatch[1]!;
+
+  const readRes = await ctx.docx.readContent(docToken, 'doc');
+  if (!readRes.ok) {
+    ctx.logger.warn('archive: read core doc failed, fall back to no Tier-1', {
+      error: readRes.error.message,
+    });
+    return undefined;
+  }
+  const text = readRes.value.trim();
+  if (!text) return undefined;
+  return text.length > CORE_DOC_MAX_CHARS
+    ? `${text.slice(0, CORE_DOC_MAX_CHARS)}\n…（已截断）`
+    : text;
+}
+
 interface ExtractedLink extends ArchiveLink {
   /** memory 写入时的 created_at，用于排序取最新 */
   readonly recordedAt: number;
@@ -252,12 +289,16 @@ export const archiveSkill: Skill = {
       taskCompletion: todos.length > 0 ? `${doneCount}/${todos.length}` : null,
     };
 
+    // 1.5. 找项目核心文档（issue #120）—— 把它当 Tier-1 喂给 LLM
+    //      失败 / 找不到 → coreDocContent = undefined，prompt 退化为单 Tier
+    const coreDocContent = await fetchCoreDocContent(ctx, memories);
+
     // 2. LLM 摘要（< 3 条记录直接跳过，避免空数据幻觉）
     const totalRecords = memories.length + decisions.length + todos.length;
     let summary = EMPTY_SUMMARY;
     if (totalRecords >= 3) {
       const llmResult = await ctx.llm.askStructured(
-        ARCHIVE_SUMMARY_PROMPT(memories, decisions, todos),
+        ARCHIVE_SUMMARY_PROMPT(memories, decisions, todos, coreDocContent),
         ArchiveSummarySchema,
         { model: 'pro', timeoutMs: 60_000 },
       );

--- a/packages/skills/src/core-doc.ts
+++ b/packages/skills/src/core-doc.ts
@@ -1,0 +1,180 @@
+/**
+ * 项目核心文档 helper（issue #120）
+ *
+ * 设计原则：
+ *   1. **Append-only** —— 永远不修改已有 entry，决策推翻就 append [Supersedes Dxx]
+ *   2. **Per-entry 模板拼接** —— 不过 LLM，所有 entry 字段从 skill 已有数据直接来
+ *      （decision 表 content / 完成产出 URL / pending todo 内容），杜绝额外幻觉源
+ *   3. **失败仅 warn** —— 找不到核心文档 / appendToSection 失败都不阻塞 skill 主流程
+ *
+ * Section 映射：
+ *   - 决策 → "决策日志"
+ *   - 里程碑 → "项目里程碑"
+ *   - 阻塞 → "阻塞与风险"
+ *   - 同步：每条 entry 同时往"完整时间线"末尾 append 一行
+ */
+
+import type { BitableClient, DocBlock, DocxClient } from '@seedhac/contracts';
+
+export interface CoreDocCtx {
+  readonly bitable: BitableClient;
+  readonly docx: DocxClient;
+  readonly logger: { warn(msg: string, meta?: Record<string, unknown>): void; info(msg: string, meta?: Record<string, unknown>): void };
+}
+
+export interface DecisionEntry {
+  readonly title: string;
+  readonly source?: string;
+  readonly supersedes?: string;
+}
+
+export interface MilestoneEntry {
+  readonly type: 'requirement' | 'completion';
+  readonly title: string;
+  readonly url?: string;
+  readonly source?: string;
+}
+
+export interface BlockerEntry {
+  readonly title: string;
+  readonly source?: string;
+}
+
+const FEISHU_URL_RE = /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/;
+
+/**
+ * 从 memory 找到当前 chatId 的核心文档 docToken。找不到返回 null。
+ */
+export async function findCoreDocToken(
+  ctx: CoreDocCtx,
+  chatId: string,
+): Promise<string | null> {
+  const filter = `AND(CurrentValue.[chat_id]="${chatId}")`;
+  const res = await ctx.bitable.find({ table: 'memory', filter, pageSize: 50 });
+  if (!res.ok) {
+    ctx.logger.warn('core-doc: memory.find failed', { error: res.error.message });
+    return null;
+  }
+  // 找最新的 [核心文档] 前缀条目（按 created_at 倒序）
+  const candidates = res.value.records
+    .filter((r) => /^\[核心文档\]/.test(String(r['content'] ?? '')))
+    .sort(
+      (a, b) => Number(b['created_at'] ?? 0) - Number(a['created_at'] ?? 0),
+    );
+  if (candidates.length === 0) return null;
+  const content = String(candidates[0]!['content'] ?? '');
+  const url = content.match(FEISHU_URL_RE)?.[0];
+  if (!url) return null;
+  // url: https://feishu.cn/docx/{token}
+  const tokenMatch = url.match(/\/docx\/([a-zA-Z0-9]+)/);
+  return tokenMatch ? tokenMatch[1]! : null;
+}
+
+function formatTime(now: number): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(now));
+}
+
+/**
+ * 同时往 "完整时间线" 段 append 一行 timeline entry。
+ * 失败仅 warn —— 时间线是辅助视图，主 section 已经记了。
+ */
+async function appendTimeline(
+  ctx: CoreDocCtx,
+  docToken: string,
+  type: '决策' | '完成' | '需求' | '阻塞',
+  title: string,
+  now: number,
+): Promise<void> {
+  const block: DocBlock = {
+    type: 'bullet',
+    text: `${formatTime(now)} [${type}] ${title}`,
+  };
+  const res = await ctx.docx.appendToSection(docToken, '完整时间线', [block]);
+  if (!res.ok) {
+    ctx.logger.warn('core-doc: appendTimeline failed', { error: res.error.message });
+  }
+}
+
+/** 决策 → "决策日志" + 时间线。失败仅 warn。 */
+export async function appendDecision(
+  ctx: CoreDocCtx,
+  chatId: string,
+  entry: DecisionEntry,
+): Promise<void> {
+  const docToken = await findCoreDocToken(ctx, chatId);
+  if (!docToken) {
+    ctx.logger.info('core-doc: no core doc found, skip appendDecision', { chatId });
+    return;
+  }
+  const now = Date.now();
+  const supersedesPart = entry.supersedes ? ` [Supersedes ${entry.supersedes}]` : '';
+  const sourcePart = entry.source ? ` · 来源：${entry.source}` : '';
+  const line: DocBlock = {
+    type: 'bullet',
+    text: `${formatTime(now)} — ${entry.title}${supersedesPart}${sourcePart}`,
+  };
+  const res = await ctx.docx.appendToSection(docToken, '决策日志', [line]);
+  if (!res.ok) {
+    ctx.logger.warn('core-doc: appendDecision failed', { error: res.error.message });
+    return;
+  }
+  await appendTimeline(ctx, docToken, '决策', entry.title, now);
+}
+
+/** 里程碑 → "项目里程碑" + 时间线。type 区分 [需求]/[完成]。 */
+export async function appendMilestone(
+  ctx: CoreDocCtx,
+  chatId: string,
+  entry: MilestoneEntry,
+): Promise<void> {
+  const docToken = await findCoreDocToken(ctx, chatId);
+  if (!docToken) {
+    ctx.logger.info('core-doc: no core doc found, skip appendMilestone', { chatId });
+    return;
+  }
+  const now = Date.now();
+  const urlPart = entry.url ? `: ${entry.url}` : '';
+  const sourcePart = entry.source ? ` · 来源：${entry.source}` : '';
+  const line: DocBlock = {
+    type: 'bullet',
+    text: `${formatTime(now)} — ${entry.title}${urlPart}${sourcePart}`,
+  };
+  const res = await ctx.docx.appendToSection(docToken, '项目里程碑', [line]);
+  if (!res.ok) {
+    ctx.logger.warn('core-doc: appendMilestone failed', { error: res.error.message });
+    return;
+  }
+  const tlType = entry.type === 'requirement' ? '需求' : '完成';
+  await appendTimeline(ctx, docToken, tlType, entry.title, now);
+}
+
+/** 阻塞 → "阻塞与风险" + 时间线。 */
+export async function appendBlocker(
+  ctx: CoreDocCtx,
+  chatId: string,
+  entry: BlockerEntry,
+): Promise<void> {
+  const docToken = await findCoreDocToken(ctx, chatId);
+  if (!docToken) {
+    ctx.logger.info('core-doc: no core doc found, skip appendBlocker', { chatId });
+    return;
+  }
+  const now = Date.now();
+  const sourcePart = entry.source ? ` · 来源：${entry.source}` : '';
+  const line: DocBlock = {
+    type: 'bullet',
+    text: `${formatTime(now)} — ${entry.title} [Open]${sourcePart}`,
+  };
+  const res = await ctx.docx.appendToSection(docToken, '阻塞与风险', [line]);
+  if (!res.ok) {
+    ctx.logger.warn('core-doc: appendBlocker failed', { error: res.error.message });
+    return;
+  }
+  await appendTimeline(ctx, docToken, '阻塞', entry.title, now);
+}

--- a/packages/skills/src/prompts/archive.ts
+++ b/packages/skills/src/prompts/archive.ts
@@ -204,10 +204,31 @@ function summarizeBitableRow(r: BitableRow, maxLen = 80): string {
   return `${trimmed}${status}`.trim();
 }
 
+const TIER_RULE = `
+# 输入分层（重要）
+
+输入分两层，优先级 Tier-1 > Tier-2：
+
+- **Tier-1：项目核心文档**（如果提供）—— 项目执行轨迹的 single source of truth，
+  从启用 bot 起每个里程碑/决策/阻塞都自动 append。**goal / outcomes / whatToImprove
+  应优先从这里提取**。如果 Tier-1 已经写了某条，**Tier-2 里同样事情不要重复列**。
+- **Tier-2：补充事实**（memory/decision/todo 表）—— 用来填 Tier-1 没覆盖到的角落。
+
+如果两层都为空 / 数据不足，按 SYSTEM_RULES 数据严重不足条款处理。
+`.trim();
+
+const PRD_DOC_MAX_CHARS = 8000;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}\n…（已截断 ${s.length - max} 字）`;
+}
+
 export function ARCHIVE_SUMMARY_PROMPT(
   memories: readonly BitableRow[],
   decisions: readonly BitableRow[],
   todos: readonly BitableRow[],
+  coreDocContent?: string,
 ): string {
   const memoryLines = memories.length
     ? memories.map((m) => `- ${summarizeBitableRow(m)}`).join('\n')
@@ -219,8 +240,19 @@ export function ARCHIVE_SUMMARY_PROMPT(
     ? todos.map((t) => `- ${summarizeBitableRow(t)}`).join('\n')
     : '（空）';
 
+  const tier1Section = coreDocContent
+    ? [
+        '## Tier-1：项目核心文档（最高优先级，请优先提取）',
+        '',
+        truncate(coreDocContent, PRD_DOC_MAX_CHARS),
+        '',
+      ]
+    : [];
+
   return [
     SYSTEM_RULES,
+    '',
+    TIER_RULE,
     '',
     '# 三个 Few-Shot 示例',
     '',
@@ -228,7 +260,8 @@ export function ARCHIVE_SUMMARY_PROMPT(
     '',
     '# 现在轮到你处理',
     '',
-    '## 输入数据',
+    ...tier1Section,
+    `## Tier-2：补充事实（memory/decision/todo 三表）`,
     '',
     `### memory（${memories.length} 条）`,
     memoryLines,

--- a/packages/skills/src/requirement-doc.ts
+++ b/packages/skills/src/requirement-doc.ts
@@ -17,6 +17,7 @@
 
 import type { Message, Skill, SkillContext } from '@seedhac/contracts';
 import { err, ok } from '@seedhac/contracts';
+import { appendMilestone } from './core-doc.js';
 import {
   REQ_PROMPT,
   RELEVANCE_PROMPT,
@@ -372,6 +373,19 @@ export const requirementDocSkill: Skill = {
         message: memRes.error.message,
       });
     }
+
+    // e2. 追加到项目核心文档 "项目里程碑" + "完整时间线"（issue #120）
+    //     失败仅 warn，不阻塞卡片输出
+    void appendMilestone(ctx, chatId, {
+      type: 'requirement',
+      title: `${doc.title} 已落地`,
+      url: fileResult.value.url,
+      source: msg.messageId,
+    }).catch((e: unknown) => {
+      ctx.logger.warn('requirementDoc: core-doc append milestone threw', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
 
     // f. patch loading 卡片为最终 docPush 卡片
     const finalCard = ctx.cardBuilder.build('docPush', {

--- a/packages/skills/src/slides.ts
+++ b/packages/skills/src/slides.ts
@@ -8,6 +8,7 @@
 import type { ChatMember, Message, Skill } from '@seedhac/contracts';
 import type { SlideDraft } from '@seedhac/contracts';
 import { ErrorCode, err, makeError, ok } from '@seedhac/contracts';
+import { appendMilestone } from './core-doc.js';
 import { OutlineSchema, SLIDES_PROMPT } from './prompts/slides.js';
 
 /** chatId 正在生成中的锁，防止同一群短时间内重复触发 */
@@ -294,6 +295,25 @@ async function runSlides(ctx: Parameters<Skill['run']>[0], msg: Message): Return
         error: e instanceof Error ? e.message : String(e),
       });
     });
+
+  // 追加到项目核心文档 "项目里程碑" + "完整时间线"（issue #120）
+  // 两条产出：演示 PPT + 汇报分工文稿。fire-and-forget。
+  void Promise.all([
+    appendMilestone(ctx, chatId, {
+      type: 'completion',
+      title: `演示 PPT 已生成（${outline.title}）`,
+      url: slidesResult.value.url,
+    }),
+    appendMilestone(ctx, chatId, {
+      type: 'completion',
+      title: `汇报分工文稿已生成`,
+      url: assignmentDocResult.value.url,
+    }),
+  ]).catch((e: unknown) => {
+    ctx.logger.warn('slides: core-doc append milestone threw', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  });
 
   return ok({
     card: assignmentCard,

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -36,6 +36,7 @@ import {
   RelevanceJudgmentSchema,
   type RelevanceCandidate,
 } from './prompts/requirement-doc.js';
+import { appendBlocker, appendDecision } from './core-doc.js';
 
 const TRIGGER_RE = /会议纪要|妙记|会议总结|本次会议/i;
 
@@ -365,6 +366,22 @@ export const summarySkill: Skill = {
       },
     });
     if (!memRes.ok) ctx.logger.warn('summary: insert memory failed', { error: memRes.error });
+
+    // 追加到项目核心文档（issue #120）：每个 decision 一条 ADR-style entry，
+    // 每个 issue（待澄清/风险）一条 blocker。fire-and-forget，失败仅 warn。
+    const sourceId = msg.messageId;
+    void Promise.all([
+      ...summary.decisions.map((d) =>
+        appendDecision(ctx, chatId, { title: d, source: sourceId }),
+      ),
+      ...summary.issues.map((i) =>
+        appendBlocker(ctx, chatId, { title: i, source: sourceId }),
+      ),
+    ]).catch((e: unknown) => {
+      ctx.logger.warn('summary: core-doc append threw', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
 
     // 不再返回 card：已通过 patchCard 替换 loading 卡，wiring 不需要再发一条
     return ok({


### PR DESCRIPTION
Closes #120

## Summary

实现"项目核心文档"功能 —— 一份持续迭代的 living doc，记录项目从 onboarding 到归档的全部演进。

完整链路：
1. **P1**: onboarding activate → 自动创建空 doc（5 段固定 H2）
2. **P2**: docx-client 加 appendToSection helper（找 H2 锚点 + 在末尾插入）
3. **P3**: skill 关键时刻 append（requirementDoc / slides / summary）
4. **P4**: archive 把核心文档当 Tier-1 输入

## 调研依据

5 个业界主流 living doc 模式融合：

| 来源 | 关键模式 |
|---|---|
| Atlassian Project Poster | 顶部摘要 + 历史 + 约束 |
| ADR (Michael Nygard) | 决策日志 append-only + Superseded 链 |
| Notion Wiki | verification dates + page owners |
| Keep a Changelog | reverse chronological |
| Confluence | 阻塞与风险 section |

**业界 100% 用 append-only + immutability**：决策推翻就 [Supersedes Dxx]，绝不重写。

## Doc 结构

\`\`\`markdown
# 项目核心文档

## 项目摘要
- 项目 / 状态 / 创建时间 / 最后更新

## 决策日志（ADR-style append-only）
- 2026-05-06 14:30 — 选用高德 SDK · 来源：msg_xxx
- 2026-05-06 14:40 — 改用百度 [Supersedes D1] · 来源：msg_yyy

## 项目里程碑（Changelog）
- 2026-05-06 14:35 — PRD v1 已落地: {URL}
- 2026-05-06 15:00 — 演示 PPT 已生成: {URL}

## 阻塞与风险
- 2026-05-06 16:00 — iOS 后台定位权限 pending [Open]

## 完整时间线（双视图：每条 entry 同步到这里）
- 14:30 [决策] 选用高德
- 14:35 [完成] PRD v1
- ...
\`\`\`

## 防幻觉 4 层

| 层 | 实现 |
|---|---|
| Per-entry 模板拼接 | 不过 LLM，所有 entry 字段从 skill 已有数据来 |
| Append-only immutability | 永远不重写已有内容 |
| Source pointer | 每条 entry 带 messageId 来源 |
| Archive Tier-1 优先 | archive 优先从核心文档提取，避免重复列同样事情 |

## Test plan

- [x] core-doc.test.ts 11 个 case：findCoreDocToken（5 case）+ append helpers（6 case）
- [x] 现有 onboarding / archive / summary / slides / requirementDoc tests 都通过（fire-and-forget 不影响主流程）
- [x] 全本地：172 skills + 298 bot tests + 0 lint errors

## Out of scope

- taskAssignment 接入（队友 Edwin 的 PR #105 改动较大，暂不动）
- 跨项目知识库 / 多语言
- doc 自动重组（永远 append-only）

## 引用

- [Atlassian Project Poster](https://www.atlassian.com/software/confluence/templates/project-poster)
- [ADR GitHub Examples](https://github.com/joelparkerhenderson/architecture-decision-record)
- [Martin Fowler: ADR](https://martinfowler.com/bliki/ArchitectureDecisionRecord.html)
- [Notion: Build a Wiki](https://www.notion.com/help/guides/how-to-build-a-wiki-for-your-company)
- [Keep a Changelog (Heroku)](https://github.com/heroku/keep_a_changelog_file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)