### PR TITLE
fix(slides): 把 lark-cli 收为项目依赖，避免 spawn ENOENT

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -31,6 +31,7 @@
     "eval:gap-detector": "node --env-file=../../.env --import tsx/esm ./node_modules/vitest/vitest.mjs run src/__tests__/gap-detector.eval.test.ts"
   },
   "dependencies": {
+    "@larksuite/cli": "^1.0.24",
     "@larksuiteoapi/node-sdk": "^1.62.1",
     "@seedhac/contracts": "workspace:*",
     "@seedhac/skills": "workspace:*",

--- a/packages/bot/src/slides-client.ts
+++ b/packages/bot/src/slides-client.ts
@@ -1,4 +1,7 @@
 import { execFile as execFileCallback } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import {
   ErrorCode,
@@ -30,12 +33,20 @@ export interface LarkSlidesClientOptions {
 
 export class LarkSlidesClient implements SlidesClient {
   private readonly bin: string;
+  private readonly binArgs: readonly string[];
   private readonly as: 'user' | 'bot';
   private readonly baseUrl: string;
   private readonly execFile: ExecFile;
 
   constructor(options: LarkSlidesClientOptions = {}) {
-    this.bin = options.bin ?? 'lark-cli';
+    const resolvedBin = options.bin ?? 'lark-cli';
+    if (resolvedBin.endsWith('.js')) {
+      this.bin = process.execPath;
+      this.binArgs = [resolvedBin];
+    } else {
+      this.bin = resolvedBin;
+      this.binArgs = [];
+    }
     // 默认用 bot 身份：bot 创建 = bot owns，可直接给团队成员授权，
     // 无需任何人登录 lark-cli 也无需补 user OAuth scope。lark-cli 在
     // bot 模式下还会自动把当前 cli 登录用户加为 full_access。
@@ -56,6 +67,7 @@ export class LarkSlidesClient implements SlidesClient {
       const { stdout, stderr } = await this.execFile(
         this.bin,
         [
+          ...this.binArgs,
           'slides',
           '+create',
           '--as',
@@ -97,6 +109,7 @@ export class LarkSlidesClient implements SlidesClient {
         const { stdout, stderr } = await this.execFile(
           this.bin,
           [
+            ...this.binArgs,
             'drive',
             'permission.members',
             'create',
@@ -422,12 +435,28 @@ function extractTokenFromUrl(url: string): string | undefined {
   return url.match(/\/slides\/([A-Za-z0-9_-]+)/)?.[1];
 }
 
+export function resolveLarkCliBin(): string {
+  const fromEnv = process.env['LARK_CLI_BIN'];
+  if (fromEnv) return fromEnv;
+
+  try {
+    const require = createRequire(import.meta.url);
+    const pkgPath = require.resolve('@larksuite/cli/package.json');
+    const binRelative = join(dirname(pkgPath), 'scripts', 'run.js');
+    if (existsSync(binRelative)) return binRelative;
+  } catch {
+    // fall through to PATH lookup
+  }
+
+  return 'lark-cli';
+}
+
 export function createSlidesClient(): LarkSlidesClient {
-  const bin = process.env['LARK_CLI_BIN'];
+  const bin = resolveLarkCliBin();
   const as = process.env['LARK_SLIDES_CLI_AS'];
   const baseUrl = process.env['LARK_SLIDES_BASE_URL'];
   return new LarkSlidesClient({
-    ...(bin && { bin }),
+    bin,
     ...(as === 'bot' || as === 'user' ? { as } : {}),
     ...(baseUrl && { baseUrl }),
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/bot:
     dependencies:
+      '@larksuite/cli':
+        specifier: ^1.0.24
+        version: 1.0.24
       '@larksuiteoapi/node-sdk':
         specifier: ^1.62.1
         version: 1.62.1
@@ -65,6 +68,14 @@ importers:
         version: 4.1.5(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
+
+  '@clack/core@1.3.0':
+    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.3.0':
+    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+    engines: {node: '>= 20.12.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -264,6 +275,13 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@larksuite/cli@1.0.24':
+    resolution: {integrity: sha512-N19FIwckWr/HgGMcMYV3Ebra/ofGTgFhGw9BHcAfmuRajnXagyaTItDBskBcRDUIK3ClKf33Oj6iMm5jAZx55w==}
+    engines: {node: '>=16'}
+    cpu: [x64, arm64]
+    os: [darwin, linux, win32]
+    hasBin: true
 
   '@larksuiteoapi/node-sdk@1.62.1':
     resolution: {integrity: sha512-o9oAjv5Ffnp/6iXIJLHrO6N0US/r2ZZy3xmO6ylGegjuVSC05cx0fADA38Dc1h0FV8T9BDK+ariWk84TNMGbKg==}
@@ -766,6 +784,15 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1203,6 +1230,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1403,6 +1433,18 @@ packages:
 
 snapshots:
 
+  '@clack/core@1.3.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.3.0':
+    dependencies:
+      '@clack/core': 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1533,6 +1575,10 @@ snapshots:
   '@humanwhocodes/object-schema@2.0.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@larksuite/cli@1.0.24':
+    dependencies:
+      '@clack/prompts': 1.3.0
 
   '@larksuiteoapi/node-sdk@1.62.1':
     dependencies:
@@ -2065,6 +2111,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -2472,6 +2528,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- 在 \`packages/bot\` 把飞书官方 CLI（**\`@larksuite/cli\`**）收成 workspace 依赖。注意：npm 上同名的 \`lark-cli\` 是一年没更新的冒名包，飞书真正的官方包名是 \`@larksuite/cli\`，bin 名才是 \`lark-cli\`。
- \`slides-client.ts\` 新增 \`resolveLarkCliBin()\`：优先级 \`LARK_CLI_BIN\` env → \`require.resolve('@larksuite/cli')\` → \`'lark-cli'\`（PATH 兜底）。
- 当解析到 \`.js\` 入口（pnpm 装下来的 \`scripts/run.js\`），改用 \`process.execPath + run.js\` 拼参数，绕开 shebang，Windows / 容器 / CI 都稳。

## Why

线上现象：bot 给用户回「演示文稿生成失败：\`spawn lark-cli ENOENT\`」。

根因：之前的代码用 \`bin = 'lark-cli'\` 这个相对名字 spawn 子进程，强依赖运行时 \`PATH\` 上有 \`lark-cli\`。
- 我自己终端的 \`PATH\` 包含 \`~/.npm-global/bin\`，所以手动跑没事。
- bot 进程（pm2/launchd/Docker 之类）继承的 \`PATH\` 没这条目录，就 ENOENT。

不是 \`lark-cli\` 本身坏了，是「命令在但 bot 看不见」。

## Approach

考虑过三档方案：
1. ✅ **本 PR**：把 \`@larksuite/cli\` 收为项目依赖，pnpm install 自动建 \`node_modules/.bin/lark-cli\`，零环境配置；
2. 启动时多源 fallback（依然依赖外部 PATH）；
3. 干脆改用 \`@larksuiteoapi/node-sdk\` 直连 API，去掉 spawn 子进程。

档位 1 改动最小、立刻持久；档位 3 长期更干净，但要重写 \`createFromOutline\` / \`grantMembersEdit\` 两个方法（涉及 OAuth、token、原生 slides XML、权限 API），暂不在范围内。

## Test plan

- [x] \`pnpm typecheck\`：\`slides-client.ts\` 编译干净（仓库里 \`gap-detector.ts\` 有先于本 PR 的类型错误，与本变更无关）。
- [x] \`pnpm --filter @seedhac/bot test slides-client\` → **8/8 通过**。
- [x] 解析逻辑实测：\`require.resolve('@larksuite/cli/package.json')\` 解到 \`node_modules/.pnpm/@larksuite+cli@1.0.24/.../scripts/run.js\`，存在且可执行。
- [x] 端到端验证（飞书群里跑 PPT 生成）：日志显示 bot 已经成功 spawn \`/usr/local/bin/node .../@larksuite/cli/scripts/run.js slides +create ...\`，不再 ENOENT；后续失败原因是飞书应用尚未开通 \`slides:presentation:create\` 等 scope，**与本 PR 无关**，业务侧申请权限即可。
- [ ] 部署后回归：bot 重启后再发一次 PPT 请求，确认 \`spawn lark-cli ENOENT\` 不再出现。

## Notes

- 不再需要在 \`.env\` 里配 \`LARK_CLI_BIN\` 走绝对路径，但保留了对它的支持，方便有需要时手动覆盖。
- 这次 \`@larksuite/cli\` 的版本是 \`^1.0.24\`，包带 postinstall 脚本，pnpm 安装时会自动执行。