### PR TITLE
fix(docx): renameTitle 改根 page block 而不是 H1

### DIFF
--- a/packages/bot/src/docx-client.ts
+++ b/packages/bot/src/docx-client.ts
@@ -408,43 +408,24 @@ export class LarkDocxClient implements DocxClient {
   /**
    * 改文档标题（issue #120 P6）。
    *
-   * 飞书 docx：文档显示的标题来自首个 H1 block 的内容。改 H1 = 改标题。
-   * 步骤：list 顶层 children → 找首个 block_type === 3 (heading1) → batchUpdate
-   * 把它的 elements 改成 [{ text_run: { content: newTitle } }]。
+   * 飞书 docx：**文件名（Drive metadata.title）来自根 block（block_type=1
+   * "page"）的 elements**，不是第一个 H1 block。改 H1 只改 doc 内显示，
+   * 不会同步到 Drive 文件名。改根 block 才能真正改文件名。
+   *
+   * E2E 实测验证：documentBlock.batchUpdate with block_id = document_id
+   * 立刻让 Drive metadata.title 同步成新值。
    */
   async renameTitle(docToken: string, newTitle: string): Promise<Result<void>> {
     if (!newTitle.trim()) return ok(undefined);
 
-    // 找首个 H1 block_id（用 documentBlock.list 不是 documentBlockChildren.list）
-    let h1BlockId: string | undefined;
-    try {
-      const res = await (this.client.docx.v1.documentBlock as any).list({
-        path: { document_id: docToken },
-        params: { page_size: 50 },
-      });
-      if (res.code !== 0) {
-        return err(makeError(ErrorCode.FEISHU_API_ERROR, `renameTitle list failed: ${res.msg}`));
-      }
-      const items =
-        (res.data?.items ?? []) as Array<{ block_id?: string; block_type?: number }>;
-      const h1 = items.find((c) => c.block_type === 3);
-      h1BlockId = h1?.block_id;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return err(makeError(ErrorCode.FEISHU_API_ERROR, `renameTitle list error: ${msg}`, e));
-    }
-    if (!h1BlockId) {
-      return err(makeError(ErrorCode.INVALID_INPUT, 'renameTitle: no H1 block found'));
-    }
-
-    // batchUpdate 改 H1 文本
     try {
       const res = await (this.client.docx.v1.documentBlock as any).batchUpdate({
         path: { document_id: docToken },
         data: {
           requests: [
             {
-              block_id: h1BlockId,
+              // block_id == document_id 就是根 page block（飞书内部叫 page block）
+              block_id: docToken,
               update_text_elements: {
                 elements: [{ text_run: { content: newTitle } }],
               },


### PR DESCRIPTION
## 用户实战 bug

PR #132 上线后用户实测：requirementDoc 完成后核心文档**文件名没变**。

## E2E 直跑真飞书 API 找到根因

之前以为：飞书 docx 文件名 = 首个 H1 block。**错的**。

实测：
- H1 (block_type 3) 只是文档内的 heading
- 文件名（Drive metadata.title）由 **根 block (block_id == document_id, block_type 1 "page")** 决定
- 改 H1 不会同步到 Drive metadata（等 15s 都不变）
- 改 page block 立刻同步（< 3 秒）

## 修复

`renameTitle` 改 root page block 而不是首个 H1：

```ts
{ block_id: docToken,  // 不是 H1 block id
  update_text_elements: {...} }
```

## 验证

E2E 真 API smoke：
- ✓ create doc + renameTitle → Drive metadata.title 立刻变 "✅ 新标题已生效 - 核心文档"
- ✗ 之前的 H1-based 实现：Drive title 永远不变

## 顺便：pinMessage 失败原因

pinMessage 代码本身正确。用户实测失败是**飞书应用没开权限** —— 错误码 99991672：

> Access denied. One of the following scopes is required: `[im:chat, im:chat.top_notice:write_only]`

需要去飞书开放平台给应用开权限。代码不需要改。

## Test plan

- [x] typecheck + 305 bot + 183 skills tests 全过
- [x] 真 API E2E 验证 rename 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)