### PR TITLE
fix(bot-runtime): 加 backfill 兜底循环，治 WSClient 长连接漏推消息 (closes #86)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ LARK_ENCRYPT_KEY=
 # 日志级别（可选）：debug | info | warn | error
 LARK_LOG_LEVEL=info
 
+# bot WSClient 长连接漏推消息时的兜底轮询间隔（毫秒，默认 30000）
+# 增大省 API 配额，减小恢复速度更快；issue #86
+BOT_BACKFILL_INTERVAL_MS=30000
+
+# 单次 backfill 每群拉多少条消息（默认 20）
+BOT_BACKFILL_PAGE_SIZE=20
+
 # 火山方舟 LLM（Doubao）
 # API Key → 火山方舟控制台 / API Key 管理
 ARK_API_KEY=

--- a/packages/bot/src/__tests__/bot-runtime.test.ts
+++ b/packages/bot/src/__tests__/bot-runtime.test.ts
@@ -8,6 +8,7 @@ const mockMessageCreate = vi.fn();
 const mockMessageReply = vi.fn();
 const mockMessagePatch = vi.fn();
 const mockMessageList = vi.fn();
+const mockChatList = vi.fn();
 const mockChatMembersGet = vi.fn();
 const mockWsStart = vi.fn();
 const mockWsClose = vi.fn();
@@ -26,6 +27,9 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
             reply: mockMessageReply,
             patch: mockMessagePatch,
             list: mockMessageList,
+          },
+          chat: {
+            list: mockChatList,
           },
           v1: {
             chatMembers: {
@@ -346,5 +350,320 @@ describe('LarkBotRuntime', () => {
     expect(event.payload.user.userId).toBe('ou_user1');
     expect(event.payload.value).toEqual({ action: 'qa.reanswer', questionMessageId: 'msg_1' });
     await expect(actionHandler({})).resolves.toBeUndefined();
+  });
+});
+
+// ─── issue #86: backfill 兜底 ────────────────────────────────────────────────
+
+import { LRUSet, LarkBotRuntime as Runtime } from '../bot-runtime.js';
+
+describe('LRUSet', () => {
+  it('refreshes recency on re-add and evicts oldest at capacity', () => {
+    const s = new LRUSet<string>(3);
+    expect(s.add('a')).toBe(true);
+    expect(s.add('b')).toBe(true);
+    expect(s.add('c')).toBe(true);
+    expect(s.size()).toBe(3);
+    // re-add 'a' 刷新它的位置，下次淘汰应该淘汰 'b'
+    expect(s.add('a')).toBe(false);
+    expect(s.add('d')).toBe(true);
+    expect(s.has('a')).toBe(true);
+    expect(s.has('b')).toBe(false);
+    expect(s.has('c')).toBe(true);
+    expect(s.has('d')).toBe(true);
+  });
+
+  it('throws when capacity <= 0', () => {
+    expect(() => new LRUSet(0)).toThrow();
+  });
+});
+
+describe('LarkBotRuntime.backfillOnce()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegister.mockReturnValue(mockDispatcherInstance);
+    mockWsStart.mockResolvedValue(undefined);
+  });
+
+  function makeBackfillRuntime(): Runtime {
+    return new Runtime({
+      appId: 'app_id',
+      appSecret: 'app_secret',
+      backfillIntervalMs: 999_999, // 不让定时器在测试里自动跑
+      backfillPageSize: 10,
+    });
+  }
+
+  function listItem(id: string, chatId: string, ts: number, text = 'hi'): Record<string, unknown> {
+    return {
+      message_id: id,
+      chat_id: chatId,
+      chat_type: 'group',
+      message_type: 'text',
+      body: { content: JSON.stringify({ text }) },
+      create_time: String(ts),
+      mentions: [],
+      sender: { id: { open_id: 'ou_x', union_id: 'uid_x' } },
+    };
+  }
+
+  it('seed mode on first sight: populates seenIds + lastSeenAt but does NOT emit', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+
+    mockChatList.mockResolvedValue({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_old' }] },
+    });
+    mockMessageList.mockResolvedValue({
+      code: 0,
+      data: { items: [listItem('msg_old_1', 'oc_old', 1700000000000)] },
+    });
+
+    await runtime.backfillOnce();
+
+    expect(handler).not.toHaveBeenCalled();
+    // 第二次拉同群应当带上 since（lastSeenAt 已写入）
+    mockMessageList.mockClear();
+    mockMessageList.mockResolvedValue({ code: 0, data: { items: [] } });
+    await runtime.backfillOnce();
+    const params = mockMessageList.mock.calls[0]![0].params;
+    expect(params.start_time).toBeDefined();
+  });
+
+  it('emits messages in subsequent runs that are not in seenIds', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+
+    // seed
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_a' }] },
+    });
+    mockMessageList.mockResolvedValueOnce({ code: 0, data: { items: [] } });
+    await runtime.backfillOnce();
+    expect(handler).not.toHaveBeenCalled();
+
+    // 第二次：返回 2 条新消息
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_a' }] },
+    });
+    mockMessageList.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          listItem('msg_1', 'oc_a', 1700000001000, 'one'),
+          listItem('msg_2', 'oc_a', 1700000002000, 'two'),
+        ],
+      },
+    });
+    await runtime.backfillOnce();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    const ids = (handler as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => (c[0] as { payload: { messageId: string } }).payload.messageId,
+    );
+    expect(ids).toEqual(['msg_1', 'msg_2']);
+  });
+
+  it('does NOT re-emit messages already pushed via WS', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+    await runtime.start();
+
+    // WS 推一条
+    const registered = mockRegister.mock.calls[0]![0] as Record<
+      string,
+      (data: unknown) => Promise<unknown>
+    >;
+    await registered['im.message.receive_v1']!({
+      sender: { sender_id: { open_id: 'ou_x' } },
+      message: {
+        message_id: 'msg_ws',
+        chat_id: 'oc_ws',
+        chat_type: 'group',
+        message_type: 'text',
+        content: JSON.stringify({ text: 'from ws' }),
+        create_time: '1700000005000',
+        mentions: [],
+      },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    (handler as ReturnType<typeof vi.fn>).mockClear();
+
+    // backfill 返回同一条消息 + 一条新的
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_ws' }] },
+    });
+    mockMessageList.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          listItem('msg_ws', 'oc_ws', 1700000005000, 'from ws'),
+          listItem('msg_new', 'oc_ws', 1700000006000, 'new one'),
+        ],
+      },
+    });
+    await runtime.backfillOnce();
+
+    // 只有 msg_new 被 emit
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = (handler as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      payload: { messageId: string };
+    };
+    expect(event.payload.messageId).toBe('msg_new');
+
+    await runtime.stop();
+  });
+
+  it('continues when one chat fails: other chats still backfill', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+
+    // 把 oc_a seed 过了；oc_b 是新群
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_a' }] },
+    });
+    mockMessageList.mockResolvedValueOnce({ code: 0, data: { items: [] } });
+    await runtime.backfillOnce();
+
+    // 第二次：oc_a 成功（有 1 条新），oc_b 失败
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_a' }, { chat_id: 'oc_b' }] },
+    });
+    mockMessageList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [listItem('msg_a1', 'oc_a', 1700000001000)] },
+      })
+      .mockResolvedValueOnce({ code: 99991401, msg: 'rate limited' });
+    await runtime.backfillOnce();
+
+    // oc_a 那条成功 emit，oc_b 失败但不阻断
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('chat.list failure aborts iteration but does not throw', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+
+    mockChatList.mockResolvedValueOnce({ code: 99991401, msg: 'rate limited' });
+
+    await expect(runtime.backfillOnce()).resolves.toBeUndefined();
+    expect(handler).not.toHaveBeenCalled();
+    expect(mockMessageList).not.toHaveBeenCalled();
+  });
+
+  it('bot-added event triggers immediate backfill', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+    await runtime.start();
+
+    mockChatList.mockResolvedValue({ code: 0, data: { items: [{ chat_id: 'oc_new' }] } });
+    mockMessageList.mockResolvedValue({
+      code: 0,
+      data: { items: [listItem('msg_seed', 'oc_new', 1700000000000)] },
+    });
+
+    const registered = mockRegister.mock.calls[0]![0] as Record<
+      string,
+      (data: unknown) => Promise<unknown>
+    >;
+    await registered['im.chat.member.bot.added_v1']!({
+      chat_id: 'oc_new',
+      operator_id: { open_id: 'ou_inviter' },
+    });
+
+    // 让 fire-and-forget 的 backfillOnce 跑完
+    await new Promise((r) => setTimeout(r, 0));
+
+    // botJoinedChat 事件 emit 1 次（同步）；backfill seed 模式不再 emit
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mockChatList).toHaveBeenCalled();
+
+    await runtime.stop();
+  });
+
+  it('integration: seed [old, new], second run discovers 2 backfill messages in new chat (no dupe with WS)', async () => {
+    const runtime = makeBackfillRuntime();
+    const handler: EventHandler = vi.fn();
+    runtime.on(handler);
+    await runtime.start();
+
+    // seed：两个群都已知，无新消息
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_old' }, { chat_id: 'oc_new' }] },
+    });
+    mockMessageList
+      .mockResolvedValueOnce({ code: 0, data: { items: [] } })
+      .mockResolvedValueOnce({ code: 0, data: { items: [] } });
+    await runtime.backfillOnce();
+    expect(handler).not.toHaveBeenCalled();
+
+    // 模拟 WS 推一条 oc_old 的消息（已被 seen 标记）
+    const registered = mockRegister.mock.calls[0]![0] as Record<
+      string,
+      (data: unknown) => Promise<unknown>
+    >;
+    await registered['im.message.receive_v1']!({
+      sender: { sender_id: { open_id: 'ou_old' } },
+      message: {
+        message_id: 'msg_ws_dup',
+        chat_id: 'oc_old',
+        chat_type: 'group',
+        message_type: 'text',
+        content: JSON.stringify({ text: 'old via ws' }),
+        create_time: '1700000010000',
+        mentions: [],
+      },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // 第二次 backfill：oc_old 拉到 ws 那条 + 1 条更新的；oc_new 拉到 2 条新
+    mockChatList.mockResolvedValueOnce({
+      code: 0,
+      data: { items: [{ chat_id: 'oc_old' }, { chat_id: 'oc_new' }] },
+    });
+    mockMessageList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            listItem('msg_ws_dup', 'oc_old', 1700000010000),
+            listItem('msg_old_new', 'oc_old', 1700000011000),
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            listItem('msg_new_1', 'oc_new', 1700000012000),
+            listItem('msg_new_2', 'oc_new', 1700000013000),
+          ],
+        },
+      });
+    await runtime.backfillOnce();
+
+    // 期望：handler 总共被调 4 次：
+    //   1 次 WS 推（msg_ws_dup） + 0 次 dupe + 1 次 msg_old_new + 2 次 msg_new_*
+    expect(handler).toHaveBeenCalledTimes(4);
+    const ids = (handler as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => (c[0] as { payload: { messageId: string } }).payload.messageId,
+    );
+    expect(ids).toEqual(['msg_ws_dup', 'msg_old_new', 'msg_new_1', 'msg_new_2']);
+
+    await runtime.stop();
   });
 });

