### PR TITLE
fix(core-doc): 修 3 个生产级 bug（PR #132 漏了的）

### DIFF
--- a/packages/bot/src/docx-client.ts
+++ b/packages/bot/src/docx-client.ts
@@ -311,8 +311,10 @@ export class LarkDocxClient implements DocxClient {
     // 1. 列出 doc 顶层 children
     let children: Array<{ block_id?: string; block_type?: number; heading2?: { elements?: Array<{ text_run?: { content?: string } }> } }> = [];
     try {
-      const res = await (this.client.docx.v1.documentBlockChildren as any).list({
-        path: { document_id: docToken, block_id: docToken },
+      // SDK 命名空间正确路径：documentBlock.list 不是 documentBlockChildren.list
+      // documentBlockChildren 只有 batchDelete + create，没 list
+      const res = await (this.client.docx.v1.documentBlock as any).list({
+        path: { document_id: docToken },
         params: { page_size: 200 },
       });
       if (res.code !== 0) {
@@ -363,10 +365,16 @@ export class LarkDocxClient implements DocxClient {
       }
     });
 
+    // 实测：飞书 documentBlockChildren.create 的 index 语义是
+    // "在第 N 个 child 之后插入"（0-based），不是 "插入到位置 N"。
+    // 想插到 nextH2Idx 之前 = 在 nextH2Idx-1 之后插入 → index = nextH2Idx - 1。
+    // 对 last section（nextH2Idx = children.length）也成立 —— 插入到最后一个
+    // block 之后 = append 到末尾。
+    const insertIndex = nextH2Idx - 1;
     try {
       const res = await (this.client.docx.v1.documentBlockChildren as any).create({
         path: { document_id: docToken, block_id: docToken },
-        data: { children: childrenPayload, index: nextH2Idx },
+        data: { children: childrenPayload, index: insertIndex },
       });
       if (res.code !== 0) {
         return err(
@@ -381,123 +389,20 @@ export class LarkDocxClient implements DocxClient {
   }
 
   /**
-   * 用新 blocks 替换某个 H2 section 下的所有内容（issue #120）。
+  /**
+   * "替换" section 内容（issue #120）。
    *
-   * 步骤：
-   *   1. 列出 doc 顶层 children
-   *   2. 找 sectionTitle 对应的 H2 index
-   *   3. 找下一个 H2 index（或 children 长度，如果是最后一段）
-   *   4. 收集 [sectionIdx + 1, nextH2Idx) 之间的 block_ids
-   *   5. batchDelete 这些 block
-   *   6. documentBlockChildren.create with index = sectionIdx + 1 插入新 blocks
+   * 当前实现退化为 appendToSection —— 飞书 batchDelete 索引语义和 SDK 文档
+   * 不一致（实测会删错 block：start=N, end=N+1 实际删了 block N+1 而非 N），
+   * 先用 append 累积模式保稳定。复赛后 follow-up 用 documentBlock.batchUpdate
+   * 实现真正的 in-place rewrite。
    */
   async replaceSection(
     docToken: string,
     sectionTitle: string,
     blocks: readonly DocBlock[],
   ): Promise<Result<void>> {
-    // 1 + 2 + 3：列 children，找 section 边界
-    let children: Array<{
-      block_id?: string;
-      block_type?: number;
-      heading2?: { elements?: Array<{ text_run?: { content?: string } }> };
-    }> = [];
-    try {
-      const res = await (this.client.docx.v1.documentBlockChildren as any).list({
-        path: { document_id: docToken, block_id: docToken },
-        params: { page_size: 200 },
-      });
-      if (res.code !== 0) {
-        return err(makeError(ErrorCode.FEISHU_API_ERROR, `replaceSection list failed: ${res.msg}`));
-      }
-      children = res.data?.items ?? [];
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return err(makeError(ErrorCode.FEISHU_API_ERROR, `replaceSection list error: ${msg}`, e));
-    }
-
-    let sectionIdx = -1;
-    let nextH2Idx = children.length;
-    for (let i = 0; i < children.length; i++) {
-      const c = children[i]!;
-      if (c.block_type === 4) {
-        const txt = c.heading2?.elements?.[0]?.text_run?.content ?? '';
-        if (sectionIdx < 0 && txt === sectionTitle) {
-          sectionIdx = i;
-        } else if (sectionIdx >= 0) {
-          nextH2Idx = i;
-          break;
-        }
-      }
-    }
-    if (sectionIdx < 0) {
-      return err(
-        makeError(ErrorCode.INVALID_INPUT, `replaceSection: section "${sectionTitle}" not found`),
-      );
-    }
-
-    // 4: 收集要删除的 block_ids（section H2 之后，next H2 之前）
-    const toDelete: string[] = [];
-    for (let i = sectionIdx + 1; i < nextH2Idx; i++) {
-      const id = children[i]?.block_id;
-      if (id) toDelete.push(id);
-    }
-
-    // 5: batchDelete（如果有要删的）
-    if (toDelete.length > 0) {
-      try {
-        const delRes = await (this.client.docx.v1.documentBlockChildren as any).batchDelete({
-          path: { document_id: docToken, block_id: docToken },
-          data: { start_index: sectionIdx + 1, end_index: nextH2Idx },
-        });
-        if (delRes.code !== 0) {
-          return err(
-            makeError(
-              ErrorCode.FEISHU_API_ERROR,
-              `replaceSection batchDelete failed: ${delRes.msg}`,
-            ),
-          );
-        }
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return err(
-          makeError(ErrorCode.FEISHU_API_ERROR, `replaceSection batchDelete error: ${msg}`, e),
-        );
-      }
-    }
-
-    // 6: 插入新 blocks（如果有）
-    const safeBlocks = blocks.filter((b) => b.text && b.text.trim().length > 0);
-    if (safeBlocks.length === 0) return ok(undefined);
-
-    const childrenPayload = safeBlocks.map((block) => {
-      switch (block.type) {
-        case 'heading1':
-          return { block_type: 3, heading1: { elements: [{ text_run: { content: block.text } }] } };
-        case 'heading2':
-          return { block_type: 4, heading2: { elements: [{ text_run: { content: block.text } }] } };
-        case 'paragraph':
-          return { block_type: 2, text: { elements: [{ text_run: { content: block.text } }] } };
-        case 'bullet':
-          return { block_type: 12, bullet: { elements: [{ text_run: { content: block.text } }] } };
-      }
-    });
-
-    try {
-      const res = await (this.client.docx.v1.documentBlockChildren as any).create({
-        path: { document_id: docToken, block_id: docToken },
-        data: { children: childrenPayload, index: sectionIdx + 1 },
-      });
-      if (res.code !== 0) {
-        return err(
-          makeError(ErrorCode.FEISHU_API_ERROR, `replaceSection insert failed: ${res.msg}`),
-        );
-      }
-      return ok(undefined);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return err(makeError(ErrorCode.FEISHU_API_ERROR, `replaceSection insert error: ${msg}`, e));
-    }
+    return this.appendToSection(docToken, sectionTitle, blocks);
   }
 
   /**
@@ -510,11 +415,11 @@ export class LarkDocxClient implements DocxClient {
   async renameTitle(docToken: string, newTitle: string): Promise<Result<void>> {
     if (!newTitle.trim()) return ok(undefined);
 
-    // 找首个 H1 block_id
+    // 找首个 H1 block_id（用 documentBlock.list 不是 documentBlockChildren.list）
     let h1BlockId: string | undefined;
     try {
-      const res = await (this.client.docx.v1.documentBlockChildren as any).list({
-        path: { document_id: docToken, block_id: docToken },
+      const res = await (this.client.docx.v1.documentBlock as any).list({
+        path: { document_id: docToken },
         params: { page_size: 50 },
       });
       if (res.code !== 0) {

--- a/packages/bot/src/onboarding.ts
+++ b/packages/bot/src/onboarding.ts
@@ -81,10 +81,11 @@ export const CORE_DOC_SECTIONS = [
 export type CoreDocSection = (typeof CORE_DOC_SECTIONS)[number];
 
 /**
- * 初始化的核心文档 blocks。每个 section 一个 H2 + 一个引导性 placeholder。
+ * 初始化的核心文档 blocks。
  *
- * Placeholder 文案是有意写的"提示性占位"而非空文字 —— 让用户翻文档时
- * 一眼就知道每段会被什么 skill 填充，而不是看到一堆空段以为坏了。
+ * 每个 section 只有 H2 标题（不含 placeholder paragraph）—— skill 后续
+ * append 内容到对应 H2 下方。这样规避 feishu batchDelete 索引语义模糊
+ * 问题，所有 section 都用纯 append 模式，简单稳定。
  */
 function buildCoreDocInitialBlocks(chatName: string, createdAtIso: string): DocBlock[] {
   return [
@@ -93,66 +94,16 @@ function buildCoreDocInitialBlocks(chatName: string, createdAtIso: string): DocB
       type: 'paragraph',
       text: `${chatName} · 由 Lark Loom 自动维护 · 创建于 ${createdAtIso}`,
     },
-
     { type: 'heading2', text: '🎯 项目 OKR' },
-    {
-      type: 'paragraph',
-      text: '（待补充。发送项目需求后，O / KR 会从需求文档中自动提取。）',
-    },
-
     { type: 'heading2', text: '一句话定义' },
-    {
-      type: 'paragraph',
-      text: '（待补充。需求文档生成后会自动填入项目核心价值描述。）',
-    },
-
     { type: 'heading2', text: '项目状态' },
-    {
-      type: 'paragraph',
-      text: `健康度：✅ 进行中 · 最后更新：${createdAtIso} · 这周重点：尚未明确`,
-    },
-
     { type: 'heading2', text: '项目背景与目标' },
-    {
-      type: 'paragraph',
-      text: '（待补充。需求文档生成后会综合成 100-150 字的项目叙述。）',
-    },
-
     { type: 'heading2', text: '关键决策' },
-    {
-      type: 'paragraph',
-      text: '（待补充。每次会议纪要识别到决策时，会综合成 ADR-style 段落，含「演变路径」。）',
-    },
-
     { type: 'heading2', text: '已交付产出' },
-    {
-      type: 'paragraph',
-      text: '（PRD / 演示 PPT / 汇报分工文稿 / 任务表生成后会自动列出。）',
-    },
-
     { type: 'heading2', text: '👥 干系人 / 团队' },
-    {
-      type: 'paragraph',
-      text: '（群成员列表 + 角色分配。可在群里 @bot 主动声明角色。）',
-    },
-
     { type: 'heading2', text: '⚠️ 阻塞与风险' },
-    {
-      type: 'paragraph',
-      text: '（任务被标 blocked 或会议纪要中识别到风险时自动汇总。）',
-    },
-
     { type: 'heading2', text: '📋 GRAI 复盘' },
-    {
-      type: 'paragraph',
-      text: '（项目结束触发归档时，按 Goal / Result / Analysis / Improvement 四段填入。）',
-    },
-
     { type: 'heading2', text: '最近动态' },
-    {
-      type: 'paragraph',
-      text: '（最近 10 条事件按时间正序排列。）',
-    },
   ];
 }
 


### PR DESCRIPTION
## 实战 E2E smoke 抓到 3 个生产级 bug

PR #132 merge 时这些 fix commit 还没 push（push 晚了 46 分钟），所以漏了。

用户现在去飞书测会发现：
- 核心文档创建后 **完全不迭代**（用户已经反映过这个，原以为 #132 修了，实际没修）
- 即便有内容，也会出现在错误的 section 下面
- replaceSection 看似工作但实际没删旧内容

## Bug 1: SDK 命名空间错

`client.docx.v1.documentBlockChildren.list` —— **该方法不存在**。
该 namespace 只有 batchDelete + create。
正确路径：`client.docx.v1.documentBlock.list`。

后果：appendToSection / replaceSection 的 list 调用全部 silent 抛 TypeError，
被 try/catch 转 err，外层 warn 后继续。这就是用户报告的 "core doc no iteration" 真因。

## Bug 2: index 语义错

`documentBlockChildren.create` 的 `index: N` 不是 "插入到位置 N"，
是 "在第 N 个 child 之后插入"。差 1 位 → 内容插到下一个 section 下面。

修：`insertIndex = nextH2Idx - 1`。

## Bug 3: batchDelete 索引语义不可靠

实测会删错 block。time 紧（复赛今天），先把 replaceSection 退化成
appendToSection 保稳定，复赛后用 documentBlock.batchUpdate 做真正 in-place rewrite。

## 配套调整

bootstrap 简化：每个 section 只 H2 不带 placeholder paragraph。
否则 placeholder 永远删不掉会污染。

## 实测验证

E2E smoke 跑完整 flow，每个 section 内容都在正确位置，标题改名成功。

## Test plan
- [x] typecheck + 183 skills + 300 bot tests 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)