### PR TITLE
fix(bot): 接入非 @ 历史指代消息的 recall 路由

### DIFF
--- a/packages/bot/src/__tests__/skill-router.test.ts
+++ b/packages/bot/src/__tests__/skill-router.test.ts
@@ -137,6 +137,31 @@ describe('progressUpdate', () => {
 });
 
 // ================================================================
+// recall（历史信息缺口主动召回，被动）
+// ================================================================
+describe('recall', () => {
+  it('pos: "上次 ... 来着" → recall', () => {
+    expect(router.route(plain('上次说徐坤负责什么来着？'))).toBe('recall');
+  });
+
+  it('pos: "之前 ... 谁负责" → recall', () => {
+    expect(router.route(plain('之前那个接口是谁负责来着'))).toBe('recall');
+  });
+
+  it('pos: "我记得之前 ..." → recall', () => {
+    expect(router.route(plain('我记得之前定过 demo 范围，是啥来着'))).toBe('recall');
+  });
+
+  it('pos: "那个 ... 后来怎么说" → recall', () => {
+    expect(router.route(plain('那个 demo 范围后来怎么说'))).toBe('recall');
+  });
+
+  it('neg: 普通非 @ 问句仍不触发 recall', () => {
+    expect(router.route(plain('徐坤负责什么'))).toBe('silent');
+  });
+});
+
+// ================================================================
 // meetingNotes（会议纪要读取，被动）
 // ================================================================
 describe('meetingNotes', () => {
@@ -204,7 +229,11 @@ describe('slides', () => {
   it('neg: merely discussing ppt does not trigger slides', () => {
     expect(router.route(plain('这个ppt怎么样'))).toBe('silent');
     expect(router.route(plain('这个 ppt 风格太丑了'))).toBe('silent');
-    expect(router.route(plain('上次 PPT 放哪了'))).toBe('silent');
+    expect(router.route(plain('我们先别做 ppt'))).toBe('silent');
+  });
+
+  it('recall 优先处理历史指代类 PPT 问句', () => {
+    expect(router.route(plain('上次 PPT 放哪了'))).toBe('recall');
     expect(router.route(plain('我们先别做 ppt'))).toBe('silent');
   });
 });

--- a/packages/bot/src/__tests__/wiring.test.ts
+++ b/packages/bot/src/__tests__/wiring.test.ts
@@ -221,6 +221,29 @@ describe('handleEvent wiring', () => {
     expect(progressSkill.run).toHaveBeenCalledOnce();
   });
 
+  it('recall intent → recall skill.run called without @mention', async () => {
+    const recallSkill: Skill = {
+      ...qaSkill,
+      name: 'recall' as SkillName,
+      match: vi.fn().mockReturnValue(true),
+      run: vi.fn().mockResolvedValue(ok({ text: '徐坤负责后端接口联调。' })),
+    };
+    const runtime = makeRuntime();
+    const msg = makeMessage({ text: '上次说徐坤负责什么来着？', mentions: [] });
+    const ctx = makeCtx(makeEvent(msg), runtime);
+
+    await handleEvent(ctx, router, {
+      recall: recallSkill,
+    } as Partial<Record<SkillName, Skill>>);
+
+    expect(recallSkill.match).toHaveBeenCalledOnce();
+    expect(recallSkill.run).toHaveBeenCalledOnce();
+    expect(runtime.sendText).toHaveBeenCalledWith({
+      chatId: 'oc_chat1',
+      text: '徐坤负责后端接口联调。',
+    });
+  });
+
   // 5. skill.run() 返回 err → 不 crash，logger.error 被调用
   it('skill.run() returns err → no crash, logger.error called', async () => {
     const failSkill: Skill = {

--- a/packages/bot/src/skill-router.ts
+++ b/packages/bot/src/skill-router.ts
@@ -6,10 +6,11 @@
  *
  * 双轨制：
  *   - qa           唯一需要 @bot（避免对组员间普通问句乱插话）
+ *   - recall       无需 @bot，但必须出现明确历史指代/信息缺口
  *   - 其余意图     纯被动监听，无需 @bot
  *
  * 优先级（高→低）：
- *   qa > archive > taskAssignment > progressUpdate > meetingNotes > slides > requirementDoc > silent
+ *   qa > archive > taskAssignment > progressUpdate > recall > meetingNotes > slides > requirementDoc > silent
  */
 
 import type { Message } from '@seedhac/contracts';
@@ -17,6 +18,7 @@ import type { Message } from '@seedhac/contracts';
 /** Router 输出的意图类型（bot 包内部，不放 contracts） */
 export type RouteIntent =
   | 'qa' // 信息缺口回答 — @bot + 疑问句
+  | 'recall' // 主动召回 — 非 @ 消息里出现历史指代/信息缺口
   | 'taskAssignment' // 分工识别与表格生成 — 听到分工讨论
   | 'progressUpdate' // 阶段进展更新 — 听到进展汇报
   | 'meetingNotes' // 会议纪要读取 — 纪要进群
@@ -108,6 +110,20 @@ const RULES: readonly RouteRule[] = [
       /进度更新/,
       /汇报一下进展/,
       /更新进度/,
+    ],
+  },
+
+  // ── recall：历史信息缺口主动召回（被动）──────────────────────────
+  {
+    intent: 'recall',
+    requireMention: false,
+    patterns: [
+      /上次.{0,24}(?:什么|啥|哪|谁|多少|来着|记得|定|说|放|负责)/,
+      /之前.{0,24}(?:什么|啥|哪|谁|多少|来着|记得|定|说|放|负责)/,
+      /我记得.{0,24}(?:之前|上次|上回|那个)/,
+      /上回.{0,24}(?:什么|啥|哪|谁|多少|来着|记得|定|说|放|负责)/,
+      /那个.{0,24}(?:是什么|是啥|在哪|哪了|谁负责|怎么说|后来怎么|来着)/,
+      /(?:是多少|是什么|是谁|在哪|哪了|谁负责|怎么说)来着/,
     ],
   },
 

--- a/packages/bot/src/wiring.ts
+++ b/packages/bot/src/wiring.ts
@@ -18,6 +18,7 @@ import { handleBotJoinedChat, handleOnboardingAction } from './onboarding.js';
 
 export const intentToSkill: Partial<Record<RouteIntent, SkillName>> = {
   qa: 'qa',
+  recall: 'recall',
   meetingNotes: 'summary',
   slides: 'slides',
   requirementDoc: 'requirementDoc',


### PR DESCRIPTION
## 背景

本地联调发现非 @ 消息 `上次说徐坤负责什么来着？` 已被 WSClient 收到，但 `SkillRouter` 判为 `silent`，只走 passive observe，没有触发 `recall` skill。

这导致 recall skill 虽然实现存在，但生产主循环里缺少历史指代类消息的触发入口。

## 改动

- `RouteIntent` 新增 `recall`。
- `SkillRouter` 增加历史指代/信息缺口规则：`上次`、`之前`、`我记得`、`上回`、`那个`、`来着` 等。
- `intentToSkill` 增加 `recall -> recall` 映射。
- 保持普通非 @ 问句 silent，例如 `徐坤负责什么` 不主动插话。
- 补充 router/wiring 测试，覆盖非 @ recall 触发和 skill 执行路径。

## 验证

- `pnpm --filter @seedhac/bot exec vitest run src/__tests__/skill-router.test.ts src/__tests__/wiring.test.ts src/__tests__/memory/tool-handlers.test.ts`：124 passed
- `pnpm exec tsc -b packages/contracts packages/skills packages/bot`：passed
