### PR TITLE
fix(core-doc): findCoreDocToken 加诊断日志 + server filter fallback（实战 bug）

### DIFF
--- a/packages/skills/src/core-doc.ts
+++ b/packages/skills/src/core-doc.ts
@@ -44,28 +44,68 @@ const FEISHU_URL_RE = /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffic
 
 /**
  * 从 memory 找到当前 chatId 的核心文档 docToken。找不到返回 null。
+ *
+ * 健壮性：先用 server-side filter 试一次，若 0 条命中则 fallback 到 client-side
+ * filter（防止 feishu bitable 列名 / 大小写差异导致 server filter 不工作）。
  */
 export async function findCoreDocToken(
   ctx: CoreDocCtx,
   chatId: string,
 ): Promise<string | null> {
+  // 第一次：server-side filter，pageSize 100
   const filter = `AND(CurrentValue.[chat_id]="${chatId}")`;
-  const res = await ctx.bitable.find({ table: 'memory', filter, pageSize: 50 });
+  const res = await ctx.bitable.find({ table: 'memory', filter, pageSize: 100 });
   if (!res.ok) {
     ctx.logger.warn('core-doc: memory.find failed', { error: res.error.message });
     return null;
   }
-  // 找最新的 [核心文档] 前缀条目（按 created_at 倒序）
-  const candidates = res.value.records
-    .filter((r) => /^\[核心文档\]/.test(String(r['content'] ?? '')))
-    .sort(
-      (a, b) => Number(b['created_at'] ?? 0) - Number(a['created_at'] ?? 0),
-    );
+
+  let records = res.value.records;
+  let candidates = records.filter((r) =>
+    /^\[核心文档\]/.test(String(r['content'] ?? '')),
+  );
+
+  // Fallback：server filter 完全 0 条记录 → 怀疑 filter 失效（列名不对 / 大小写
+  // 等），再拉一次不带 filter 的全量 + 客户端过滤。
+  // server filter 有记录但 0 个 [核心文档] → 真的没核心文档，不 fallback。
+  if (records.length === 0) {
+    const allRes = await ctx.bitable.find({ table: 'memory', pageSize: 200 });
+    if (allRes.ok) {
+      records = allRes.value.records.filter((r) => String(r['chat_id'] ?? '') === chatId);
+      candidates = records.filter((r) => /^\[核心文档\]/.test(String(r['content'] ?? '')));
+      ctx.logger.info('core-doc: findCoreDocToken client fallback', {
+        chatId,
+        totalAllRecords: allRes.value.records.length,
+        matchedChatId: records.length,
+        coreDocCandidates: candidates.length,
+        sampleContents: records.slice(0, 3).map((r) => String(r['content'] ?? '').slice(0, 60)),
+      });
+    } else {
+      ctx.logger.warn('core-doc: fallback memory.find failed', {
+        error: allRes.error.message,
+      });
+    }
+  } else {
+    ctx.logger.info('core-doc: findCoreDocToken server filter', {
+      chatId,
+      totalRecords: records.length,
+      coreDocCandidates: candidates.length,
+      sampleContents:
+        candidates.length === 0
+          ? records.slice(0, 3).map((r) => String(r['content'] ?? '').slice(0, 60))
+          : undefined,
+    });
+  }
+
   if (candidates.length === 0) return null;
-  const content = String(candidates[0]!['content'] ?? '');
+
+  // 取最新的 [核心文档]（按 created_at 倒序）
+  const sorted = [...candidates].sort(
+    (a, b) => Number(b['created_at'] ?? 0) - Number(a['created_at'] ?? 0),
+  );
+  const content = String(sorted[0]!['content'] ?? '');
   const url = content.match(FEISHU_URL_RE)?.[0];
   if (!url) return null;
-  // url: https://feishu.cn/docx/{token}
   const tokenMatch = url.match(/\/docx\/([a-zA-Z0-9]+)/);
   return tokenMatch ? tokenMatch[1]! : null;
 }


### PR DESCRIPTION
## 实战 bug

PR #122/#123 上线后用户实测：
- bootstrap log 显示 docToken 写入成功
- 但后续每个 skill 都 `core-doc: no core doc found, skip appendMilestone`
- archive Tier-1 也吃不到核心文档

无法从现有日志判断是 server filter 列名问题 / read-after-write 索引延迟 / 还是别的。

## 修复

### 加诊断日志
`info` 级日志输出：
- totalRecords（server filter 返回多少条）
- coreDocCandidates（其中多少条匹配 [核心文档] 前缀）
- sampleContents（前 3 条 content 前缀，看实际存储的是什么）

### Server filter fallback
server filter 返回 0 条 records → 怀疑列名不匹配 → fallback 拉全量（pageSize 200）+ 客户端按 chat_id 过滤。

server filter 有 records 但 0 个 [核心文档] → 真没有核心文档，不 fallback（避免不必要的全表扫描）。

## Test plan

- [x] 173 skills + 300 bot tests 通过
- [x] typecheck + lint 全绿
- [ ] 实战 retest：merge 后重启 dev，看日志能不能定位问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)