### PR TITLE
feat(taskAssignment): 接 loading 卡片 pipeline + 去掉虚假仅群内成员文案

### DIFF
--- a/packages/bot/src/__tests__/card-builder.test.ts
+++ b/packages/bot/src/__tests__/card-builder.test.ts
@@ -135,6 +135,35 @@ describe('tablePush card', () => {
     expect(j).toContain('@Antares');
     expect(j).toContain('2026-05-06');
     expect(j).toContain('查看分工表');
+    // 不应该再有「仅群内成员可查看与编辑」这条虚假宣传 —— 共享 bitable 做不到
+    expect(j).not.toContain('仅群内成员可查看与编辑');
+  });
+
+  it('renders loading state', () => {
+    const card = larkCardBuilder.build('tablePush', {
+      tableTitle: '项目分工表',
+      bitableUrl: '',
+      taskCount: 0,
+      members: [],
+      isLoading: true,
+    });
+    const j = json(card);
+    expect(noPlaceholders(j)).toBe(true);
+    expect(j).toContain('分工表生成中');
+    expect(j).toContain('整理完会自动替换');
+  });
+
+  it('renders error state', () => {
+    const card = larkCardBuilder.build('tablePush', {
+      tableTitle: '项目分工表',
+      bitableUrl: '',
+      taskCount: 0,
+      members: [],
+      errorMessage: '本次未识别到明确的分工',
+    });
+    const j = json(card);
+    expect(j).toContain('分工表生成失败');
+    expect(j).toContain('未识别到明确的分工');
   });
 });
 