--- a/packages/bot/src/bot-runtime.ts
+++ b/packages/bot/src/bot-runtime.ts
@@ -78,6 +78,45 @@ class RateLimiter {
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * 简易 LRU Set —— 用于 backfill 去重。
+ *
+ * 容量满时淘汰最久未 add 的元素。Map 的插入顺序天然就是 access 顺序（每次 add 已存在
+ * 元素时会 delete + set 重新插到末尾），所以 keys().next() 拿到的就是最旧的那个。
+ */
+export class LRUSet<T> {
+  private readonly capacity: number;
+  private readonly map = new Map<T, true>();
+
+  constructor(capacity: number) {
+    if (capacity <= 0) throw new Error('LRUSet capacity must be > 0');
+    this.capacity = capacity;
+  }
+
+  has(item: T): boolean {
+    return this.map.has(item);
+  }
+
+  /** 返回 true 表示是新加的，false 表示已存在（recency 已刷新） */
+  add(item: T): boolean {
+    if (this.map.has(item)) {
+      this.map.delete(item);
+      this.map.set(item, true);
+      return false;
+    }
+    this.map.set(item, true);
+    if (this.map.size > this.capacity) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+    return true;
+  }
+
+  size(): number {
+    return this.map.size;
+  }
+}
+
 function parseMsgType(raw: string): MessageContentType {
   const map: Record<string, MessageContentType> = {
     text: 'text',
@@ -152,6 +191,35 @@ function parseMessage(data: Record<string, unknown>): Message {
   };
 }
 
+/**
+ * 把 im.message.list / chat-history API 返回的 item 转为 Message。
+ *
+ * im.message.list 的 item 字段名跟 receive_v1 不同（content 在 body.content / sender.id
+ * 直接挂 sender 上 / 等等），这里把它对齐到 parseMessage 期望的 receive_v1 形状。
+ */
+function parseListItem(item: Record<string, unknown>): Message {
+  const sender = (item.sender as Record<string, unknown> | undefined) ?? {};
+  const senderId = (sender.id as Record<string, unknown> | undefined) ?? {};
+  return parseMessage({
+    message: {
+      message_id: item.message_id,
+      chat_id: item.chat_id,
+      chat_type: item.chat_type,
+      message_type: item.message_type ?? item.msg_type,
+      content: item.body ? (item.body as Record<string, unknown>).content : item.content,
+      create_time: item.create_time,
+      mentions: item.mentions ?? [],
+      parent_id: item.parent_id,
+    },
+    sender: {
+      sender_id: {
+        open_id: senderId.open_id ?? (sender.id as string | undefined),
+        union_id: senderId.union_id,
+      },
+    },
+  });
+}
+
 function parseCardAction(data: Record<string, unknown>): CardAction {
   const context = (data.context ?? {}) as Record<string, unknown>;
   const action = (data.action ?? {}) as Record<string, unknown>;
@@ -196,6 +264,15 @@ export class LarkBotRuntime implements BotRuntime {
   /** patchCard 节流：messageId → 上次 patch 完成的时间 */
   private readonly patchTimes = new Map<string, number>();
 
+  // ─── issue #86: backfill 兜底（WSClient 长连接漏推消息时的轮询补救）
+  /** 已经被 emit 过的 messageId（无论来源是 WS 还是 backfill），防止 backfill 重复 emit */
+  private readonly seenMessageIds: LRUSet<string>;
+  /** chatId → 该群最后已知消息时间戳（毫秒）；下次 backfill 用作 since 起点 */
+  private readonly lastSeenAt = new Map<string, number>();
+  private backfillTimer: NodeJS.Timeout | null = null;
+  private readonly backfillIntervalMs: number;
+  private readonly backfillPageSize: number;
+
   constructor(
     private readonly env: {
       appId: string;
@@ -205,6 +282,10 @@ export class LarkBotRuntime implements BotRuntime {
       logLevel?: lark.LoggerLevel;
       logger?: Logger;
       quotaTracker?: QuotaTracker;
+      /** 测试 / 显式覆盖：默认从 env 读 BOT_BACKFILL_INTERVAL_MS / BOT_BACKFILL_PAGE_SIZE */
+      backfillIntervalMs?: number;
+      backfillPageSize?: number;
+      seenIdsCapacity?: number;
     },
   ) {
     this.client = new lark.Client({
@@ -219,6 +300,11 @@ export class LarkBotRuntime implements BotRuntime {
     this.tracker = env.quotaTracker ?? globalQuotaTracker;
     this.limiter = new RateLimiter(this.tracker);
     this.logger = env.logger;
+    this.backfillIntervalMs =
+      env.backfillIntervalMs ?? (Number(process.env['BOT_BACKFILL_INTERVAL_MS']) || 30_000);
+    this.backfillPageSize =
+      env.backfillPageSize ?? (Number(process.env['BOT_BACKFILL_PAGE_SIZE']) || 20);
+    this.seenMessageIds = new LRUSet<string>(env.seenIdsCapacity ?? 1000);
   }
 
   /** 暴露给测试 / 监控用，运行时可读取当前配额观测。 */
@@ -250,16 +336,18 @@ export class LarkBotRuntime implements BotRuntime {
       }).register({
         'im.message.receive_v1': async (data) => {
           const msg = parseMessage(data as unknown as Record<string, unknown>);
+          this.markMessageSeen(msg);
           this.emit({ type: 'message', payload: msg });
           return { code: 0 };
         },
         'im.chat.member.bot.added_v1': async (data) => {
           const d = data as unknown as Record<string, unknown>;
           const operatorId = (d.operator_id ?? {}) as Record<string, unknown>;
+          const chatId = (d.chat_id as string | undefined) ?? '';
           this.emit({
             type: 'botJoinedChat',
             payload: {
-              chatId: (d.chat_id as string | undefined) ?? '',
+              chatId,
               inviter: {
                 userId: (operatorId.open_id as string | undefined) ?? '',
                 ...((operatorId.union_id as string | undefined) !== undefined && {
@@ -269,6 +357,17 @@ export class LarkBotRuntime implements BotRuntime {
               timestamp: Date.now(),
             },
           });
+          // issue #86：bot 被拉进新群后 WS 长连接订阅集不会自动刷新，新群消息推不到
+          // 客户端。立即触发一次 backfill，把这个新群的最近消息从 HTTP API 拉回来。
+          // 不重连 WS（重连本身有丢事件窗口），只额外补一道 HTTP 兜底。
+          if (chatId) {
+            void this.backfillOnce().catch((e) => {
+              this.logger?.warn('[BotRuntime] immediate backfill on bot-added failed', {
+                chatId,
+                error: e instanceof Error ? e.message : String(e),
+              });
+            });
+          }
           return { code: 0 };
         },
         p2p_chat_create: async (data) => {
@@ -293,6 +392,8 @@ export class LarkBotRuntime implements BotRuntime {
 
       // WSClient.start() 是长期阻塞的，用 fire-and-forget 启动
       void this.wsClient.start({ eventDispatcher: dispatcher });
+      // issue #86：开 backfill 兜底循环（WS 漏推时定时从 HTTP API 拉回来）
+      this.startBackfillLoop();
       return ok(undefined);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -301,7 +402,166 @@ export class LarkBotRuntime implements BotRuntime {
   }
 
   async stop(): Promise<void> {
+    this.stopBackfillLoop();
     this.wsClient.close();
+  }
+
+  // ─── backfill (issue #86) ───────────────────────────────────────────────────
+
+  /**
+   * 标记某条消息已被 emit 过。WS 推 + backfill 拉都会调，避免后续 backfill 重复 emit。
+   */
+  private markMessageSeen(msg: Message): void {
+    if (msg.messageId) this.seenMessageIds.add(msg.messageId);
+    if (msg.chatId && msg.timestamp > 0) {
+      const prev = this.lastSeenAt.get(msg.chatId) ?? 0;
+      if (msg.timestamp > prev) this.lastSeenAt.set(msg.chatId, msg.timestamp);
+    }
+  }
+
+  /**
+   * 跑一次 backfill：列出 bot 所在的所有群，对每个群拉 lastSeenAt 之后的新消息，
+   * emit 没在 seenMessageIds 里的。第一次见到某个群时进 seed 模式，只把现有消息的 id
+   * 灌进去防止把历史消息当新消息 emit。
+   *
+   * 暴露为 public 是为了：1) 单元测试直接调；2) 在 bot 入群事件后立即触发一次。
+   */
+  async backfillOnce(): Promise<void> {
+    let chats: Array<{ chat_id?: string }> = [];
+    try {
+      const res = await (
+        this.client.im.chat as unknown as {
+          list: (p: unknown) => Promise<{
+            code?: number;
+            msg?: string;
+            data?: { items?: Array<{ chat_id?: string }>; has_more?: boolean };
+          }>;
+        }
+      ).list({ params: { page_size: 100 } });
+      if (res.code !== 0) {
+        this.logger?.warn('[BotRuntime] backfill: chat.list failed', {
+          code: res.code,
+          msg: res.msg,
+        });
+        return;
+      }
+      chats = res.data?.items ?? [];
+    } catch (e) {
+      this.logger?.warn('[BotRuntime] backfill: chat.list threw', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return;
+    }
+
+    for (const chat of chats) {
+      const chatId = chat.chat_id;
+      if (!chatId) continue;
+      await this.backfillChat(chatId);
+    }
+  }
+
+  private async backfillChat(chatId: string): Promise<void> {
+    const since = this.lastSeenAt.get(chatId);
+    // 第一次见这个群：seed 模式，把现有消息灌进 seenMessageIds，但不 emit
+    const seedMode = since === undefined;
+
+    let res: {
+      code?: number;
+      msg?: string;
+      data?: { items?: Array<Record<string, unknown>>; has_more?: boolean };
+    };
+    try {
+      await this.limiter.acquire();
+      res = await (
+        this.client.im.message as unknown as {
+          list: (p: unknown) => Promise<typeof res>;
+        }
+      ).list({
+        params: {
+          container_id: chatId,
+          container_id_type: 'chat',
+          page_size: this.backfillPageSize,
+          ...(since !== undefined && { start_time: String(Math.floor(since / 1000)) }),
+          sort_type: 'ByCreateTimeAsc',
+        },
+      });
+    } catch (e) {
+      this.logger?.warn('[BotRuntime] backfill: message.list threw', {
+        chatId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return;
+    }
+
+    if (res.code !== 0) {
+      this.logger?.warn('[BotRuntime] backfill: message.list failed', {
+        chatId,
+        code: res.code,
+        msg: res.msg,
+      });
+      return;
+    }
+
+    const items = res.data?.items ?? [];
+    let maxTs = since ?? 0;
+    let emitted = 0;
+
+    for (const item of items) {
+      const messageId = item.message_id as string | undefined;
+      if (!messageId) continue;
+      if (this.seenMessageIds.has(messageId)) continue;
+
+      let parsed: Message;
+      try {
+        parsed = parseListItem(item);
+      } catch (e) {
+        this.logger?.warn('[BotRuntime] backfill: parseListItem failed', {
+          chatId,
+          messageId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        continue;
+      }
+
+      this.seenMessageIds.add(messageId);
+      if (parsed.timestamp > maxTs) maxTs = parsed.timestamp;
+
+      if (!seedMode) {
+        this.emit({ type: 'message', payload: parsed });
+        emitted += 1;
+      }
+    }
+
+    // 即便 items 为空也要把 lastSeenAt 推进到"现在"，否则下次 seedMode 还会再触发一遍
+    if (maxTs > 0) {
+      this.lastSeenAt.set(chatId, maxTs);
+    } else if (seedMode) {
+      this.lastSeenAt.set(chatId, Date.now());
+    }
+
+    if (emitted > 0) {
+      this.logger?.info('[BotRuntime] backfill recovered messages', { chatId, count: emitted });
+    }
+  }
+
+  private startBackfillLoop(): void {
+    if (this.backfillTimer) return;
+    this.backfillTimer = setInterval(() => {
+      void this.backfillOnce().catch((e) => {
+        this.logger?.warn('[BotRuntime] backfill iteration failed', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      });
+    }, this.backfillIntervalMs);
+    // 在 Node 里允许 process 在没有其它工作时仍然退出
+    if (typeof this.backfillTimer.unref === 'function') this.backfillTimer.unref();
+  }
+
+  private stopBackfillLoop(): void {
+    if (this.backfillTimer) {
+      clearInterval(this.backfillTimer);
+      this.backfillTimer = null;
+    }
   }
 
   async sendText(params: SendTextParams): Promise<Result<SentMessage>> {
@@ -434,29 +694,7 @@ export class LarkBotRuntime implements BotRuntime {
       }
 
       const items = res.data?.items ?? [];
-      const messages: Message[] = items.map((item) => {
-        // im.message.list 的 item 字段名与 receive_v1 不同，手动对齐
-        const sender = (item.sender as Record<string, unknown> | undefined) ?? {};
-        const senderId = (sender.id as Record<string, unknown> | undefined) ?? {};
-        return parseMessage({
-          message: {
-            message_id: item.message_id,
-            chat_id: item.chat_id,
-            chat_type: item.chat_type,
-            message_type: item.message_type ?? item.msg_type,
-            content: item.body ? (item.body as Record<string, unknown>).content : item.content,
-            create_time: item.create_time,
-            mentions: item.mentions ?? [],
-            parent_id: item.parent_id,
-          },
-          sender: {
-            sender_id: {
-              open_id: senderId.open_id ?? (sender.id as string | undefined),
-              union_id: senderId.union_id,
-            },
-          },
-        });
-      });
+      const messages: Message[] = items.map((item) => parseListItem(item));
 
       const nextPageToken = res.data?.page_token;
       return ok({


### PR DESCRIPTION
## Summary

实现 #86 推荐方案 A：在 `LarkBotRuntime` 里加周期性 backfill 循环，从 HTTP API 兜底拉群消息，治 WSClient 长连接的两种**静默丢消息**问题：

1. **新群订阅未刷新** — bot 启动后被拉进新群，长连接不会自动订阅新群
2. **WS 抖动重连** — 短暂断开窗口内的事件不重传

## 实现

### 核心数据结构

- `seenMessageIds: LRUSet<string>`（容量 1000）—— WS 推 + backfill 拉共用一个去重池
- `lastSeenAt: Map<chatId, ms>` —— 每群独立 since 起点，避免全量回扫

### Backfill 循环

```
每 30s（可配）：
  chats = im.chat.list({ page_size: 100 })
  for chat in chats:
    msgs = im.message.list(chat, start_time=lastSeenAt[chatId])
    for m in msgs if m.id not in seenMessageIds:
      seenMessageIds.add(m.id)
      lastSeenAt[chatId] = max(prev, m.timestamp)
      emit({ type: 'message', payload: m })  ← 仅在非 seed 模式
```

### Seed 模式

第一次见某 chatId 时：populate `seenMessageIds + lastSeenAt`，**不 emit**。避免 bot 重启时把所有历史消息当新消息 spam 出去。

### 顺手做方案 B

`im.chat.member.bot.added_v1` 事件触发立即 backfill（不重连 WS），新群被拉进来时不用等 30s 周期。

## 不做（按 #86 范围）

- ❌ webhook 模式（方案 C）—— 另开 issue
- ❌ 跨进程持久化 `lastSeenAt` / `seenMessageIds` —— MVP 进程内即可

## 配置

| Env | 默认 | 说明 |
|---|---|---|
| `BOT_BACKFILL_INTERVAL_MS` | 30000 | 兜底轮询间隔 |
| `BOT_BACKFILL_PAGE_SIZE` | 20 | 每群每轮最多拉多少条 |

构造器也支持显式覆盖（测试用）。

## 顺手清理

`fetchHistory` 里 33 行的 inline message.list → Message 字段对齐抽到 top-level `parseListItem` helper，backfill 直接复用，`fetchHistory` 主路径缩成 1 行。

## Test Plan

- `tsc -b packages/contracts packages/skills packages/bot`：0 error
- `vitest run`：**31 files / 497 tests passed**
- `eslint`：0 error

新增 9 个测试覆盖：
- **LRUSet**：recency 刷新 + 容量淘汰 + 边界
- **backfillOnce 8 个 case**：
  - seed 模式不 emit，但写 `lastSeenAt`
  - 后续 run emit 新消息
  - WS + backfill 同 messageId 不重复 emit
  - 单群失败不阻断其他群
  - `chat.list` 失败不抛
  - bot-added 事件触发立即 backfill
  - **integration happy path**：mock `[old, new]` 两群 + WS 推一条 + 第二轮 backfill 拉 4 条，断言总 emit 4 次（含核心去重断言）

## 影响面 & 风险

- **API 配额**：每 30s 1 次 chat.list + N 次 message.list（N = 群数）。100 req/min 限流下 N ≤ 49 安全。已用同一个 `RateLimiter` 排队，不会突击撞限。
- **进程退出**：`backfillTimer.unref()` 让 backfill 不阻止进程退出
- **重启**：seed 模式保证不会把历史消息当新消息 spam，但代价是重启后第一轮的丢失消息找不回来——这是 MVP 范围内可接受的折中

## Closes

#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)