### PR TITLE
fix(core-doc/archive): FEISHU_URL_RE 正则 bug 真修复（PR #130 漏了）

### DIFF
--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -38,7 +38,10 @@ import {
 const TRIGGER_RE = /复盘|归档|项目结束|收尾|准备交付/i;
 
 // 飞书域名 URL 提取（docs / wiki / lark / sheets / bitable）
-const FEISHU_URL_RE = /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/g;
+// 注意：`[^\s)>]*`（不是 `+`）—— 必须允许域名前 0 字符，否则
+// `https://feishu.cn/...`（无 tenant 子域）不会被匹配。
+const FEISHU_URL_RE =
+  /https?:\/\/[^\s)>]*(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/g;
 
 const CORE_DOC_PREFIX_RE = /^\[核心文档\]/;
 const CORE_DOC_TOKEN_RE = /\/docx\/([a-zA-Z0-9]+)/;

--- a/packages/skills/src/core-doc.ts
+++ b/packages/skills/src/core-doc.ts
@@ -40,7 +40,10 @@ export interface BlockerEntry {
   readonly source?: string;
 }
 
-const FEISHU_URL_RE = /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/;
+// 注意：`[^\s)>]*`（不是 `+`）—— 必须允许域名前 0 字符，否则
+// `https://feishu.cn/...`（无 tenant 子域）不会被匹配。
+const FEISHU_URL_RE =
+  /https?:\/\/[^\s)>]*(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/;
 
 /**
  * 从 memory 找到当前 chatId 的核心文档 docToken。找不到返回 null。


### PR DESCRIPTION
## 实战 bug

PR #130 上线后用户实测：bootstrap 写了 [核心文档] memory，server filter 找到 candidate，但 URL 提取仍然返回 null。

跑 `probe-core-doc-memory.ts` 直接读 memory 表，看到内容完全正常：
`[核心文档] 项目核心文档 - 本群\nhttps://feishu.cn/docx/Nb87...`

**根因**：`FEISHU_URL_RE` 的 `[^\s)>]+` 量词要求 `https://` 后**至少 1 个字符**才能接 `feishu.cn`。但 `docx-client.create()` 返回的 URL 是 `https://feishu.cn/docx/{token}`（无 tenant 子域，中间 0 字符），永远不匹配。

requirementDoc / slides 的 URL 形如 `https://jcneyh7qlo8i.feishu.cn/...` 带 tenant 子域，所以那些都能匹配。**只有 onboarding 自己 bootstrap 的核心文档 URL 撞了这个 bug**。

## 修复

`+` → `*`：允许 `https://` 后 0 字符。

```diff
-  /https?:\/\/[^\s)>]+(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/
+  /https?:\/\/[^\s)>]*(?:feishu\.cn|larksuite\.com|larkoffice\.com)[^\s)>]*/
```

## 为什么 PR #130 漏掉

我 push 这个修复时 PR #130 已经被 merge 了（merge commit 只含第一个 commit），后续的 regex fix commit 留在了已合并的 dead branch 上。

## Test plan

- [x] 本地 typecheck + 470 tests 全过
- [x] 本地 probe 直查 memory 表，确认修复后 URL match + docx token 都正确解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)