### PR TITLE
fix(recall): 注入 BitableRetriever 并修复两处使其可用

### DIFF
--- a/packages/bot/src/bitable-retriever.ts
+++ b/packages/bot/src/bitable-retriever.ts
@@ -26,7 +26,7 @@ export class BitableRetriever implements Retriever {
 
     const result = await this.bitable.find({
       table: 'memory',
-      ...(query.chatId ? { filter: `AND(CurrentValue.[chatId]="${query.chatId}")` } : {}),
+      ...(query.chatId ? { filter: `AND(CurrentValue.[chat_id] = "${query.chatId}")` } : {}),
       pageSize: topK,
     });
 

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -11,6 +11,7 @@ import { VolcanoLLMClient } from './llm-client.js';
 import { MemoryStore } from './memory/memory-store.js';
 import { SystemPromptCache } from './memory/system-prompt.js';
 import { createSlidesClient } from './slides-client.js';
+import { BitableRetriever } from './bitable-retriever.js';
 import { SkillRouter } from './skill-router.js';
 import { handleEvent } from './wiring.js';
 
@@ -143,7 +144,7 @@ async function main(): Promise<void> {
       slides,
       cardBuilder: larkCardBuilder,
       memoryStore,
-      retrievers: {},
+      retrievers: { bitable: new BitableRetriever(bitable) },
       logger,
     };
     await handleEvent(ctx, router, skillsByName, harness);

--- a/packages/skills/src/recall.ts
+++ b/packages/skills/src/recall.ts
@@ -70,7 +70,8 @@ class RecallSkill implements Skill {
 
     const histResult = await ctx.runtime.fetchHistory({ chatId: msg.chatId, pageSize: 10 });
     const fetched = histResult.ok ? histResult.value.messages : [];
-    const messages = fetched.length > 0 ? fetched : [msg];
+    const hasCurrent = fetched.some((m) => m.messageId === msg.messageId);
+    const messages = hasCurrent ? fetched : [msg, ...fetched];
 
     const detector = new GapDetector(ctx.llm);
     const gapResult = await detector.detect(messages);
@@ -97,7 +98,8 @@ class RecallSkill implements Skill {
     if (!detection) {
       const histResult = await ctx.runtime.fetchHistory({ chatId: msg.chatId, pageSize: 10 });
       const fetched = histResult.ok ? histResult.value.messages : [];
-      const messages = fetched.length > 0 ? fetched : [msg];
+      const hasCurrent = fetched.some((m) => m.messageId === msg.messageId);
+      const messages = hasCurrent ? fetched : [msg, ...fetched];
       const detector = new GapDetector(ctx.llm);
       const gapResult = await detector.detect(messages);
       if (!gapResult.ok || !gapResult.value.shouldRecall) return ok({ text: '' });


### PR DESCRIPTION
## Summary
  - index.ts: retrievers 从空对象改为注入 BitableRetriever，recall
  之前因无数据源始终返回空文本
  - bitable-retriever.ts: filter 字段名 chatId → chat_id，与 memory
  表实际列名对齐
  - recall.ts: fetchHistory 不含当前消息时补到列表首位，确保 GapDetector
  规则层能命中触发词

  ## Test plan
  - [ ] 发"上次说张三在做什么来着？"（不 @bot），确认 intent=recall 且有回复
  - [ ] 先发含分工信息的消息再触发 recall，确认回复与历史相关
  - [ ] 确认 summary / slides / archive 无回归
