### PR TITLE
fix(relevance-filter): 触发消息 100% 保留，修复 0/N 全丢导致空文档

### DIFF
--- a/packages/skills/src/requirement-doc.ts
+++ b/packages/skills/src/requirement-doc.ts
@@ -118,7 +118,17 @@ async function filterByRelevance(
     return { history, linkedDocs };
   }
 
-  const candidates: RelevanceCandidate[] = natives.map((m, i) => ({
+  // 触发消息本身是用户当前显式输入，跟 forwarded / linkedDocs 同等地位 —— 100% 保留，
+  // 不进 lite 模型 candidates，否则 lite 容易按"重复触发消息"规则把它丢了（实战 bug：
+  // 触发消息被丢掉时整个 history 变 0/N，pro 模型拿到空 prompt，输出空文档）
+  const judgable = natives.filter((m) => m.messageId !== trigger.messageId);
+
+  // 没有非触发候选可筛 → 直接返回全量
+  if (judgable.length === 0) {
+    return { history, linkedDocs };
+  }
+
+  const candidates: RelevanceCandidate[] = judgable.map((m, i) => ({
     id: `m${i}`,
     kind: 'message',
     excerpt: `[${m.sender.name ?? m.sender.userId}] ${summarize(m.text, 200)}`,
@@ -126,9 +136,10 @@ async function filterByRelevance(
 
   ctx.logger.info('requirementDoc: relevance pre-filter', {
     nativeCount: natives.length,
+    judgableCount: judgable.length,
     forwardedCount: forwarded.length,
     linkedDocCount: linkedDocs.length,
-    note: 'forwarded + linkedDocs are always kept; lite filter only judges native messages',
+    note: 'trigger + forwarded + linkedDocs are always kept; lite only judges other natives',
   });
 
   const judgmentResult = await ctx.llm.askStructured(
@@ -152,15 +163,20 @@ async function filterByRelevance(
   }
 
   const keepIds = new Set(judgmentResult.value.results.filter((r) => r.keep).map((r) => r.id));
-  const keptNatives = natives.filter((_, i) => keepIds.has(`m${i}`));
+  const keptJudgable = judgable.filter((_, i) => keepIds.has(`m${i}`));
 
-  // 把「保留的原生」+「全部 forwarded」按 history 原顺序组合，保证时间序正确
+  // 触发消息 + 保留的判定项 + 全部 forwarded（按 history 原顺序保时间序）
+  const keptNativesSet = new Set<Message>([
+    ...natives.filter((m) => m.messageId === trigger.messageId),
+    ...keptJudgable,
+  ]);
   const keptHistory = history.filter(
-    (m) => forwardedIds.has(m.messageId) || keptNatives.includes(m),
+    (m) => forwardedIds.has(m.messageId) || keptNativesSet.has(m),
   );
 
   ctx.logger.info('requirementDoc: relevance pre-filter done', {
-    nativeKept: `${keptNatives.length}/${natives.length}`,
+    nativeKept: `${keptNativesSet.size}/${natives.length}`,
+    judgableKept: `${keptJudgable.length}/${judgable.length}`,
     forwardedKept: `${forwarded.length}/${forwarded.length} (always kept)`,
     linkedDocKept: `${linkedDocs.length}/${linkedDocs.length} (always kept)`,
   });

--- a/packages/skills/src/summary.ts
+++ b/packages/skills/src/summary.ts
@@ -88,6 +88,9 @@ function summarize(value: string, max = 200): string {
 /**
  * 用 lite 模型预筛历史 — 群里可能掺多个项目讨论 / bot 诊断噪音。
  * 失败时降级为原 history（不致命）。
+ *
+ * 触发消息（trigger）100% 保留，不进 candidates —— 否则 lite 容易按
+ * "重复触发消息"规则把它丢了（参考 requirement-doc 同款修复）。
  */
 async function filterByRelevance(
   ctx: SkillContext,
@@ -96,7 +99,10 @@ async function filterByRelevance(
 ): Promise<readonly Message[]> {
   if (history.length <= 5) return history;
 
-  const candidates: RelevanceCandidate[] = history.map((m, i) => ({
+  const judgable = history.filter((m) => m.messageId !== trigger.messageId);
+  if (judgable.length === 0) return history;
+
+  const candidates: RelevanceCandidate[] = judgable.map((m, i) => ({
     id: `m${i}`,
     kind: 'message',
     excerpt: `[${m.sender.name ?? m.sender.userId}] ${summarize(m.text, 200)}`,
@@ -119,10 +125,17 @@ async function filterByRelevance(
   if (judgmentResult.value.results.length === 0) return history;
 
   const keepIds = new Set(judgmentResult.value.results.filter((r) => r.keep).map((r) => r.id));
-  const kept = history.filter((_, i) => keepIds.has(`m${i}`));
+  const keptJudgable = judgable.filter((_, i) => keepIds.has(`m${i}`));
+  // 触发消息永远保留 + 按 history 原顺序保时间序
+  const keptSet = new Set<Message>([
+    ...history.filter((m) => m.messageId === trigger.messageId),
+    ...keptJudgable,
+  ]);
+  const kept = history.filter((m) => keptSet.has(m));
 
   ctx.logger.info('summary: relevance pre-filter done', {
     kept: `${kept.length}/${history.length}`,
+    judgableKept: `${keptJudgable.length}/${judgable.length}`,
   });
 
   // 如果筛完几乎全没了，可能是模型误判：保底退回原 history


### PR DESCRIPTION
## 问题（实战 bug）

用户在 fresh 群里发：
> 这次的项目需求是这样的，我们要做一个校园骑行打卡 App，目标是大学生群体，鼓励运动习惯。要支持地图轨迹、积分排行榜、好友分享。

requirementDoc 跑出**空文档**「[待补充：无需求输入]」。日志：

```
[bot] requirementDoc: relevance pre-filter done {
  nativeKept: '0/7',     ← 7 条全被丢，包括触发消息本身
}
[bot] requirementDoc: asking LLM for structured extraction { historyCount: 0 }
[bot] requirementDoc: creating feishu doc { title: '[待补充：无需求输入]', goalCount: 0 }
```

## 根因

`packages/skills/src/requirement-doc.ts:121` 把**触发消息也塞进 candidates 喂给 lite 模型**。`prompts/requirement-doc.ts:RELEVANCE_PROMPT` 里有这条规则：

> 完全无关的闲聊、其他项目讨论、机器人诊断噪音、**重复触发消息** → keep: false

lite 模型看到 candidates 里有一条跟 trigger 一模一样的消息，按"重复触发消息"规则丢掉。其他 6 条是 bot 自己的 onboarding 卡 + 系统消息，被合理判为无关。结果 0/7 全没，pro 模型拿到空 prompt → 输出空文档。

`summary.ts` 也有同款 bug（上次 PR #111 改的时候带进来的）。

## 修复

把触发消息从 candidates 里抽出来，跟 `forwarded` / `linkedDocs` 同等地位 —— 用户当前显式输入，100% 保留，**不进 lite 模型**：

```ts
const judgable = natives.filter((m) => m.messageId !== trigger.messageId);
if (judgable.length === 0) return { history, linkedDocs };

// 只把 judgable 喂给 lite 模型
// ...

const keptNativesSet = new Set([
  ...natives.filter((m) => m.messageId === trigger.messageId),  // 触发消息永远保留
  ...keptJudgable,
]);
```

`requirement-doc.ts` 和 `summary.ts` 各修一处，逻辑对齐。

prompt 里的"重复触发消息"规则**保留**作为防御性兜底（万一以后有别的路径让 trigger 进了 candidates，仍能识别）。

## Test Plan

- `tsc -b packages/contracts packages/skills packages/bot`：0 error
- `vitest run`：**31 files / 470 tests passed**
- `eslint`：0 error

复现路径：
- 旧行为：fresh 群发 requirementDoc 触发消息 → `nativeKept: 0/7` → 空文档
- 新行为：触发消息保底 → `nativeKept: ≥1/7` → 至少触发消息进 pro 模型的 prompt → 文档至少有 title / summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)