### PR TITLE
feat(skill): 主动协作层支持资料提示与澄清提问 #121

### DIFF
--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -10,7 +10,13 @@ import type {
   SkillName,
 } from '@seedhac/contracts';
 import { SkillRouter } from '../skill-router.js';
-import { handleEvent, shouldObservePassively, PASSIVE_MIN_TEXT_LENGTH, type HarnessConfig } from '../wiring.js';
+import {
+  handleEvent,
+  shouldConsiderProactive,
+  shouldObservePassively,
+  PASSIVE_MIN_TEXT_LENGTH,
+  type HarnessConfig,
+} from '../wiring.js';
 import { NullMemoryStore } from '../memory/memory-store.js';
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -752,6 +758,20 @@ describe('shouldObservePassively', () => {
   });
 });
 
+// ─── shouldConsiderProactive ─────────────────────────────────────────────────
+
+describe('shouldConsiderProactive', () => {
+  it('明显需要资料/澄清的消息应进入主动层候选', () => {
+    expect(shouldConsiderProactive('这个资料在哪里？')).toBe(true);
+    expect(shouldConsiderProactive('下一步我们先做什么')).toBe(true);
+  });
+
+  it('短闲聊或无工作信号的消息不进入主动层', () => {
+    expect(shouldConsiderProactive('好的')).toBe(false);
+    expect(shouldConsiderProactive('今天大家辛苦了')).toBe(false);
+  });
+});
+
 // ─── handlePassiveObserve（通过 handleEvent 集成） ────────────────────────────
 
 describe('handleEvent — passive observe', () => {
@@ -825,5 +845,90 @@ describe('handleEvent — passive observe', () => {
     // Harness 可能调 chatWithTools，但 passive observe 不应额外再调一次
     // 每条 @mention 消息 chatWithTools 调用次数 ≤ 1（只有 Harness，没有 passive observe）
     expect(chatWithTools.mock.calls.length).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─── handleEvent — proactive layer ───────────────────────────────────────────
+
+describe('handleEvent — proactive layer', () => {
+  const router = new SkillRouter(BOT_ID);
+
+  it('非 @mention 且无 skill 接管时，可主动发送资料提示', async () => {
+    const msg = makeMessage({ text: '这个资料在哪里？', mentions: [] });
+    const runtime = makeRuntime();
+    const chatWithTools = vi.fn().mockResolvedValue(
+      ok({
+        content: JSON.stringify({
+          action: 'share',
+          text: '我找到一条相关资料：项目 PRD 在飞书文档里，先看“验收标准”那节。',
+          reason: '用户在找资料',
+        }),
+        toolCalls: [{ id: 'tc1', name: 'memory.search', argumentsRaw: '{}' }],
+        rounds: 1,
+      }),
+    );
+    const ctx = makeCtx(makeEvent(msg), runtime, { chatWithTools });
+
+    await handleEvent(ctx, router, {}, makeHarness());
+    await vi.waitFor(() => expect(runtime.sendText).toHaveBeenCalledOnce());
+
+    expect(chatWithTools).toHaveBeenCalledOnce();
+    const [, opts] = chatWithTools.mock.calls[0]!;
+    const toolNames = (opts as { tools: Array<{ name: string }> }).tools.map((t) => t.name);
+    expect(toolNames.sort()).toEqual(['memory.search', 'skill.list', 'skill.read']);
+    expect(toolNames).not.toContain('memory.write');
+    expect(toolNames).not.toContain('decision.write');
+    expect(runtime.sendText).toHaveBeenCalledWith({
+      chatId: 'oc_chat1',
+      text: '我找到一条相关资料：项目 PRD 在飞书文档里，先看“验收标准”那节。',
+    });
+  });
+
+  it('非 @mention 且 skill 已接管时，不额外触发主动层', async () => {
+    const msg = makeMessage({ text: '我来负责资料吗？', mentions: [] });
+    const runtime = makeRuntime();
+    const chatWithTools = vi.fn().mockResolvedValue(
+      ok({ content: JSON.stringify({ action: 'clarify', text: 'x' }), toolCalls: [], rounds: 1 }),
+    );
+    const ctx = makeCtx(makeEvent(msg), runtime, { chatWithTools });
+    const taskSkill: Skill = {
+      ...qaSkill,
+      name: 'taskAssignment' as SkillName,
+      match: vi.fn().mockReturnValue(true),
+      run: vi.fn().mockResolvedValue(ok({ reasoning: 'assignment captured' })),
+    };
+
+    await handleEvent(ctx, router, { taskAssignment: taskSkill }, makeHarness());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(taskSkill.run).toHaveBeenCalledOnce();
+    expect(chatWithTools).not.toHaveBeenCalled();
+  });
+
+  it('share 没有实际检索工具调用时不发送，避免编造资料', async () => {
+    const msg = makeMessage({ text: '这个资料在哪里？', mentions: [] });
+    const runtime = makeRuntime();
+    const chatWithTools = vi.fn().mockResolvedValue(
+      ok({
+        content: JSON.stringify({
+          action: 'share',
+          text: '资料在这里。',
+          reason: '用户在找资料',
+        }),
+        toolCalls: [],
+        rounds: 1,
+      }),
+    );
+    const ctx = makeCtx(makeEvent(msg), runtime, { chatWithTools });
+
+    await handleEvent(ctx, router, {}, makeHarness());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chatWithTools).toHaveBeenCalledOnce();
+    expect(runtime.sendText).not.toHaveBeenCalled();
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      'proactive layer share without grounding tool call',
+      expect.objectContaining({ reason: '用户在找资料' }),
+    );
   });
 });

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -12,6 +12,7 @@ import type {
 import { SkillRouter } from '../skill-router.js';
 import {
   handleEvent,
+  PROACTIVE_TIMEOUT_MS,
   shouldConsiderProactive,
   shouldObservePassively,
   PASSIVE_MIN_TEXT_LENGTH,
@@ -874,10 +875,16 @@ describe('handleEvent — proactive layer', () => {
 
     expect(chatWithTools).toHaveBeenCalledOnce();
     const [, opts] = chatWithTools.mock.calls[0]!;
-    const toolNames = (opts as { tools: Array<{ name: string }> }).tools.map((t) => t.name);
+    const callOptions = opts as {
+      tools: Array<{ name: string }>;
+      timeoutMs: number;
+    };
+    const toolNames = callOptions.tools.map((t) => t.name);
     expect(toolNames.sort()).toEqual(['memory.search', 'skill.list', 'skill.read']);
     expect(toolNames).not.toContain('memory.write');
     expect(toolNames).not.toContain('decision.write');
+    expect(callOptions.timeoutMs).toBe(PROACTIVE_TIMEOUT_MS);
+    expect(callOptions.timeoutMs).toBeLessThanOrEqual(30_000);
     expect(runtime.sendText).toHaveBeenCalledWith({
       chatId: 'oc_chat1',
       text: '我找到一条相关资料：项目 PRD 在飞书文档里，先看“验收标准”那节。',

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -539,6 +539,7 @@ export function shouldObservePassively(text: string): boolean {
 }
 
 const PROACTIVE_MIN_TEXT_LENGTH = 8;
+export const PROACTIVE_TIMEOUT_MS = 30_000;
 const PROACTIVE_SIGNAL_RE =
   /(?:怎么|如何|有没有|哪里|找不到|不确定|不清楚|缺|需要什么|先做什么|下一步|资料|文档|链接|方案|规则|标准|口径|背景|参考|帮忙看看|卡住|blocked)/i;
 
@@ -677,7 +678,7 @@ async function handleProactiveLayer(
     executor,
     maxToolCallRounds: 3,
     model: 'lite',
-    timeoutMs: 600_000,
+    timeoutMs: PROACTIVE_TIMEOUT_MS,
   });
 
   if (!result.ok) {

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -86,24 +86,33 @@ export async function handleEvent(
       });
     });
   }
-  await handleWithSkillRouter(ctx, router, skills);
+  const handledBySkill = await handleWithSkillRouter(ctx, router, skills);
+  if (!handledBySkill && harness && shouldConsiderProactive(msg.text)) {
+    void handleProactiveLayer(ctx, msg, skills, harness).catch((e) => {
+      logger.warn('proactive layer threw', {
+        chatId: msg.chatId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
+  }
 }
 
 async function handleWithSkillRouter(
   ctx: SkillContext,
   router: SkillRouter,
   skills: Readonly<Partial<Record<SkillName, Skill>>>,
-): Promise<void> {
+): Promise<boolean> {
   const { event } = ctx;
-  if (event.type !== 'message') return;
+  if (event.type !== 'message') return false;
   const msg = event.payload;
   const intent = router.route(msg);
   const skillName = intentToSkill[intent];
-  if (!skillName) return;
+  if (!skillName) return false;
   const skill = skills[skillName];
-  if (!skill) return;
-  if (!(await skill.match(ctx))) return;
+  if (!skill) return false;
+  if (!(await skill.match(ctx))) return false;
   await runSkill(ctx, skill);
+  return true;
 }
 
 async function runSkill(ctx: SkillContext, skill: Skill): Promise<void> {
@@ -529,6 +538,16 @@ export function shouldObservePassively(text: string): boolean {
   return text.trim().length >= PASSIVE_MIN_TEXT_LENGTH;
 }
 
+const PROACTIVE_MIN_TEXT_LENGTH = 8;
+const PROACTIVE_SIGNAL_RE =
+  /(?:怎么|如何|有没有|哪里|找不到|不确定|不清楚|缺|需要什么|先做什么|下一步|资料|文档|链接|方案|规则|标准|口径|背景|参考|帮忙看看|卡住|blocked)/i;
+
+export function shouldConsiderProactive(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < PROACTIVE_MIN_TEXT_LENGTH) return false;
+  return PROACTIVE_SIGNAL_RE.test(trimmed);
+}
+
 async function handlePassiveObserve(
   ctx: SkillContext,
   msg: Message,
@@ -607,4 +626,139 @@ async function observeWithTimeout(
     model: 'lite', // 被动用便宜模型
     timeoutMs,
   });
+}
+
+type ProactiveDecision =
+  | { readonly action: 'silent'; readonly reason?: string }
+  | { readonly action: 'share' | 'clarify'; readonly text: string; readonly reason?: string };
+
+const PROACTIVE_TOOL_NAMES = new Set(['memory.search', 'skill.list', 'skill.read']);
+
+async function handleProactiveLayer(
+  ctx: SkillContext,
+  msg: Message,
+  skills: Readonly<Partial<Record<SkillName, Skill>>>,
+  harness: HarnessConfig,
+): Promise<void> {
+  const { llm, logger, runtime } = ctx;
+  const chatId = msg.chatId;
+
+  const tools = getLLMTools().filter((tool) => PROACTIVE_TOOL_NAMES.has(tool.name));
+  if (tools.length === 0) {
+    logger.warn('proactive layer: no tools available', { chatId });
+    return;
+  }
+
+  const executor = makeExecutor({
+    store: harness.memoryStore,
+    bitable: ctx.bitable,
+    skills: registeredSkillValues(skills),
+    chatId,
+    logger,
+    docsRoot: harness.docsRoot,
+    sourceSkill: 'proactive_layer',
+  });
+
+  const systemPrompt =
+    '你是 Lark Loom 的主动协作层。你只在群聊当前消息明显需要帮助时短暂介入。\n' +
+    '可做两件事：1) 主动给资料：先调用 memory.search 或 skill.read 查到相关信息，再用 1-3 句话给出链接/事实/下一步；' +
+    '2) 主动澄清：当信息不足且继续执行会误导时，只问一个具体澄清问题。\n' +
+    '不要主动推送未被触发的完整 skill 结果；不要编造资料；没有把握就 silent。\n' +
+    '输出必须是 JSON：{"action":"silent|share|clarify","text":"要发送到群里的短文本","reason":"一句话原因"}。' +
+    'action=silent 时可以省略 text。不要输出 JSON 以外的文字。';
+
+  const messages: ChatMessage[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: msg.text },
+  ];
+
+  const result = await llm.chatWithTools(messages, {
+    tools,
+    executor,
+    maxToolCallRounds: 3,
+    model: 'lite',
+    timeoutMs: 600_000,
+  });
+
+  if (!result.ok) {
+    logger.warn('proactive layer failed', {
+      chatId,
+      code: result.error.code,
+      message: result.error.message,
+    });
+    return;
+  }
+
+  const decision = parseProactiveDecision(result.value.content);
+  if (!decision) {
+    logger.warn('proactive layer decision parse failed', {
+      chatId,
+      content: result.value.content,
+    });
+    return;
+  }
+
+  if (decision.action === 'silent') {
+    logger.info('proactive layer selected silent', { chatId, reason: decision.reason });
+    return;
+  }
+
+  if (decision.action === 'share' && !hasGroundingToolCall(result.value.toolCalls)) {
+    logger.warn('proactive layer share without grounding tool call', {
+      chatId,
+      reason: decision.reason,
+    });
+    return;
+  }
+
+  const text = decision.text.trim();
+  if (!text) {
+    logger.warn('proactive layer selected empty text', { chatId, action: decision.action });
+    return;
+  }
+
+  const sendResult = await runtime.sendText({ chatId, text });
+  if (!sendResult.ok) {
+    logger.error('proactive layer send text failed', {
+      chatId,
+      code: sendResult.error.code,
+      message: sendResult.error.message,
+    });
+    return;
+  }
+
+  logger.info('proactive layer replied', {
+    chatId,
+    action: decision.action,
+    reason: decision.reason,
+    rounds: result.value.rounds,
+    toolCallCount: result.value.toolCalls.length,
+  });
+}
+
+function hasGroundingToolCall(toolCalls: readonly ToolCall[]): boolean {
+  return toolCalls.some((call) => call.name === 'memory.search' || call.name === 'skill.read');
+}
+
+function parseProactiveDecision(raw: string): ProactiveDecision | null {
+  const trimmed = stripCodeFence(raw);
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      action?: unknown;
+      text?: unknown;
+      reason?: unknown;
+    };
+    if (parsed.action === 'silent') {
+      return typeof parsed.reason === 'string'
+        ? { action: 'silent', reason: parsed.reason }
+        : { action: 'silent' };
+    }
+    if (parsed.action !== 'share' && parsed.action !== 'clarify') return null;
+    if (typeof parsed.text !== 'string') return null;
+    let decision: ProactiveDecision = { action: parsed.action, text: parsed.text };
+    if (typeof parsed.reason === 'string') decision = { ...decision, reason: parsed.reason };
+    return decision;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## 背景
Closes #121。

为非 @bot 的群聊消息增加一层受控 proactive layer：当消息明显在找资料、缺上下文、卡住或需要下一步判断时，机器人可以主动给出短资料提示，或提出一个具体澄清问题。

## 改动
- 在非 @mention 路径中保留现有 SkillRouter；只有没有 skill 接管时才进入主动层，避免重复插话。
- 新增 `shouldConsiderProactive()`，用轻量规则过滤短闲聊和低价值消息。
- 主动层只暴露只读工具：`memory.search` / `skill.list` / `skill.read`。
- 支持三种结构化决策：`silent` / `share` / `clarify`。
- `share` 必须实际调用过 `memory.search` 或 `skill.read` 才允许发送，避免编造资料。
- 补充 wiring 单测，覆盖主动提示、工具白名单、skill 已接管不重复触发、无检索不发送等场景。

## 验证
- `vitest run packages/bot/src/__tests__`
- `tsc -b packages/contracts packages/skills packages/bot`
- `git diff --check`