--- a/packages/bot/src/card-builder.ts
+++ b/packages/bot/src/card-builder.ts
@@ -272,17 +272,47 @@ function buildDocPush(input: DocPushCardInput): Card {
  * UI：列出成员和最近 DDL，突出"查看表格"入口
  */
 function buildTablePush(input: TablePushCardInput): Card {
+  // 三态共用同一个模板色，仅 header 标题区分；与 summary / slides 的「两态同色」对齐
+  const HEADER_TEMPLATE = 'yellow' as const;
+
+  if (input.isLoading) {
+    return card('tablePush', {
+      schema: '2.0',
+      header: { title: pt('分工表生成中'), template: HEADER_TEMPLATE },
+      body: {
+        elements: [
+          md(
+            `**${input.tableTitle}**\n\n正在识别群里讨论的分工（owner / 任务 / DDL / 验收标准），通常需要 30-60 秒。`,
+          ),
+          md('_整理完会自动替换这条卡片。_'),
+        ],
+      },
+    });
+  }
+
+  if (input.errorMessage) {
+    return card('tablePush', {
+      schema: '2.0',
+      header: { title: pt('分工表生成失败'), template: 'red' },
+      body: {
+        elements: [md(`**${input.tableTitle}**\n\n${input.errorMessage}`)],
+      },
+    });
+  }
+
   const memberLine = input.members.map((m) => `@${m}`).join('  ');
   const dueLine = input.nearestDue ? `\n⏰ 最近截止：**${input.nearestDue}**` : '';
+  // 注：分工表是项目共享 bitable（所有群共用同一个 base），目前**无法**做到
+  // "仅群内成员可查看与编辑"——按钮点开就是整张 base。要做真正的隔离需要
+  // 每群独立 bitable 或 per-chat filter view，单开 issue 跟进。
   return card('tablePush', {
     schema: '2.0',
-    header: { title: pt('分工表已生成'), template: 'yellow' },
+    header: { title: pt('分工表已生成'), template: HEADER_TEMPLATE },
     body: {
       elements: [
         md(`**${input.tableTitle}**\n共 ${input.taskCount} 个任务 · 成员：${memberLine}${dueLine}`),
         hr(),
         btn('查看分工表', { action: 'open_url', url: input.bitableUrl }, 'primary'),
-        md('_仅群内成员可查看与编辑_'),
       ],
     },
   });

--- a/packages/contracts/src/card.ts
+++ b/packages/contracts/src/card.ts
@@ -80,11 +80,16 @@ export interface DocPushCardInput {
 
 export interface TablePushCardInput {
   readonly tableTitle: string;
+  /** 终态分工表 URL；loading / error 态可为空字符串 */
   readonly bitableUrl: string;
   readonly taskCount: number;
   readonly members: readonly string[];
   /** 最近一个 DDL，格式 YYYY-MM-DD */
   readonly nearestDue?: string;
+  /** loading 占位：先 sendCard 拿 messageId，跑完后 patchCard 替换为终态 */
+  readonly isLoading?: boolean;
+  /** error 终态：跑挂时把 loading 卡片 patch 成失败提示 */
+  readonly errorMessage?: string;
 }
 
 export interface QaCardInput {

--- a/packages/skills/src/__tests__/task-assignment.test.ts
+++ b/packages/skills/src/__tests__/task-assignment.test.ts
@@ -68,7 +68,9 @@ function makeRuntime(history: readonly Message[]): BotRuntime {
     start: vi.fn().mockResolvedValue(ok(undefined)),
     stop: vi.fn().mockResolvedValue(undefined),
     sendText: vi.fn(),
-    sendCard: vi.fn().mockResolvedValue(ok({ messageId: 'm1', chatId: 'oc_chat_001', timestamp: 0 })),
+    sendCard: vi
+      .fn()
+      .mockResolvedValue(ok({ messageId: 'load_msg', chatId: 'oc_chat_001', timestamp: 0 })),
     patchCard: vi.fn().mockResolvedValue(ok(undefined)),
     fetchHistory: vi.fn().mockResolvedValue(ok({ messages: history, hasMore: false })),
     fetchMembers: vi.fn().mockResolvedValue(ok({ members: [] })),
@@ -101,7 +103,12 @@ function makeCtx(event: BotEvent, opts: CtxOpts = {}): SkillContext {
       insert: vi.fn().mockResolvedValue(ok({ tableId: 't_mem', recordId: 'r_mem' })),
       batchInsert: vi
         .fn()
-        .mockResolvedValue(ok([{ tableId: 't_todo', recordId: 'r1' }, { tableId: 't_todo', recordId: 'r2' }])),
+        .mockResolvedValue(
+          ok([
+            { tableId: 't_todo', recordId: 'r1' },
+            { tableId: 't_todo', recordId: 'r2' },
+          ]),
+        ),
       update: vi.fn(),
       delete: vi.fn(),
       link: vi.fn(),
@@ -142,17 +149,47 @@ describe('taskAssignmentSkill.match()', () => {
 });
 
 describe('taskAssignmentSkill.run() — happy path', () => {
-  it('writes structured todo rows and pushes tablePush card', async () => {
+  it('sends loading card, writes todo + memory, patches final card with task info', async () => {
     const ctx = makeCtx(makeEvent('A 负责用户访谈，DDL 明天'));
     const result = await taskAssignmentSkill.run(ctx);
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
+    // 不再返回 card —— 已通过 patchCard 替换 loading 卡
+    expect(result.value.card).toBeUndefined();
 
-    expect(result.value.card).toBe(MOCK_CARD);
+    // 1. 第一次 build 是 loading 卡
+    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
+    expect(build).toHaveBeenNthCalledWith(
+      1,
+      'tablePush',
+      expect.objectContaining({ isLoading: true }),
+    );
+    // 2. sendCard 把 loading 卡发出去
+    expect(ctx.runtime.sendCard).toHaveBeenCalledOnce();
+    // 3. todo + memory 写入
+    expect(ctx.bitable.batchInsert).toHaveBeenCalledOnce();
+    expect(ctx.bitable.insert).toHaveBeenCalledOnce();
+    // 4. 最后一次 build 是终态卡（带 taskCount / members / nearestDue）
+    const finalBuildCall = build.mock.calls[build.mock.calls.length - 1]!;
+    expect(finalBuildCall[0]).toBe('tablePush');
+    expect(finalBuildCall[1]).toMatchObject({
+      taskCount: 2,
+      members: ['A', 'B'],
+      nearestDue: '2026-05-07',
+      tableTitle: '项目分工表',
+    });
+    // 5. patchCard 把 loading 替换成终态
+    expect(ctx.runtime.patchCard).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'load_msg' }),
+    );
+  });
+
+  it('writes structured todo rows', async () => {
+    const ctx = makeCtx(makeEvent('A 负责用户访谈，DDL 明天'));
+    await taskAssignmentSkill.run(ctx);
 
     const batchInsert = ctx.bitable.batchInsert as unknown as ReturnType<typeof vi.fn>;
-    expect(batchInsert).toHaveBeenCalledOnce();
     const call = batchInsert.mock.calls[0]![0];
     expect(call.table).toBe('todo');
     expect(call.rows).toHaveLength(2);
@@ -172,7 +209,6 @@ describe('taskAssignmentSkill.run() — happy path', () => {
     await taskAssignmentSkill.run(ctx);
 
     const insert = ctx.bitable.insert as unknown as ReturnType<typeof vi.fn>;
-    expect(insert).toHaveBeenCalledOnce();
     const memCall = insert.mock.calls[0]![0];
     expect(memCall.table).toBe('memory');
     const row = memCall.row;
@@ -184,35 +220,29 @@ describe('taskAssignmentSkill.run() — happy path', () => {
     expect(row.key).toMatch(/^task-oc_chat_001-/);
     expect(row.content).toContain('A → 用户访谈');
   });
-
-  it('builds tablePush card with task count + members + nearestDue', async () => {
-    const ctx = makeCtx(makeEvent('A 负责用户访谈'));
-    await taskAssignmentSkill.run(ctx);
-
-    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
-    expect(build).toHaveBeenCalledOnce();
-    const [name, input] = build.mock.calls[0]!;
-    expect(name).toBe('tablePush');
-    expect(input.taskCount).toBe(2);
-    expect(input.members).toEqual(['A', 'B']);
-    expect(input.nearestDue).toBe('2026-05-07');
-    expect(input.tableTitle).toBe('项目分工表');
-  });
 });
 
 describe('taskAssignmentSkill.run() — degraded paths', () => {
-  it('skips card when LLM extracts no valid tasks', async () => {
+  it('patches error card when LLM extracts no valid tasks', async () => {
     const ctx = makeCtx(makeEvent('A 负责...'), { extraction: { tasks: [] } });
     const result = await taskAssignmentSkill.run(ctx);
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
     expect(result.value.card).toBeUndefined();
+    // loading 卡已发，跑完发现 0 条 → patch 成 error 卡
+    expect(ctx.runtime.sendCard).toHaveBeenCalledOnce();
+    expect(ctx.runtime.patchCard).toHaveBeenCalledOnce();
+    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
+    const lastBuildCall = build.mock.calls[build.mock.calls.length - 1]!;
+    expect(lastBuildCall[1]).toMatchObject({
+      errorMessage: expect.stringContaining('未识别到明确的分工'),
+    });
     expect(ctx.bitable.batchInsert).not.toHaveBeenCalled();
     expect(ctx.bitable.insert).not.toHaveBeenCalled();
   });
 
-  it('filters out low-confidence tasks', async () => {
+  it('filters out low-confidence tasks (treats as empty)', async () => {
     const ctx = makeCtx(makeEvent('A 负责...'), {
       extraction: {
         tasks: [
@@ -225,9 +255,11 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
 
     expect(result.ok).toBe(true);
     expect(ctx.bitable.batchInsert).not.toHaveBeenCalled();
+    // 跟 empty extraction 一样走 error 卡
+    expect(ctx.runtime.patchCard).toHaveBeenCalledOnce();
   });
 
-  it('skips card when bitable batchInsert fails', async () => {
+  it('patches error card when bitable batchInsert fails', async () => {
     const ctx = makeCtx(makeEvent('A 负责用户访谈'));
     (ctx.bitable.batchInsert as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       err(makeError(ErrorCode.FEISHU_API_ERROR, 'bitable down')),
@@ -238,10 +270,14 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
     expect(result.value.card).toBeUndefined();
-    expect(ctx.cardBuilder.build).not.toHaveBeenCalled();
+    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
+    const lastBuildCall = build.mock.calls[build.mock.calls.length - 1]!;
+    expect(lastBuildCall[1]).toMatchObject({
+      errorMessage: expect.stringContaining('写入分工表失败'),
+    });
   });
 
-  it('still builds card when memory insert fails (warn-only)', async () => {
+  it('still patches final card when memory insert fails (warn-only)', async () => {
     const ctx = makeCtx(makeEvent('A 负责用户访谈'));
     (ctx.bitable.insert as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       err(makeError(ErrorCode.FEISHU_API_ERROR, 'mem down')),
@@ -251,11 +287,15 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
-    expect(result.value.card).toBe(MOCK_CARD);
+    // 终态卡仍然 patch 出去（不带 errorMessage）
+    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
+    const lastBuildCall = build.mock.calls[build.mock.calls.length - 1]!;
+    expect(lastBuildCall[1].errorMessage).toBeUndefined();
+    expect(lastBuildCall[1].taskCount).toBe(2);
     expect(ctx.logger.warn).toHaveBeenCalled();
   });
 
-  it('returns err when fetchHistory fails', async () => {
+  it('returns err when fetchHistory fails (and patches error card)', async () => {
     const ctx = makeCtx(makeEvent('A 负责...'));
     (ctx.runtime.fetchHistory as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       err(makeError(ErrorCode.FEISHU_API_ERROR, 'history down')),
@@ -263,9 +303,10 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
 
     const result = await taskAssignmentSkill.run(ctx);
     expect(result.ok).toBe(false);
+    expect(ctx.runtime.patchCard).toHaveBeenCalledOnce();
   });
 
-  it('treats LLM extraction failure as empty (returns ok, no card)', async () => {
+  it('LLM extraction failure → empty tasks → patches "未识别到明确分工" error card', async () => {
     const ctx = makeCtx(makeEvent('A 负责...'));
     (ctx.llm.askStructured as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       err(makeError(ErrorCode.LLM_INVALID_RESPONSE, 'parse fail')),
@@ -275,9 +316,11 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
     expect(result.value.card).toBeUndefined();
+    // LLM fail → extract 返回 ok(EMPTY) → run 走"未识别"分支 patch error
+    expect(ctx.runtime.patchCard).toHaveBeenCalledOnce();
   });
 
-  it('skips card (but still writes todo + memory) when BITABLE_APP_TOKEN missing', async () => {
+  it('patches error card when BITABLE_APP_TOKEN missing (still writes todo + memory)', async () => {
     delete process.env['BITABLE_APP_TOKEN'];
     const ctx = makeCtx(makeEvent('A 负责用户访谈'));
 
@@ -288,11 +331,24 @@ describe('taskAssignmentSkill.run() — degraded paths', () => {
     expect(result.value.card).toBeUndefined();
     expect(ctx.bitable.batchInsert).toHaveBeenCalled();
     expect(ctx.bitable.insert).toHaveBeenCalled();
-    expect(ctx.cardBuilder.build).not.toHaveBeenCalled();
-    expect(ctx.logger.warn).toHaveBeenCalledWith(
-      'taskAssignment: BITABLE_APP_TOKEN missing, skip card',
-      expect.any(Object),
+    // 卡片 patch 成 error 提示 Bitable URL 未配置
+    const build = ctx.cardBuilder.build as unknown as ReturnType<typeof vi.fn>;
+    const lastBuildCall = build.mock.calls[build.mock.calls.length - 1]!;
+    expect(lastBuildCall[1]).toMatchObject({
+      errorMessage: expect.stringContaining('Bitable URL 未配置'),
+    });
+  });
+
+  it('returns err if loading card send fails (no further work done)', async () => {
+    const ctx = makeCtx(makeEvent('A 负责...'));
+    (ctx.runtime.sendCard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      err(makeError(ErrorCode.FEISHU_API_ERROR, 'send fail')),
     );
+
+    const result = await taskAssignmentSkill.run(ctx);
+    expect(result.ok).toBe(false);
+    expect(ctx.runtime.fetchHistory).not.toHaveBeenCalled();
+    expect(ctx.bitable.batchInsert).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/skills/src/task-assignment.ts
+++ b/packages/skills/src/task-assignment.ts
@@ -103,18 +103,52 @@ export const taskAssignmentSkill: Skill = {
     }
     const { chatId } = ctx.event.payload;
 
+    // 0. 立刻发 loading 卡片占位（仿 summary / requirementDoc / slides）
+    const loadingCard = ctx.cardBuilder.build('tablePush', {
+      tableTitle: '项目分工表',
+      bitableUrl: '',
+      taskCount: 0,
+      members: [],
+      isLoading: true,
+    });
+    const loadingSent = await ctx.runtime.sendCard({ chatId, card: loadingCard });
+    if (!loadingSent.ok) return err(loadingSent.error);
+    const loadingMessageId = loadingSent.value.messageId;
+
+    const patchToError = async (message: string): Promise<void> => {
+      const errCard = ctx.cardBuilder.build('tablePush', {
+        tableTitle: '项目分工表',
+        bitableUrl: '',
+        taskCount: 0,
+        members: [],
+        errorMessage: message,
+      });
+      const patchRes = await ctx.runtime.patchCard({ messageId: loadingMessageId, card: errCard });
+      if (!patchRes.ok) {
+        ctx.logger.warn('taskAssignment: patch error card failed', {
+          code: patchRes.error.code,
+          message: patchRes.error.message,
+        });
+      }
+    };
+
+    // 1. LLM 抽取
     const extractResult = await extract(ctx, chatId);
-    if (!extractResult.ok) return err(extractResult.error);
+    if (!extractResult.ok) {
+      await patchToError(`抽取失败：${extractResult.error.message}`);
+      return err(extractResult.error);
+    }
 
     const tasks = filterValidTasks(extractResult.value.tasks);
     if (tasks.length === 0) {
       ctx.logger.warn('taskAssignment: no valid tasks extracted', { chatId });
-      return ok({ reasoning: '未识别到明确分工，跳过' });
+      await patchToError('本次未识别到明确的分工（owner / 任务都需要明确）');
+      return ok({ reasoning: '未识别到明确分工' });
     }
 
     const now = Date.now();
 
-    // 1. 写 todo 表（失败降级，但不发卡 — 表是状态源，没写进去发卡反而误导）
+    // 2. 写 todo 表（失败 patch 错误卡，告知用户表写失败）
     //    LLM 输出字段做硬截断，防止 prompt-injected 长串撑爆 Bitable 行
     const insertResult = await ctx.bitable.batchInsert({
       table: 'todo',
@@ -137,10 +171,12 @@ export const taskAssignmentSkill: Skill = {
         code: insertResult.error.code,
         message: insertResult.error.message,
       });
-      return ok({ reasoning: '写入分工表失败，跳过卡片' });
+      await patchToError(`写入分工表失败：${insertResult.error.message}`);
+      return ok({ reasoning: '写入分工表失败' });
     }
 
-    // 2. 写 memory（统一 MemoryRecord schema）—— content 走 LONG 截断，防多任务拼接超长
+    // 3. 写 memory（统一 MemoryRecord schema）—— content 走 LONG 截断，防多任务拼接超长
+    //    失败仅 warn，不阻断卡片输出
     const memContent = clamp(
       tasks
         .map((t) => `${t.owner} → ${t.task}${t.ddl ? ` (DDL ${t.ddl})` : ''}`)
@@ -168,27 +204,38 @@ export const taskAssignmentSkill: Skill = {
       });
     }
 
-    // 3. tablePush 卡片 — 没有 BITABLE_APP_TOKEN 就不发卡（避免按钮坏链）
+    // 4. patch 成最终卡 — 没有 BITABLE_APP_TOKEN 时按钮没有链接，patch 成 error 态
     const bitableUrl = bitableUrlFromEnv();
     if (!bitableUrl) {
-      ctx.logger.warn('taskAssignment: BITABLE_APP_TOKEN missing, skip card', { chatId });
+      ctx.logger.warn('taskAssignment: BITABLE_APP_TOKEN missing', { chatId });
+      await patchToError('Bitable URL 未配置，无法生成查看链接（已写入 todo 表）');
       return ok({
-        reasoning: `抽取到 ${tasks.length} 条分工，但 Bitable URL 未配置，跳过卡片`,
+        reasoning: `抽取到 ${tasks.length} 条分工，但 Bitable URL 未配置`,
       });
     }
 
     const owners = Array.from(new Set(tasks.map((t) => t.owner)));
     const nearestDue = pickNearestDue(tasks);
-    const card = ctx.cardBuilder.build('tablePush', {
+    const finalCard = ctx.cardBuilder.build('tablePush', {
       tableTitle: '项目分工表',
       bitableUrl,
       taskCount: tasks.length,
       members: owners,
       ...(nearestDue ? { nearestDue } : {}),
     });
+    const patchRes = await ctx.runtime.patchCard({
+      messageId: loadingMessageId,
+      card: finalCard,
+    });
+    if (!patchRes.ok) {
+      ctx.logger.warn('taskAssignment: patch final card failed; final card not visible', {
+        code: patchRes.error.code,
+        message: patchRes.error.message,
+      });
+    }
 
+    // 不再返回 card：已通过 patchCard 替换 loading 卡，wiring 不需要再发一条
     return ok({
-      card,
       reasoning: `抽取到 ${tasks.length} 条分工，涉及 ${owners.length} 位成员`,
     });
   },


### PR DESCRIPTION
## Summary

把 taskAssignment 接上跟 summary / requirementDoc / slides 同款的 **loading → patch 终态 / error 三态卡片**，并顺手去掉虚假的"仅群内成员可查看与编辑"文案（对共享 bitable 不成立）。

## 起因

用户在群里说"A 负责前端，B 负责后端"触发 taskAssignment 后，LLM 抽取 + bitable 写入 30-90 秒群里**完全没动静**，体感等同超时。其他 skill 都已接上 loading 卡片，taskAssignment 是唯一的漏网。

另：测试时发现 tablePush 卡底部 "_仅群内成员可查看与编辑_" 这行字是虚假宣传——分工表是项目共享 bitable，按钮点开就是整张 base。

## 改动 1：三态卡片 pipeline

```
[用户消息: "A 负责前端"]
   ↓
sendCard("分工表生成中…")        ← loading 卡，黄色 header
   ↓
fetchHistory + LLM askStructured
   ↓
   ├─ 失败 / 0 有效分工 / bitable 失败 / token 缺失
   │     → patchCard("分工表生成失败…")   ← error 卡，红色 header
   │
   └─ 成功
         → batchInsert(todo) + insert(memory)
         → patchCard("分工表已生成…")      ← 终态卡，黄色 header
```

跟 summary / requirementDoc 的两态同色规范对齐：loading + 终态都用黄色，仅 header 标题区分；error 走红色。

## 改动 2：去掉虚假"仅群内成员可查看与编辑"

| 卡片 | 资源类型 | 能不能锁群成员？ |
|---|---|---|
| `docPush`（requirementDoc / summary） | 每次新建 docx | ✓ `docx.grantMembersEdit` |
| `tablePush`（taskAssignment） | 所有群共享一个 bitable | ✗ 整张 base 是项目级，做不到 per-group |

直接去掉这行字。真做"每群独立访问"需要 per-group bitable 或 per-chat filter view，工程量较大，单独开 issue 跟进。

## Test Plan

- `tsc -b packages/contracts packages/skills packages/bot`：0 error
- `vitest run`：**31 files / 473 tests passed**
- `eslint`：0 error
- task-assignment.test 完全重写，覆盖：
  - **happy path**：loading → 写入 → patch 终态完整序列
  - **8 个 degraded 路径**：0 有效分工 / 低置信度 / batchInsert 失败 / memory 失败 / fetchHistory 失败 / LLM 失败 / BITABLE_APP_TOKEN 缺失 / loading sendCard 失败
- card-builder.test 新增 loading / error 两态 + "不再含仅群内成员可查看与编辑" 断言

🤖 Generated with [Claude Code](https://claude.com/claude-code)